### PR TITLE
refactor layout

### DIFF
--- a/src/core/gridGL/QuadraticGrid.tsx
+++ b/src/core/gridGL/QuadraticGrid.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { createRef, useRef, useState, useLayoutEffect } from 'react';
 import useWindowDimensions from '../../hooks/useWindowDimensions';
 import type { Viewport } from 'pixi-viewport';
 import { Stage } from '@inlet/react-pixi';
@@ -24,9 +24,14 @@ import RightClickMenu from '../../ui/menus/RightClickMenu';
 
 import { ViewportEventRegister } from './interaction/ViewportEventRegister';
 
-export default function QuadraticGrid() {
-  const { loading } = useLoading();
+interface QuadraticGridProps {
+  loading: boolean;
+}
+
+export default function QuadraticGrid(props: QuadraticGridProps) {
+  const { loading } = props;
   const viewportRef = useRef<Viewport>();
+  const stageContainerRef = createRef<HTMLDivElement>();
   const { height: windowHeight, width: windowWidth } = useWindowDimensions();
 
   // Live query to update cells
@@ -50,20 +55,40 @@ export default function QuadraticGrid() {
     useMenuState();
   const [rightClickPoint, setRightClickPoint] = useState({ x: 0, y: 0 });
 
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    setWidth(stageContainerRef?.current?.offsetWidth || 100);
+    setHeight(stageContainerRef?.current?.offsetHeight || 100);
+  }, [stageContainerRef]);
+
+  console.log('width ', width, ' height ', height);
+
   return (
     <div
+      style={{
+        // backgroundColor: 'green',
+        display: 'flex',
+        flexGrow: 1,
+        // height: '100%',
+        // position: 'absolute',
+        overflow: 'hidden',
+      }}
       onContextMenu={(event) => {
         event.preventDefault();
         setRightClickPoint({ x: event.clientX, y: event.clientY });
         toggleRightClickMenu(true);
       }}
+      ref={stageContainerRef}
     >
       <Stage
         id="QuadraticCanvasID"
-        height={windowHeight}
-        width={windowWidth}
+        style={{ display: loading ? 'none' : 'block', position: 'static' }}
+        width={width}
+        height={height}
         options={{
-          resizeTo: window,
+          // resizeTo: window,
           resolution:
             // Always use 2 instead of 1. Better resolution.
             window.devicePixelRatio === 1.0 ? 2 : window.devicePixelRatio,
@@ -99,15 +124,14 @@ export default function QuadraticGrid() {
             setEditorInteractionState
           );
         }}
-        style={{ display: loading ? 'none' : 'inline' }}
         // Disable rendering on each frame
         raf={false}
         // Render on each state change
         renderOnComponentChange={true}
       >
         <ViewportComponent
-          screenWidth={windowWidth}
-          screenHeight={windowHeight}
+          screenWidth={width}
+          screenHeight={height}
           viewportRef={viewportRef}
         >
           {!loading &&

--- a/src/core/gridGL/graphics/ViewportComponent.tsx
+++ b/src/core/gridGL/graphics/ViewportComponent.tsx
@@ -16,7 +16,6 @@ export interface ViewportProps {
 
 export interface PixiComponentViewportProps extends ViewportProps {
   app: PIXI.Application;
-  setLoading?: Function;
 }
 
 const PixiComponentViewport = PixiComponent('Viewport', {

--- a/src/quadratic/QuadraticApp.tsx
+++ b/src/quadratic/QuadraticApp.tsx
@@ -1,13 +1,11 @@
 import { useEffect } from 'react';
 import QuadraticUI from '../ui/QuadraticUI';
-import QuadraticGrid from '../core/gridGL/QuadraticGrid';
 import { RecoilRoot } from 'recoil';
 import { useLoading } from '../contexts/LoadingContext';
-import { QuadraticLoading } from '../ui/QuadtraticLoading';
 import { loadPython } from '../core/computations/python/loadPython';
-import { TopBarLoading } from '../ui/components/TopBarLoading';
 import { WelcomeComponent } from './WelcomeComponent';
 import { AnalyticsProvider } from './AnalyticsProvider';
+import { QuadraticLoading } from '../ui/QuadtraticLoading';
 
 export default function QuadraticApp() {
   const { loading, setLoading } = useLoading();
@@ -26,14 +24,8 @@ export default function QuadraticApp() {
       <AnalyticsProvider></AnalyticsProvider>
       {/* Welcome Component for first time users */}
       {!loading && <WelcomeComponent></WelcomeComponent>}
-      {/* Provider of WebGL Canvas and Quadratic Grid */}
-      <QuadraticGrid></QuadraticGrid>
       {/* Provider of All React UI Components */}
-      {!loading && <QuadraticUI></QuadraticUI>}
-      {/* ToBarLoading allows window to be moved while loading in electron */}
-      {loading && <TopBarLoading></TopBarLoading>}
-      {/* Loading screen */}
-      {loading && <QuadraticLoading></QuadraticLoading>}
+      <QuadraticUI loading={loading}></QuadraticUI>
     </RecoilRoot>
   );
 }

--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -7,18 +7,41 @@ import useLocalStorage from '../hooks/useLocalStorage';
 import { useRecoilValue } from 'recoil';
 import { editorInteractionStateAtom } from '../atoms/editorInteractionStateAtom';
 import BottomBar from './menus/BottomBar';
+import QuadraticGrid from '../core/gridGL/QuadraticGrid';
+import { QuadraticLoading } from './QuadtraticLoading';
 
-export default function QuadraticUI() {
+interface QuadraticUIProps {
+  loading: boolean;
+}
+
+export default function QuadraticUI(props: QuadraticUIProps) {
+  const { loading } = props;
   const [showDebugMenu] = useLocalStorage('showDebugMenu', false);
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
 
   return (
     <>
-      {editorInteractionState.showCellTypeMenu && <CellTypeMenu></CellTypeMenu>}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          flex: 1,
+          // backgroundColor: 'purple',
+          height: '100%',
+        }}
+      >
+        {/* WebGL Canvas and Quadratic Grid */}
+        {!loading && <TopBar></TopBar>}
+
+        <QuadraticGrid loading={loading}></QuadraticGrid>
+        {!loading && <BottomBar></BottomBar>}
+        {/* Loading screen */}
+        {loading && <QuadraticLoading></QuadraticLoading>}
+      </div>
       <CodeEditor editorInteractionState={editorInteractionState}></CodeEditor>
+      {editorInteractionState.showCellTypeMenu && <CellTypeMenu></CellTypeMenu>}
       {showDebugMenu && <DebugMenu />}
-      <TopBar></TopBar>
-      <BottomBar></BottomBar>
     </>
   );
 }

--- a/src/ui/QuadtraticLoading/index.tsx
+++ b/src/ui/QuadtraticLoading/index.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
 
 import './styles.css';
+import { TopBarLoading } from '../components/TopBarLoading';
 
 export function QuadraticLoading() {
   const [progress, setProgress] = useState<number>(0);
@@ -25,24 +26,27 @@ export function QuadraticLoading() {
   }, []);
 
   return (
-    <div
-      style={{
-        height: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        userSelect: 'none',
-      }}
-    >
-      <div className="loadingContainer">
-        <img
-          className="loadingLogoGif"
-          src="/images/logo_loading.gif"
-          alt="Loading Quadratic Grid"
-        ></img>
-        <Box sx={{ width: '100px', marginTop: '15px' }}>
-          <LinearProgress variant="determinate" value={progress} />
-        </Box>
+    <>
+      <TopBarLoading></TopBarLoading>
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          userSelect: 'none',
+        }}
+      >
+        <div className="loadingContainer">
+          <img
+            className="loadingLogoGif"
+            src="/images/logo_loading.gif"
+            alt="Loading Quadratic Grid"
+          ></img>
+          <Box sx={{ width: '100px', marginTop: '15px' }}>
+            <LinearProgress variant="determinate" value={progress} />
+          </Box>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/ui/menus/BottomBar/BottomBar.tsx
+++ b/src/ui/menus/BottomBar/BottomBar.tsx
@@ -51,8 +51,9 @@ export const BottomBar = () => {
         event.preventDefault();
       }}
       style={{
-        position: 'fixed',
+        // position: 'fixed',
         backgroundColor: 'rgba(255, 255, 255, 0.9)',
+        // backgroundColor: 'blue',
         color: colors.darkGray,
         bottom: 0,
         width: '100%',

--- a/src/ui/menus/TopBar/TopBar.tsx
+++ b/src/ui/menus/TopBar/TopBar.tsx
@@ -21,8 +21,8 @@ export const TopBar = () => {
         event.preventDefault();
       }}
       style={{
-        position: 'absolute',
         backgroundColor: 'rgba(255, 255, 255)',
+        // backgroundColor: 'yellow',
         color: '#212121',
         //@ts-expect-error
         WebkitAppRegion: 'drag', // this allows the window to be dragged in Electron


### PR DESCRIPTION
Currently, in Quadratic, the grid is 100% of the width and 100% of the height of the browser window and all UI elements are overlayed on it. This is not great because we need to offset things from the top where the TopBar covers the grid, and from the right where the editor pane is on of the screen.

I have already done some work refactoring the app to make the grid a smaller window. However, there is a bug where the viewport does not calculate the clicked cell position correctly. 