### PR TITLE
dynamic grid lines rendering by moving the grid

### DIFF
--- a/src/core/gridGL/graphics/ViewportComponent.tsx
+++ b/src/core/gridGL/graphics/ViewportComponent.tsx
@@ -3,7 +3,7 @@ import { Viewport } from 'pixi-viewport';
 import { Simple } from 'pixi-cull';
 import { UpdateGridAlphaOnZoom } from './UpdateGridAlphaOnZoom';
 
-import drawGridLines from './drawGridLines';
+import drawGridLines, { moveGrid } from './drawGridLines';
 import Globals from '../globals';
 import { PixiComponent, useApp } from '@inlet/react-pixi';
 
@@ -67,6 +67,7 @@ const PixiComponentViewport = PixiComponent('Viewport', {
             // render
             props.app.renderer.render(props.app.stage);
             viewport.dirty = false;
+            moveGrid(viewport, grid_ui);
           }
         },
         null,

--- a/src/core/gridGL/graphics/drawGridLines.ts
+++ b/src/core/gridGL/graphics/drawGridLines.ts
@@ -5,7 +5,6 @@ import {
   CELL_HEIGHT,
   GRID_SIZE,
 } from '../../../constants/gridConstants';
-import * as PIXI from 'pixi.js';
 
 import { colors } from '../../../theme/colors';
 

--- a/src/core/gridGL/graphics/drawGridLines.ts
+++ b/src/core/gridGL/graphics/drawGridLines.ts
@@ -5,6 +5,7 @@ import {
   CELL_HEIGHT,
   GRID_SIZE,
 } from '../../../constants/gridConstants';
+import * as PIXI from 'pixi.js';
 
 import { colors } from '../../../theme/colors';
 
@@ -14,11 +15,12 @@ const drawGridLines = function (viewport: Viewport) {
   // Configure Line Style
   grid.lineStyle(1, colors.gridLines, 0.25, 0.5, true);
 
-  const xoffset = (-CELL_WIDTH * GRID_SIZE) / 2;
-  const yoffset = -CELL_HEIGHT * GRID_SIZE * 2;
+  const offsets = getOffsets(viewport);
+  const xoffset = offsets.x
+  const yoffset = offsets.y
 
   // Draw vertical lines
-  for (var i = 0; i < GRID_SIZE; i++) {
+  for (var i = 0; i < GRID_SIZE / 2; i++) {
     grid.moveTo(xoffset + i * CELL_WIDTH, yoffset);
     grid.lineTo(
       xoffset + i * CELL_WIDTH,
@@ -27,7 +29,7 @@ const drawGridLines = function (viewport: Viewport) {
   }
 
   // Draw horizontal LINES
-  for (var j = 0; j < GRID_SIZE * 5; j++) {
+  for (var j = 0; j < GRID_SIZE * 2; j++) {
     grid.moveTo(xoffset, yoffset + j * CELL_HEIGHT);
     grid.lineTo(xoffset + CELL_WIDTH * GRID_SIZE, yoffset + j * CELL_HEIGHT);
   }
@@ -35,5 +37,24 @@ const drawGridLines = function (viewport: Viewport) {
   viewport.addChild(grid);
   return grid;
 };
+
+// Calculates the x and y offsets based on the viewport's visible bounds
+const getOffsets = function (viewport: Viewport) {
+  const visibleBounds = viewport.getVisibleBounds();
+
+  const xoffset = Math.round((visibleBounds.x - visibleBounds.width / 2) / CELL_WIDTH) * CELL_WIDTH; // matching alignment by rounding to nearest cell width value
+  const yoffset = Math.round((visibleBounds.y - visibleBounds.height / 2) / CELL_HEIGHT) * CELL_HEIGHT;  // matching aligment by rounding to nearest cell height value
+
+  return {
+    x: xoffset,
+    y: yoffset,
+  };
+}
+
+// moves the grid around to match the viewport
+export const moveGrid = function (viewport: Viewport, grid: Graphics) {
+  const offsets = getOffsets(viewport)
+  grid.transform.position.set(offsets.x, offsets.y);
+}
 
 export default drawGridLines;


### PR DESCRIPTION
Added a moveGrid function which will change the transform.position of the grid
Called this function in the main render listener when the viewport becomes dirty

fixes issues #103 