### PR TITLE
Revert "Features/axis lines"

### DIFF
--- a/src/core/gridGL/QuadraticGrid.tsx
+++ b/src/core/gridGL/QuadraticGrid.tsx
@@ -8,6 +8,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { useLoading } from '../../contexts/LoadingContext';
 import useLocalStorage from '../../hooks/useLocalStorage';
 import CellPixiReact from './graphics/CellPixiReact';
+import AxesPixiReact from './graphics/AxesPixiReact';
 import CursorPixiReact from './graphics/CursorPixiReact';
 import MultiCursorPixiReact from './graphics/MultiCursorPixiReact';
 import { gridInteractionStateAtom } from '../../atoms/gridInteractionStateAtom';
@@ -108,7 +109,6 @@ export default function QuadraticGrid() {
           screenWidth={windowWidth}
           screenHeight={windowHeight}
           viewportRef={viewportRef}
-          showGridAxes={showGridAxes}
         >
           {!loading &&
             cells?.map((cell) => (
@@ -129,6 +129,7 @@ export default function QuadraticGrid() {
                 array_cells={cell.array_cells}
               ></CellPixiReact>
             ))}
+          <AxesPixiReact visible={showGridAxes}></AxesPixiReact>
           <CursorPixiReact
             location={interactionState.cursorPosition}
           ></CursorPixiReact>

--- a/src/core/gridGL/graphics/AxesPixiReact.tsx
+++ b/src/core/gridGL/graphics/AxesPixiReact.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { Graphics } from '@inlet/react-pixi';
+import { Graphics as PixiGraphics } from 'pixi.js';
+
+interface AxesPixiReactProps {
+  visible: boolean;
+}
+
+const AxesPixiReact = (props: AxesPixiReactProps) => {
+  const draw_outline = useCallback(
+    (g: PixiGraphics) => {
+      g.clear();
+
+      if (props.visible) {
+        g.lineStyle(1, 0x000000, 0.35, 0, true);
+
+        g.moveTo(-1000000, 0);
+        g.lineTo(1000000, 0);
+
+        g.moveTo(0, -1000000);
+        g.lineTo(0, 1000000);
+      }
+    },
+    [props.visible]
+  );
+
+  return <Graphics draw={draw_outline} />;
+};
+
+export default AxesPixiReact;

--- a/src/core/gridGL/graphics/ViewportComponent.tsx
+++ b/src/core/gridGL/graphics/ViewportComponent.tsx
@@ -12,7 +12,6 @@ export interface ViewportProps {
   screenHeight: number;
   children?: React.ReactNode;
   viewportRef: React.MutableRefObject<Viewport | undefined>;
-  showGridAxes: boolean;
 }
 
 export interface PixiComponentViewportProps extends ViewportProps {
@@ -67,7 +66,7 @@ const PixiComponentViewport = PixiComponent('Viewport', {
           if (viewport.dirty) {
 
             // render
-            drawGridLines(viewport, grid_ui, props.showGridAxes);
+            drawGridLines(viewport, grid_ui);
             props.app.renderer.render(props.app.stage);
             viewport.dirty = false;
           }

--- a/src/core/gridGL/graphics/drawGridLines.ts
+++ b/src/core/gridGL/graphics/drawGridLines.ts
@@ -7,7 +7,7 @@ import {
 
 import { colors } from '../../../theme/colors';
 
-const drawGridLines = function (viewport: Viewport, grid: Graphics, showGridAxes: boolean): void {
+const drawGridLines = function (viewport: Viewport, grid: Graphics): void {
   grid.clear();
 
   // Configure Line Style
@@ -27,18 +27,6 @@ const drawGridLines = function (viewport: Viewport, grid: Graphics, showGridAxes
   for (let y = bounds.top; y <= bounds.bottom + CELL_HEIGHT; y += CELL_HEIGHT) {
     grid.moveTo(bounds.left, y - y_offset);
     grid.lineTo(bounds.right, y - y_offset);
-  }
-
-  if (showGridAxes) {
-    grid.lineStyle(10, 0x000000, 0.35, 0, true);
-    if (0 >= bounds.left && 0 <= bounds.right) {
-      grid.moveTo(0, bounds.top);
-      grid.lineTo(0, bounds.bottom);
-    }
-    if (0 >= bounds.top && 0 <= bounds.bottom) {
-      grid.moveTo(bounds.left, 0);
-      grid.lineTo(bounds.right, 0);
-    }
   }
 };
 


### PR DESCRIPTION
Reverts quadratichq/quadratic#108

@davidfig I noticed 2 regressions from this PR

1) When zoomed out, axis lines should not disappear with the grid lines.
2) View > Show Axis no longer toggles the visibility of the Axis lines

<img width="576" alt="Screen Shot 2022-08-26 at 10 44 54 AM" src="https://user-images.githubusercontent.com/3479421/186931081-6c05915f-b288-44da-9427-0c823ac8d810.png">

