### PR TITLE
separate out axisLines from gridLines

### DIFF
--- a/src/core/gridGL/graphics/ViewportComponent.tsx
+++ b/src/core/gridGL/graphics/ViewportComponent.tsx
@@ -6,6 +6,7 @@ import { UpdateGridAlphaOnZoom } from './UpdateGridAlphaOnZoom';
 import drawGridLines from './drawGridLines';
 import Globals from '../globals';
 import { PixiComponent, useApp } from '@inlet/react-pixi';
+import { drawAxisLines } from './drawAxesLines';
 
 export interface ViewportProps {
   screenWidth: number;
@@ -54,7 +55,7 @@ const PixiComponentViewport = PixiComponent('Viewport', {
     function startup() {
       // draw grid lines
       let grid_ui = viewport.addChild(new PIXI.Graphics());
-
+      let axis_ui = viewport.addChild(new PIXI.Graphics());
       const globals = new Globals(viewport, props.app.view, grid_ui);
 
       let ticker = PIXI.Ticker.shared;
@@ -67,7 +68,8 @@ const PixiComponentViewport = PixiComponent('Viewport', {
           if (viewport.dirty) {
 
             // render
-            drawGridLines(viewport, grid_ui, props.showGridAxes);
+            drawGridLines(viewport, grid_ui);
+            drawAxisLines(viewport, axis_ui, props.showGridAxes);
             props.app.renderer.render(props.app.stage);
             viewport.dirty = false;
           }

--- a/src/core/gridGL/graphics/drawAxesLines.ts
+++ b/src/core/gridGL/graphics/drawAxesLines.ts
@@ -1,0 +1,20 @@
+import { Graphics } from 'pixi.js';
+import { Viewport } from 'pixi-viewport';
+
+export const drawAxisLines = (viewport: Viewport, grid: Graphics, showGridAxes: boolean): void => {
+    grid.clear();
+
+    const bounds = viewport.getVisibleBounds();
+
+    if (showGridAxes) {
+        grid.lineStyle(10, 0x000000, 0.35, 0, true);
+        if (0 >= bounds.left && 0 <= bounds.right) {
+            grid.moveTo(0, bounds.top);
+            grid.lineTo(0, bounds.bottom);
+        }
+        if (0 >= bounds.top && 0 <= bounds.bottom) {
+            grid.moveTo(bounds.left, 0);
+            grid.lineTo(bounds.right, 0);
+        }
+    }
+};

--- a/src/core/gridGL/graphics/drawGridLines.ts
+++ b/src/core/gridGL/graphics/drawGridLines.ts
@@ -7,7 +7,7 @@ import {
 
 import { colors } from '../../../theme/colors';
 
-const drawGridLines = function (viewport: Viewport, grid: Graphics, showGridAxes: boolean): void {
+const drawGridLines = function (viewport: Viewport, grid: Graphics): void {
   grid.clear();
 
   // Configure Line Style
@@ -27,18 +27,6 @@ const drawGridLines = function (viewport: Viewport, grid: Graphics, showGridAxes
   for (let y = bounds.top; y <= bounds.bottom + CELL_HEIGHT; y += CELL_HEIGHT) {
     grid.moveTo(bounds.left, y - y_offset);
     grid.lineTo(bounds.right, y - y_offset);
-  }
-
-  if (showGridAxes) {
-    grid.lineStyle(10, 0x000000, 0.35, 0, true);
-    if (0 >= bounds.left && 0 <= bounds.right) {
-      grid.moveTo(0, bounds.top);
-      grid.lineTo(0, bounds.bottom);
-    }
-    if (0 >= bounds.top && 0 <= bounds.bottom) {
-      grid.moveTo(bounds.left, 0);
-      grid.lineTo(bounds.right, 0);
-    }
   }
 };
 


### PR DESCRIPTION
- [x] separated drawAxesLines and drawGridLines so the axes lines don't fade with grid.

I'll work on the props.showGridAxes in a separate branch.