### PR TITLE
Add missing argument to Getcells alias and fix dataframe indexing

### DIFF
--- a/src/core/computations/python/run_python.py
+++ b/src/core/computations/python/run_python.py
@@ -185,8 +185,8 @@ async def run_python(code):
     async def cell(p0_x, p0_y):
         return await getCell(p0_x, p0_y)
 
-    async def cells(p0, p1):
-        return await getCells(p0, p1)
+    async def cells(p0, p1, first_row_header=False):
+        return await getCells(p0, p1, first_row_header)
 
     globals = {
         "getCells": getCells,

--- a/src/core/computations/python/run_python.py
+++ b/src/core/computations/python/run_python.py
@@ -165,6 +165,7 @@ async def run_python(code):
         if first_row_header:
             df.rename(columns=df.iloc[0], inplace=True)
             df.drop(df.index[0], inplace=True)
+            df.reset_index(drop=True, inplace=True)
 
         return df
 


### PR DESCRIPTION
# Description

Hi! This looks like a great project. I just had a play with the demo and noticed a couple of things that I thought should be fixed.

1. The `first_row_header` argument mentioned in the [docs](https://docs.quadratic.to/reference/python-cell-reference/pandas-dataframe#referencing-a-range-of-cells) is missing from the `cells()` function. I believe this is supposed to be a direct alias of `getCells()`. Please correct me if I am wrong.

2. When passing the `first_row_header` argument, the row index of the dataframe returned starts from 1. I think that starting from 0 would be good for consistency and is what people expect.

This PR fixes these two issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

## Python unit tests
 `tests-python/test.py`
```
Launching unittests with arguments python -m unittest /quadratic/tests-python/test.py in /quadratic/tests-python

environment ready

Ran 2 tests in 0.096s

OK
```

## Testing behavior
1. Build and run with
```bash
npm build
npm start
```

2. Add following code in cell (0, 0) in UI
```python
import pandas as pd
pd.DataFrame({'a': [1, 2, 3], 'b': [2, 4, 6]})
```

3. Add following code in another three cells
   a.
   ```python
   df = cells((0, 0), (1, 3))
   print(df)
   df
   ```
   b.
   ```python
   df = cells((0, 0), (1, 3), first_row_header=False)
   print(df)
   df
   ```
   c.
   ```python
   df = cells((0, 0), (1, 3), first_row_header=True)
   print(df)
   df
   ```

4. Check outputs
- Cell outputs: 
  - all equal, showing full dataframe (without index)
- Console outputs from print statement:
   - a., b. 
   ```
      0  1
   0  a  b
   1  1  2
   2  2  4
   3  3  6
   ```
   - c. 
   ```
      a  b
   0  1  2
   1  2  4
   2  3  6
   ```

