### PR TITLE
Fix: Blurry text when `devicePixelRatio` is less than one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ yarn-error.log*
 
 venv/*
 *.pyc
+.idea

--- a/src/core/gridGL/QuadraticGrid.tsx
+++ b/src/core/gridGL/QuadraticGrid.tsx
@@ -124,7 +124,7 @@ export default function QuadraticGrid() {
           // resizeTo: window,
           resolution:
             // Always use 2 instead of 1. Better resolution.
-            window.devicePixelRatio === 1.0 ? 2 : window.devicePixelRatio,
+            window.devicePixelRatio <= 1.0 ? 2 : window.devicePixelRatio,
           backgroundColor: 0xffffff,
           antialias: true,
           autoDensity: true,


### PR DESCRIPTION
## Summary
This PR fixes a bug where the text will be blurry on devices that have a `devicePixelRatio` less than `1`. This is an edge-case I had to debug and fix on production for an enterprise Pixi application a few years ago, so when I was casually browsing the source code and noticed it, I forked it to add this fix so you don't get caught by it too. All this PR does is changes the check for your `resolution` Pixi configuration option to be a `<=` instead of a strict `===`. Effectively clamping the `resolution` to `2` if the `devicePixelRatio` is less than 1.0.

## The Bug
Having a `devicePixelRatio` less than 1.0 is generally pretty unusual, however it is much more common in enterprise environments (office workers, construction workers, product planners, etc) due to both accessibility tools or janky browser plugins/extensions often mandated by corporate IT departments. The easiest way to reproduce this is to change your browser zoom to be less than 100%.

## Reproduction Steps
1.) Easiest way to repro this is to change your browser zoom to be less than 100%.
2.) Load up early.quadratic.to. If your `devicePixelRatio` is less than 1.0, you should notice blurry text.

Here is what I saw:
Before:
![before](https://user-images.githubusercontent.com/2981742/192130860-198bb678-c03c-4f2d-9000-73d4a4e941d0.png)

After:
![after](https://user-images.githubusercontent.com/2981742/192130862-be44597e-e909-4c4d-8de5-15a8926f8250.png)


Overall a very cool product! Best of luck to y'all :D


Cheers.