### PR TITLE
fix: apply consistent UI copy casing, tweak menu design elements

### DIFF
--- a/src/ui/menus/TopBar/SubMenus/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu.tsx
@@ -44,7 +44,7 @@ export const FormatMenu = () => {
         </Tooltip>
       }
     >
-      <MenuHeader>Coming Soon</MenuHeader>
+      <MenuHeader>Coming soon</MenuHeader>
       <MenuDivider></MenuDivider>
       <MenuHeader>Text</MenuHeader>
       <MenuItem disabled>

--- a/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
@@ -20,7 +20,7 @@ export const NumberFormatMenu = () => {
   return (
     <Menu
       menuButton={
-        <Tooltip title="Number Format" arrow>
+        <Tooltip title="Number format" arrow>
           <Button style={{ color: colors.darkGray }}>
             <span style={{ fontSize: '1rem' }}>123</span>
             <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>
@@ -29,9 +29,9 @@ export const NumberFormatMenu = () => {
       }
       menuStyles={{ minWidth: '18rem' }}
     >
-      <MenuHeader>Coming Soon</MenuHeader>
+      <MenuHeader>Coming soon</MenuHeader>
       <MenuDivider></MenuDivider>
-      <MenuHeader>Number Format</MenuHeader>
+      <MenuHeader>Number format</MenuHeader>
       <MenuItem disabled type="checkbox" checked={true}>
         Automatic
       </MenuItem>

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import Button from '@mui/material/Button';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import { Menu, MenuItem, SubMenu, MenuDivider, MenuHeader } from '@szhsin/react-menu';
-import { LogoutOutlined, NorthEastOutlined } from '@mui/icons-material';
 import { isMobileOnly } from 'react-device-detect';
 import { useAuth0 } from '@auth0/auth0-react';
 
@@ -13,7 +12,6 @@ import { Tooltip } from '@mui/material';
 import { SaveGridFile } from '../../../../core/actions/gridFile/SaveGridFile';
 import { OpenGridFile } from '../../../../core/actions/gridFile/OpenGridFile';
 
-import { menuItemIconStyles, menuItemIconExternalLinkStyles } from './menuStyles';
 import { colors } from '../../../../theme/colors';
 import { DOCUMENTATION_URL, BUG_REPORT_URL } from '../../../../constants/urls';
 
@@ -86,22 +84,13 @@ export const QuadraticMenu = () => {
       {isAuthenticated && (
         <SubMenu label="Account">
           <MenuHeader>{user?.email}</MenuHeader>
-          <MenuItem onClick={() => logout({ returnTo: window.location.origin })}>
-            <LogoutOutlined style={menuItemIconStyles} />
-            Log out
-          </MenuItem>
+          <MenuItem onClick={() => logout({ returnTo: window.location.origin })}>Log out</MenuItem>
         </SubMenu>
       )}
 
       <SubMenu label="Help">
-        <MenuItem onClick={() => window.open(DOCUMENTATION_URL, '_blank')}>
-          Read the docs
-          <NorthEastOutlined style={menuItemIconExternalLinkStyles} fontSize="inherit" />
-        </MenuItem>
-        <MenuItem onClick={() => window.open(BUG_REPORT_URL, '_blank')}>
-          Report a problem
-          <NorthEastOutlined style={menuItemIconExternalLinkStyles} fontSize="inherit" />
-        </MenuItem>
+        <MenuItem onClick={() => window.open(DOCUMENTATION_URL, '_blank')}>Read the docs</MenuItem>
+        <MenuItem onClick={() => window.open(BUG_REPORT_URL, '_blank')}>Report a problem</MenuItem>
       </SubMenu>
     </Menu>
   );

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -2,13 +2,7 @@ import { useEffect } from 'react';
 import Button from '@mui/material/Button';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import { Menu, MenuItem, SubMenu, MenuDivider, MenuHeader } from '@szhsin/react-menu';
-import {
-  MenuBookOutlined,
-  FileOpenOutlined,
-  SaveOutlined,
-  BugReportOutlined,
-  LogoutOutlined,
-} from '@mui/icons-material';
+import { LogoutOutlined, NorthEastOutlined } from '@mui/icons-material';
 import { isMobileOnly } from 'react-device-detect';
 import { useAuth0 } from '@auth0/auth0-react';
 
@@ -19,7 +13,7 @@ import { Tooltip } from '@mui/material';
 import { SaveGridFile } from '../../../../core/actions/gridFile/SaveGridFile';
 import { OpenGridFile } from '../../../../core/actions/gridFile/OpenGridFile';
 
-import { menuItemIconStyles } from './menuStyles';
+import { menuItemIconStyles, menuItemIconExternalLinkStyles } from './menuStyles';
 import { colors } from '../../../../theme/colors';
 import { DOCUMENTATION_URL, BUG_REPORT_URL } from '../../../../constants/urls';
 
@@ -52,39 +46,32 @@ export const QuadraticMenu = () => {
     >
       <MenuHeader>Quadratic</MenuHeader>
       <SubMenu label="File">
-        <MenuItem onClick={() => SaveGridFile(true)}>
-          <SaveOutlined style={menuItemIconStyles}></SaveOutlined> Save Grid
-        </MenuItem>
-        <MenuItem onClick={() => OpenGridFile()}>
-          <FileOpenOutlined style={menuItemIconStyles}></FileOpenOutlined> Open Grid
-        </MenuItem>
+        <MenuItem onClick={() => SaveGridFile(true)}>Save grid</MenuItem>
+        <MenuItem onClick={() => OpenGridFile()}>Open grid</MenuItem>
       </SubMenu>
       <SubMenu label="Import">
-        <MenuHeader>Import</MenuHeader>
         <MenuItem disabled>CSV (coming soon)</MenuItem>
         <MenuItem disabled>Excel (coming soon)</MenuItem>
       </SubMenu>
       <SubMenu label="View">
-        <MenuHeader>UI</MenuHeader>
         <MenuItem type="checkbox" checked={showHeadings} onClick={() => setShowHeadings(!showHeadings)}>
-          Show Headings
+          Show headings
         </MenuItem>
-        <MenuHeader>Grid</MenuHeader>
+        <MenuDivider />
         <MenuItem type="checkbox" checked={showGridAxes} onClick={() => setShowGridAxes(!showGridAxes)}>
-          Show Axis
+          Show grid axis
         </MenuItem>
         <MenuItem type="checkbox" checked={showGridLines} onClick={() => setShowGridLines(!showGridLines)}>
-          Show Grid Lines
+          Show grid lines
         </MenuItem>
         <MenuItem
           type="checkbox"
           checked={showCellTypeOutlines}
           onClick={() => setShowCellTypeOutlines(!showCellTypeOutlines)}
         >
-          Show Cell Type Outlines
+          Show cell type outlines
         </MenuItem>
         <MenuDivider />
-        <MenuHeader>Debug</MenuHeader>
         <MenuItem
           type="checkbox"
           checked={showDebugMenu}
@@ -92,7 +79,7 @@ export const QuadraticMenu = () => {
             setShowDebugMenu(!showDebugMenu);
           }}
         >
-          Show DebugMenu
+          Show debug menu
         </MenuItem>
       </SubMenu>
 
@@ -101,17 +88,19 @@ export const QuadraticMenu = () => {
           <MenuHeader>{user?.email}</MenuHeader>
           <MenuItem onClick={() => logout({ returnTo: window.location.origin })}>
             <LogoutOutlined style={menuItemIconStyles} />
-            Log Out
+            Log out
           </MenuItem>
         </SubMenu>
       )}
 
       <SubMenu label="Help">
         <MenuItem onClick={() => window.open(DOCUMENTATION_URL, '_blank')}>
-          <MenuBookOutlined style={menuItemIconStyles}></MenuBookOutlined> Read the docs
+          Read the docs
+          <NorthEastOutlined style={menuItemIconExternalLinkStyles} fontSize="inherit" />
         </MenuItem>
         <MenuItem onClick={() => window.open(BUG_REPORT_URL, '_blank')}>
-          <BugReportOutlined style={menuItemIconStyles}></BugReportOutlined> Report a problem
+          Report a problem
+          <NorthEastOutlined style={menuItemIconExternalLinkStyles} fontSize="inherit" />
         </MenuItem>
       </SubMenu>
     </Menu>

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -34,7 +34,7 @@ export const QuadraticMenu = () => {
   return (
     <Menu
       menuButton={
-        <Tooltip title="Main Menu" arrow>
+        <Tooltip title="Main menu" arrow>
           <Button style={{ color: colors.darkGray }}>
             <img src="favicon.ico" height="22px" alt="Quadratic Icon" />
             <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>
@@ -53,7 +53,7 @@ export const QuadraticMenu = () => {
       </SubMenu>
       <SubMenu label="View">
         <MenuItem type="checkbox" checked={showHeadings} onClick={() => setShowHeadings(!showHeadings)}>
-          Show headings
+          Show row & column headings
         </MenuItem>
         <MenuDivider />
         <MenuItem type="checkbox" checked={showGridAxes} onClick={() => setShowGridAxes(!showGridAxes)}>

--- a/src/ui/menus/TopBar/SubMenus/menuStyles.ts
+++ b/src/ui/menus/TopBar/SubMenus/menuStyles.ts
@@ -10,3 +10,9 @@ export const menuItemIconStyles = {
   marginRight: '0.5rem',
   color: colors.darkGray,
 };
+
+export const menuItemIconExternalLinkStyles = {
+  color: colors.darkGray,
+  fontSize: '.8125rem',
+  marginLeft: '1rem',
+};

--- a/src/ui/menus/TopBar/SubMenus/menuStyles.ts
+++ b/src/ui/menus/TopBar/SubMenus/menuStyles.ts
@@ -10,9 +10,3 @@ export const menuItemIconStyles = {
   marginRight: '0.5rem',
   color: colors.darkGray,
 };
-
-export const menuItemIconExternalLinkStyles = {
-  color: colors.darkGray,
-  fontSize: '.8125rem',
-  marginLeft: '1rem',
-};

--- a/src/ui/menus/TopBar/TopBar.tsx
+++ b/src/ui/menus/TopBar/TopBar.tsx
@@ -113,7 +113,7 @@ export const TopBar = () => {
                 {user?.name && user?.name[0]}
               </Avatar>
             </AvatarGroup>
-            <Tooltip title="Coming Soon" arrow>
+            <Tooltip title="Coming soon" arrow>
               <Button
                 style={{
                   color: colors.darkGray,

--- a/src/ui/menus/TopBar/ZoomDropdown.tsx
+++ b/src/ui/menus/TopBar/ZoomDropdown.tsx
@@ -23,7 +23,7 @@ export const ZoomDropdown = () => {
           focusGrid();
         }}
       >
-        Zoom to Fit
+        Zoom to fit
       </MenuItem>
       <MenuDivider></MenuDivider>
       <MenuItem


### PR DESCRIPTION
This aims to refine and polish these aspects of the app:

1. Apply consistent UI copy and casing
2. Remove (redundant) menu label dividers
3. Remove (inconsistent application of) icons from menus
4. Tweak language for the sake of clarity

## Changes Rationale

More detailed rationale for each change and a before/after snapshot of the changes:

### Consistent UI copy casing

There is some inconsistent casing in the UI copy. In some places you’ll find “Title Case”, in others “Sentence case”. It’s a seemingly minor detail, but helps provide solid polish and a sense of care to the overall app.

<img width="709" alt="CleanShot 2022-12-21 at 09 44 10@2x" src="https://user-images.githubusercontent.com/1316441/211062268-ac0424fc-aa47-47ab-b59e-f946752322b9.png">

I suggested apply a standard approach to casing across the UI. Personally, I recommended going with “Sentence case” for many reasons, one being that it’s the most predictable for people writing copy and friendly for people reading copy ([this is a great article on the subject](https://medium.com/@jsaito/making-a-case-for-letter-case-19d09f653c98)).

## Menus

Not convinced label dividers are necessary in fly out menus, especially when labels are repeated in the divider and menuitem. For example, here we have “Grid” as the label and “Show Grid Lines” as the menuitem (which could be just “Show Lines” since it’s already qualified under “Grid”)

<img width="416" alt="CleanShot 2022-12-21 at 10 59 28@2x" src="https://user-images.githubusercontent.com/1316441/211063780-c7df233d-f6cc-4669-83db-67b6fd0d2d2a.png">

Similarly with the "Import" menu, where the label is repeated twice:

<img width="387" alt="CleanShot 2022-12-21 at 11 08 51@2x" src="https://user-images.githubusercontent.com/1316441/211064216-a577fa4e-1012-4b9d-a1de-1ae9c8134243.png">

With good labels, I believe a dividing lines is enough in the menus — this is a case of "less is more". For example, see Figma's menus:

<img width="227" alt="CleanShot 2022-12-21 at 11 00 09@2x" src="https://user-images.githubusercontent.com/1316441/211063857-5bee38af-4693-48ae-907c-51fb22df9202.png">

Additionally, I would recommend changing the text label for today’s “Show Headings”. I don’t think that is immediately clear; whereas a name like “Show row & column headings” is more clear — and that’s what [those things are called in Excel](https://support.microsoft.com/en-us/office/print-row-and-column-headings-de41db7e-b716-4d8b-a5fd-5fb50645101f)).

Lastly, the use of icons in the "Main menu" is inconsistent and I thought it better to take those icons out completely — until there's a compelling rationale in the future to include them in a more coherent, consistent manner.

### Before/after preview of changes

![quad-pr](https://user-images.githubusercontent.com/1316441/211065439-68407dae-67a8-4f81-8492-e577538b4f8e.png)
