### PR TITLE
fix: small UI tweaks

### DIFF
--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback } from 'react';
 import Button from '@mui/material/Button';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
-import { Menu, MenuItem, MenuDivider, MenuHeader, SubMenu, MenuChangeEvent } from '@szhsin/react-menu';
+import { Menu, MenuItem, MenuDivider, SubMenu, MenuChangeEvent } from '@szhsin/react-menu';
 
 import {
   FormatBold,

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
@@ -11,13 +11,14 @@ import {
   FormatAlignCenter,
   FormatColorText,
   FormatColorFill,
+  FormatClear,
   ReadMore,
 } from '@mui/icons-material';
 import { PaletteOutlined } from '@mui/icons-material';
 import '@szhsin/react-menu/dist/index.css';
 import { Tooltip } from '@mui/material';
 import { colors } from '../../../../../theme/colors';
-import { menuItemIconStyles, topBarIconStyles } from '../menuStyles';
+import { menuItemIconStyles, menuItemIconDisabledStyles, topBarIconStyles } from '../menuStyles';
 import { CompactPicker } from 'react-color';
 import { useFormatCells } from '../useFormatCells';
 import { useGetBorderMenu } from './useGetBorderMenu';
@@ -63,15 +64,14 @@ export const FormatMenu = (props: IProps) => {
         </Tooltip>
       }
     >
-      <MenuHeader>Text</MenuHeader>
       <MenuItem disabled>
-        <FormatBold style={menuItemIconStyles}></FormatBold> Bold
+        <FormatBold style={menuItemIconDisabledStyles}></FormatBold> Bold
       </MenuItem>
       <MenuItem disabled>
-        <FormatItalic style={menuItemIconStyles}></FormatItalic> Italic
+        <FormatItalic style={menuItemIconDisabledStyles}></FormatItalic> Italic
       </MenuItem>
       <MenuItem disabled>
-        <FormatColorText style={menuItemIconStyles}></FormatColorText> Color
+        <FormatColorText style={menuItemIconDisabledStyles}></FormatColorText> Text color
       </MenuItem>
 
       <MenuDivider />
@@ -90,17 +90,16 @@ export const FormatMenu = (props: IProps) => {
 
       <MenuDivider />
       <MenuItem disabled>
-        <FormatAlignLeft style={menuItemIconStyles}></FormatAlignLeft> Left
+        <FormatAlignLeft style={menuItemIconDisabledStyles}></FormatAlignLeft> Left
       </MenuItem>
       <MenuItem disabled>
-        <FormatAlignCenter style={menuItemIconStyles}></FormatAlignCenter> Center
+        <FormatAlignCenter style={menuItemIconDisabledStyles}></FormatAlignCenter> Center
       </MenuItem>
       <MenuItem disabled>
-        <FormatAlignRight style={menuItemIconStyles}></FormatAlignRight> Right
+        <FormatAlignRight style={menuItemIconDisabledStyles}></FormatAlignRight> Right
       </MenuItem>
 
       <MenuDivider />
-      <MenuHeader>Cell</MenuHeader>
       <SubMenu
         id="FillColorMenuID"
         menuStyles={{
@@ -108,18 +107,21 @@ export const FormatMenu = (props: IProps) => {
         }}
         label={
           <>
-            <FormatColorFill style={menuItemIconStyles}></FormatColorFill> Fill Color
+            <FormatColorFill style={menuItemIconStyles}></FormatColorFill> Fill color
           </>
         }
       >
-        <MenuHeader>Fill Color</MenuHeader>
         <CompactPicker onChange={changeFillColor} />
-        <MenuItem onClick={removeFillColor}>Clear Fill Color</MenuItem>
+        <MenuItem onClick={removeFillColor}>Clear</MenuItem>
       </SubMenu>
 
       {borders}
 
-      <MenuItem onClick={handleClearFormatting}>Clear Formatting</MenuItem>
+      <MenuDivider />
+      <MenuItem onClick={handleClearFormatting}>
+        <FormatClear style={menuItemIconStyles}></FormatClear>
+        Clear formatting
+      </MenuItem>
     </Menu>
   );
 };

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -15,6 +15,7 @@ import {
   BorderVertical,
   BorderClear,
 } from '@mui/icons-material';
+import { Tooltip } from '@mui/material';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { ColorResult, CompactPicker } from 'react-color';
 import { useRecoilState } from 'recoil';
@@ -64,6 +65,10 @@ export function useGetBorderMenu(props: Props): JSX.Element {
   const handleChangeBorders = useCallback(
     (borderSelection: BorderSelection, color: string, lineStyle?: BorderType): void => {
       if (!borderSelection) return;
+      if (borderSelection === BorderSelection.clear) {
+        clearBorders();
+        return;
+      }
       const borders: ChangeBorder = {};
       if (color !== defaultColor) borders.color = color;
       if (lineStyle) borders.type = lineStyle;
@@ -131,6 +136,7 @@ export function useGetBorderMenu(props: Props): JSX.Element {
     type: BorderSelection;
     label: JSX.Element;
     disabled?: boolean;
+    title: string;
   }): JSX.Element => {
     return (
       <div
@@ -144,7 +150,9 @@ export function useGetBorderMenu(props: Props): JSX.Element {
           }
         }}
       >
-        {props.label}
+        <Tooltip title={props.title} arrow>
+          {props.label}
+        </Tooltip>
       </div>
     );
   };
@@ -161,24 +169,33 @@ export function useGetBorderMenu(props: Props): JSX.Element {
       <div className="borderMenu">
         <div className="borderMenuLines">
           <div className="borderMenuLine">
-            <BorderSelectionButton type={BorderSelection.all} label={<BorderAll />} />
-            <BorderSelectionButton type={BorderSelection.inner} label={<BorderInner />} disabled={!multiCursor} />
-            <BorderSelectionButton type={BorderSelection.outer} label={<BorderOuter />} />
+            <BorderSelectionButton type={BorderSelection.all} title="All borders" label={<BorderAll />} />
+            <BorderSelectionButton
+              type={BorderSelection.inner}
+              title="Inner borders"
+              label={<BorderInner />}
+              disabled={!multiCursor}
+            />
+            <BorderSelectionButton type={BorderSelection.outer} title="Outer borders" label={<BorderOuter />} />
             <BorderSelectionButton
               type={BorderSelection.horizontal}
+              title="Horizontal borders"
               label={<BorderHorizontal />}
               disabled={!multiCursor}
             />
-            <BorderSelectionButton type={BorderSelection.vertical} label={<BorderVertical />} disabled={!multiCursor} />
+            <BorderSelectionButton
+              type={BorderSelection.vertical}
+              title="Vertical borders"
+              label={<BorderVertical />}
+              disabled={!multiCursor}
+            />
           </div>
           <div className="borderMenuLine">
-            <BorderSelectionButton type={BorderSelection.left} label={<BorderLeft />} />
-            <BorderSelectionButton type={BorderSelection.top} label={<BorderTop />} />
-            <BorderSelectionButton type={BorderSelection.right} label={<BorderRight />} />
-            <BorderSelectionButton type={BorderSelection.bottom} label={<BorderBottom />} />
-            <div className="borderMenuType" onClick={clearBorders}>
-              <BorderClear />
-            </div>
+            <BorderSelectionButton type={BorderSelection.left} title="Left border" label={<BorderLeft />} />
+            <BorderSelectionButton type={BorderSelection.top} title="Top border" label={<BorderTop />} />
+            <BorderSelectionButton type={BorderSelection.right} title="Right border" label={<BorderRight />} />
+            <BorderSelectionButton type={BorderSelection.bottom} title="Bottom border" label={<BorderBottom />} />
+            <BorderSelectionButton type={BorderSelection.clear} title="Clear borders" label={<BorderClear />} />
           </div>
         </div>
         <div className="borderMenuFormatting">

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -140,9 +140,7 @@ export function useGetBorderMenu(props: Props): JSX.Element {
   }): JSX.Element => {
     return (
       <div
-        className={`borderMenuType ${borderSelection === props.type ? 'borderSelected' : ''} ${
-          props.disabled ? 'borderDisabled' : ''
-        }`}
+        className={`borderMenuType ${props.disabled ? 'borderDisabled' : ''}`}
         onClick={() => {
           if (!props.disabled) {
             setBorderSelection(props.type);

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -1,4 +1,4 @@
-import { ClickEvent, MenuHeader, MenuItem, SubMenu, SubMenuProps } from '@szhsin/react-menu';
+import { ClickEvent, MenuItem, SubMenu, SubMenuProps } from '@szhsin/react-menu';
 import { menuItemIconStyles } from '../menuStyles';
 import { BorderType } from '../../../../../core/gridDB/gridTypes';
 import {
@@ -107,7 +107,7 @@ export function useGetBorderMenu(props: Props): JSX.Element {
       }
       changeBorders(borders);
     },
-    [changeBorders, defaultColor]
+    [changeBorders, defaultColor, clearBorders]
   );
 
   const handleChangeBorderColor = useCallback(

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -190,7 +190,6 @@ export function useGetBorderMenu(props: Props): JSX.Element {
             }}
             label={<BorderColor style={{ ...menuItemIconStyles, color }}></BorderColor>}
           >
-            <MenuHeader>Border Color</MenuHeader>
             <CompactPicker onChangeComplete={handleChangeBorderColor} />
           </SubMenu>
           <SubMenu

--- a/src/ui/menus/TopBar/SubMenus/menuStyles.ts
+++ b/src/ui/menus/TopBar/SubMenus/menuStyles.ts
@@ -10,3 +10,8 @@ export const menuItemIconStyles = {
   marginRight: '0.5rem',
   color: colors.darkGray,
 };
+
+export const menuItemIconDisabledStyles = {
+  ...menuItemIconStyles,
+  color: 'inherit',
+};


### PR DESCRIPTION
Fixes a number of issues described in [the corresponding Notion page](https://www.notion.so/Formatting-UI-Feedback-204dcd15ddce4db0a185409f02f1678c), including:

- Normalize menu item casing, e.g. "Fill Color" -> "Fill color"
- Remove unnecessary labels
- Style disabled menu icons so they also appear disabled
- Add icon to "Clear formatting" with a divider (to separate it from any one specific menu section)
- Add tooltips to border application buttons (and remove "selected" state of border buttons, as those are buttons to _apply_ a style, not representative of the current state of borders)

| Change | Before | After |
| --- | --- | --- |
| Formatting menu | <img width="199" alt="CleanShot 2023-01-11 at 12 04 31@2x" src="https://user-images.githubusercontent.com/1316441/211895396-65ccd3d6-8f9a-4813-b076-4ed55a13a1c8.png"> | <img width="222" alt="CleanShot 2023-01-11 at 12 03 49@2x" src="https://user-images.githubusercontent.com/1316441/211895265-0ba54dd2-b431-44df-8422-f96538b1e2a9.png"> |
| Fill menu | <img width="445" alt="CleanShot 2023-01-11 at 12 05 35@2x" src="https://user-images.githubusercontent.com/1316441/211895711-f550de03-d10a-4fc5-874a-b92c7550581b.png"> | <img width="488" alt="CleanShot 2023-01-11 at 12 05 49@2x" src="https://user-images.githubusercontent.com/1316441/211895677-6a95267c-cd1c-47c3-9706-4460f5fbaf1d.png"> |
| Border tooltips | <img width="428" alt="CleanShot 2023-01-11 at 14 05 13@2x" src="https://user-images.githubusercontent.com/1316441/211917676-fb2700e9-4e4a-4236-bbd2-69b57ae0462d.png"> | <img width="455" alt="CleanShot 2023-01-11 at 14 03 25@2x" src="https://user-images.githubusercontent.com/1316441/211917935-41ad6199-2be6-4172-84b1-bb13863895ad.png"> |
