### PR TITLE
feat: add zoom shortcuts

### DIFF
--- a/src/core/gridGL/interaction/keyboard/keyboardViewport.ts
+++ b/src/core/gridGL/interaction/keyboard/keyboardViewport.ts
@@ -1,8 +1,9 @@
 import { Viewport } from 'pixi-viewport';
-import { zoomInOut } from '../../helpers/zoom';
+import { Sheet } from '../../../gridDB/Sheet';
+import { zoomInOut, zoomToFit } from '../../helpers/zoom';
 
-export function keyboardViewport(options: { event: KeyboardEvent; viewport?: Viewport }): boolean {
-  const { event, viewport } = options;
+export function keyboardViewport(options: { event: KeyboardEvent; sheet: Sheet; viewport?: Viewport }): boolean {
+  const { event, sheet, viewport } = options;
 
   if (!viewport) return false;
 
@@ -14,6 +15,18 @@ export function keyboardViewport(options: { event: KeyboardEvent; viewport?: Vie
 
   if ((event.metaKey || event.ctrlKey) && event.code === 'Minus') {
     zoomInOut(viewport, viewport.scale.x * 0.5);
+    event.preventDefault();
+    return true;
+  }
+
+  if (event.shiftKey && event.code === 'Digit1') {
+    zoomToFit(sheet, viewport);
+    event.preventDefault();
+    return true;
+  }
+
+  if ((event.metaKey || event.ctrlKey) && event.code === 'Digit0') {
+    zoomInOut(viewport, 1);
     event.preventDefault();
     return true;
   }

--- a/src/core/gridGL/interaction/keyboard/useKeyboard.ts
+++ b/src/core/gridGL/interaction/keyboard/useKeyboard.ts
@@ -23,18 +23,18 @@ interface IProps {
 export const pixiKeyboardCanvasProps: { headerSize: Size } = { headerSize: { width: 0, height: 0 } };
 
 export const useKeyboard = (props: IProps): { onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void } => {
-  const { interactionState, setInteractionState, setEditorInteractionState, app } = props;
+  const { interactionState, setInteractionState, setEditorInteractionState, app, sheetController } = props;
 
   const keyDownWindow = useCallback(
     (event: KeyboardEvent): void => {
       if (interactionState.showInput) return;
 
-      if (keyboardViewport({ event, viewport: app?.viewport })) {
+      if (keyboardViewport({ event, viewport: app?.viewport, sheet: sheetController.sheet })) {
         event.stopPropagation();
         event.preventDefault();
       }
     },
-    [app?.viewport, interactionState]
+    [app?.viewport, interactionState, sheetController.sheet]
   );
 
   useEffect(() => {

--- a/src/ui/menus/KeyboardShortcut.tsx
+++ b/src/ui/menus/KeyboardShortcut.tsx
@@ -5,6 +5,7 @@ export interface IKeyboardShortcut {
   text: string;
   shortcut?: string;
   ctrl?: boolean;
+  shift?: boolean;
 }
 
 export const KeyboardShortcut = (props: IKeyboardShortcut): JSX.Element => {
@@ -18,9 +19,12 @@ export const KeyboardShortcut = (props: IKeyboardShortcut): JSX.Element => {
         shortcut += 'CTRL ';
       }
     }
+    if (props.shift) {
+      shortcut += '⇧ ';
+    }
     shortcut += props.shortcut;
     return shortcut;
-  }, [props.shortcut, props.ctrl]);
+  }, [props.shortcut, props.ctrl, props.shift]);
 
   return (
     <div style={{ display: 'flex', width: '175px' }}>

--- a/src/ui/menus/TopBar/ZoomDropdown.tsx
+++ b/src/ui/menus/TopBar/ZoomDropdown.tsx
@@ -25,7 +25,7 @@ export const ZoomDropdown = () => {
           focusGrid();
         }}
       >
-        Zoom to fit
+        <KeyboardShortcut text="Zoom to fit" shortcut="1" shift={true} />
       </MenuItem>
       <MenuDivider></MenuDivider>
       <MenuItem
@@ -34,7 +34,7 @@ export const ZoomDropdown = () => {
           focusGrid();
         }}
       >
-        <KeyboardShortcut text="Zoom in" shortcut="=" ctrl={true} />
+        <KeyboardShortcut text="Zoom in" shortcut="+" ctrl={true} />
       </MenuItem>
       <MenuItem
         onClick={() => {
@@ -42,7 +42,7 @@ export const ZoomDropdown = () => {
           focusGrid();
         }}
       >
-        <KeyboardShortcut text="Zoom out" shortcut="-" ctrl={true} />
+        <KeyboardShortcut text="Zoom out" shortcut="−" ctrl={true} />
       </MenuItem>
       <MenuDivider></MenuDivider>
       <MenuItem
@@ -59,7 +59,7 @@ export const ZoomDropdown = () => {
           focusGrid();
         }}
       >
-        Zoom to 100%
+        <KeyboardShortcut text="Zoom to 100%" shortcut="0" ctrl={true} />
       </MenuItem>
       <MenuItem
         onClick={() => {


### PR DESCRIPTION
Add support for shortcuts related to zoom controls and display them in the zoom menu bar.

<img width="259" alt="CleanShot 2023-01-12 at 22 38 05@2x" src="https://user-images.githubusercontent.com/1316441/212245355-0dd6b6b5-5e25-49c7-ae71-3003d4447f44.png">

Resolves a few takeaways from [the UI/UX research on navigating infinite canvas tools](https://www.notion.so/Navigation-Infinite-Canvas-Tools-23789227181b419e9a72444308343ccf)