### PR TITLE
feat: add keyboard shortcuts to context menu

### DIFF
--- a/src/ui/menus/KeyboardShortcut.tsx
+++ b/src/ui/menus/KeyboardShortcut.tsx
@@ -6,7 +6,7 @@ export interface IKeyboardShortcut {
 
 export const KeyboardShortcut = ({ modifier = '', shortcut, text }: IKeyboardShortcut): JSX.Element => {
   return (
-    <div style={{ display: 'flex', width: '175px' }}>
+    <div style={{ display: 'flex', width: '175px', justifyContent: 'space-between' }}>
       <div style={{ width: '140px' }}>{text}</div>
       <div style={{ fontSize: '14px', color: '#aaaaaa' }}>{modifier + shortcut}</div>
     </div>

--- a/src/ui/menus/RightClickMenu/ContextMenu.tsx
+++ b/src/ui/menus/RightClickMenu/ContextMenu.tsx
@@ -4,6 +4,8 @@ import { MenuState, MenuCloseEvent } from '@szhsin/react-menu/types';
 import { copyToClipboard, cutToClipboard, pasteFromClipboard } from '../../../core/actions/clipboard';
 import { GridInteractionState } from '../../../atoms/gridInteractionStateAtom';
 import { SheetController } from '../../../core/transaction/sheetController';
+import { KeyboardShortcut } from '../KeyboardShortcut';
+import { KeyboardSymbols } from '../../../helpers/keyboardSymbols';
 
 interface EventHandler<E> {
   (event: E): void;
@@ -54,7 +56,7 @@ export const ContextMenu = (props: ContextMenuProps) => {
             );
           }}
         >
-          Cut
+          <KeyboardShortcut text="Cut" shortcut="X" modifier={KeyboardSymbols.Command} />
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -65,14 +67,14 @@ export const ContextMenu = (props: ContextMenuProps) => {
             );
           }}
         >
-          Copy
+          <KeyboardShortcut text="Copy" shortcut="C" modifier={KeyboardSymbols.Command} />
         </MenuItem>
         <MenuItem
           onClick={() => {
             pasteFromClipboard(props.sheet_controller, props.interactionState.cursorPosition);
           }}
         >
-          Paste
+          <KeyboardShortcut text="Paste" shortcut="V" modifier={KeyboardSymbols.Command} />
         </MenuItem>
       </ControlledMenu>
     </>


### PR DESCRIPTION
Display keyboard shortcuts in the context menu (like we do in the zoom dropdown):

<img width="362" alt="CleanShot 2023-02-02 at 16 54 59@2x" src="https://user-images.githubusercontent.com/1316441/216477753-5a18faa3-9c57-47d8-9f1b-9b4282f35648.png">
