### PR TITLE
fix: menus

### DIFF
--- a/src/ui/menus/CommandPalette/ListItems/Format.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Format.tsx
@@ -2,7 +2,8 @@ import { useFormatCells } from '../../TopBar/SubMenus/useFormatCells';
 import { useGetSelection } from '../../TopBar/SubMenus/useGetSelection';
 import { CommandPaletteListItem } from '../CommandPaletteListItem';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
-import { FormatBold, FormatItalic } from '@mui/icons-material';
+import { FormatBold, FormatClear, FormatItalic } from '@mui/icons-material';
+import { useBorders } from '../../TopBar/SubMenus/useBorders';
 
 const ListItems = [
   {
@@ -36,6 +37,25 @@ const ListItems = [
             format.changeItalic(!selection.format?.italic);
           }}
           shortcut="I"
+          shortcutModifiers={KeyboardSymbols.Command}
+        />
+      );
+    },
+  },
+  {
+    label: 'Format: Clear all',
+    Component: (props: any) => {
+      const { clearFormatting } = useFormatCells(props.sheetController, props.app);
+      const { clearBorders } = useBorders(props.sheetController.sheet, props.app);
+      return (
+        <CommandPaletteListItem
+          {...props}
+          icon={<FormatClear />}
+          action={() => {
+            clearFormatting();
+            clearBorders();
+          }}
+          shortcut="\"
           shortcutModifiers={KeyboardSymbols.Command}
         />
       );

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -241,6 +241,18 @@ export const FloatingContextMenu = (props: Props) => {
             <FormatItalic fontSize={iconSize} />
           </IconButton>
         </TooltipHint>
+        <Menu
+          menuButton={
+            <div>
+              <TooltipHint title="Text color">
+                <IconButton>{<FormatColorText fontSize={iconSize}></FormatColorText>}</IconButton>
+              </TooltipHint>
+            </div>
+          }
+        >
+          <QColorPicker onChangeComplete={changeTextColor} />
+          <MenuItem onClick={removeTextColor}>Clear</MenuItem>
+        </Menu>
 
         <MenuDivider />
 
@@ -261,18 +273,6 @@ export const FloatingContextMenu = (props: Props) => {
         <Menu
           menuButton={
             <div>
-              <TooltipHint title="Text color">
-                <IconButton>{<FormatColorText fontSize={iconSize}></FormatColorText>}</IconButton>
-              </TooltipHint>
-            </div>
-          }
-        >
-          <QColorPicker onChangeComplete={changeTextColor} />
-          <MenuItem onClick={removeTextColor}>Clear</MenuItem>
-        </Menu>
-        <Menu
-          menuButton={
-            <div>
               <TooltipHint title="Borders">
                 <IconButton>
                   <BorderAll fontSize={iconSize} />
@@ -283,6 +283,7 @@ export const FloatingContextMenu = (props: Props) => {
         >
           {borders}
         </Menu>
+        <MenuDivider />
         <TooltipHint title="Clear formatting" shortcut={KeyboardSymbols.Command + '\\'}>
           <IconButton onClick={handleClearFormatting}>
             <FormatClear fontSize={iconSize} />
@@ -333,8 +334,8 @@ function MenuDivider() {
       flexItem
       style={{
         // add padding left and right
-        paddingLeft: '10px',
-        marginRight: '10px',
+        paddingLeft: '4px',
+        marginRight: '4px',
       }}
     />
   );

--- a/src/ui/menus/KeyboardShortcut.tsx
+++ b/src/ui/menus/KeyboardShortcut.tsx
@@ -7,12 +7,12 @@ export interface IKeyboardShortcut {
 
 export const KeyboardShortcut = ({ modifier = '', shortcut, text, icon }: IKeyboardShortcut): JSX.Element => {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', width: '175px', justifyContent: 'space-between' }}>
-      <div style={{ width: '140px', display: 'flex', alignItems: 'center' }}>
+    <div style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ minWidth: '140px', display: 'flex', alignItems: 'center' }}>
         {icon && icon}
         {text}
       </div>
-      <div style={{ fontSize: '14px', color: '#aaaaaa' }}>{modifier + shortcut}</div>
+      <div style={{ marginLeft: '24px', fontSize: '14px', color: '#aaaaaa' }}>{modifier + shortcut}</div>
     </div>
   );
 };

--- a/src/ui/menus/KeyboardShortcut.tsx
+++ b/src/ui/menus/KeyboardShortcut.tsx
@@ -8,7 +8,7 @@ export interface IKeyboardShortcut {
 export const KeyboardShortcut = ({ modifier = '', shortcut, text, icon }: IKeyboardShortcut): JSX.Element => {
   return (
     <div style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' }}>
-      <div style={{ minWidth: '140px', display: 'flex', alignItems: 'center' }}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         {icon && icon}
         {text}
       </div>

--- a/src/ui/menus/TopBar/SubMenus/DataMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/DataMenu.tsx
@@ -14,7 +14,7 @@ export const DataMenu = () => {
   return (
     <Menu
       menuButton={
-        <Tooltip title="Data" arrow>
+        <Tooltip title="Data" arrow disableInteractive enterDelay={500} enterNextDelay={500}>
           <Button style={{ color: colors.darkGray }}>
             <DataObjectOutlined style={topBarIconStyles}></DataObjectOutlined>
             <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
@@ -6,20 +6,20 @@ import { Menu, MenuItem, MenuDivider, SubMenu, MenuChangeEvent } from '@szhsin/r
 import {
   FormatBold,
   FormatItalic,
-  FormatAlignLeft,
-  FormatAlignRight,
-  FormatAlignCenter,
+  // FormatAlignLeft,
+  // FormatAlignRight,
+  // FormatAlignCenter,
   FormatColorText,
   FormatColorFill,
   FormatClear,
-  ReadMore,
+  // ReadMore,
   BorderAll,
 } from '@mui/icons-material';
 import { PaletteOutlined } from '@mui/icons-material';
 import '@szhsin/react-menu/dist/index.css';
 import { Tooltip } from '@mui/material';
 import { colors } from '../../../../../theme/colors';
-import { menuItemIconStyles, menuItemIconDisabledStyles, topBarIconStyles } from '../menuStyles';
+import { menuItemIconStyles, topBarIconStyles } from '../menuStyles';
 import { QColorPicker } from '../../../../components/qColorPicker';
 import { useFormatCells } from '../useFormatCells';
 import { useGetBorderMenu } from './useGetBorderMenu';
@@ -69,7 +69,7 @@ export const FormatMenu = (props: IProps) => {
     <Menu
       onMenuChange={onMenuChange}
       menuButton={
-        <Tooltip title="Format" arrow>
+        <Tooltip title="Format" arrow disableInteractive enterDelay={500} enterNextDelay={500}>
           <Button style={{ color: colors.darkGray }}>
             <PaletteOutlined style={topBarIconStyles}></PaletteOutlined>
             <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>
@@ -77,7 +77,7 @@ export const FormatMenu = (props: IProps) => {
         </Tooltip>
       }
     >
-      <MenuItem type="checkbox" checked={format.bold === true} onClick={() => changeBold(!(format.bold === true))}>
+      <MenuItem onClick={() => changeBold(!(format.bold === true))}>
         <KeyboardShortcut
           text="Bold"
           shortcut="B"
@@ -85,11 +85,7 @@ export const FormatMenu = (props: IProps) => {
           icon={<FormatBold style={menuItemIconStyles} />}
         />
       </MenuItem>
-      <MenuItem
-        type="checkbox"
-        checked={format.italic === true}
-        onClick={() => changeItalic(!(format.italic === true))}
-      >
+      <MenuItem onClick={() => changeItalic(!(format.italic === true))}>
         <KeyboardShortcut
           text="Italic"
           shortcut="I"
@@ -98,7 +94,6 @@ export const FormatMenu = (props: IProps) => {
         />
       </MenuItem>
       <SubMenu
-        className="menuItemIndent"
         id="TextColorMenuID"
         menuStyles={{
           padding: '0px',
@@ -113,13 +108,14 @@ export const FormatMenu = (props: IProps) => {
         <MenuItem onClick={removeTextColor}>Clear</MenuItem>
       </SubMenu>
 
-      {/* <MenuItem className="menuItemIndent">
-        <FormatColorText style={menuItemIconDisabledStyles}></FormatColorText> Text color
+      {/* <MenuItem >
+        <FormatColorText></FormatColorText> Text color
       </MenuItem> */}
 
+      {/*
       <MenuDivider />
       <SubMenu
-        className="menuItemIndent"
+        
         label={
           <Fragment>
             <ReadMore style={menuItemIconStyles}></ReadMore>
@@ -132,20 +128,20 @@ export const FormatMenu = (props: IProps) => {
         <MenuItem type="checkbox">Clip</MenuItem>
       </SubMenu>
 
+      
       <MenuDivider />
       <MenuItem type="checkbox">
-        <FormatAlignLeft style={menuItemIconDisabledStyles}></FormatAlignLeft> Left
+        <FormatAlignLeft></FormatAlignLeft> Left
       </MenuItem>
       <MenuItem type="checkbox">
-        <FormatAlignCenter style={menuItemIconDisabledStyles}></FormatAlignCenter> Center
+        <FormatAlignCenter></FormatAlignCenter> Center
       </MenuItem>
       <MenuItem type="checkbox">
-        <FormatAlignRight style={menuItemIconDisabledStyles}></FormatAlignRight> Right
-      </MenuItem>
+        <FormatAlignRight></FormatAlignRight> Right
+      </MenuItem>*/}
 
       <MenuDivider />
       <SubMenu
-        className="menuItemIndent"
         id="FillColorMenuID"
         menuStyles={{
           padding: '0px',
@@ -161,7 +157,6 @@ export const FormatMenu = (props: IProps) => {
       </SubMenu>
 
       <SubMenu
-        className="menuItemIndent"
         label={
           <Fragment>
             <BorderAll style={menuItemIconStyles}></BorderAll>
@@ -173,9 +168,13 @@ export const FormatMenu = (props: IProps) => {
       </SubMenu>
 
       <MenuDivider />
-      <MenuItem onClick={handleClearFormatting} className="menuItemIndent">
-        <FormatClear style={menuItemIconStyles}></FormatClear>
-        Clear formatting
+      <MenuItem onClick={handleClearFormatting}>
+        <KeyboardShortcut
+          text="Clear formatting"
+          shortcut="\"
+          modifier={KeyboardSymbols.Command}
+          icon={<FormatClear style={menuItemIconStyles} />}
+        />
       </MenuItem>
     </Menu>
   );

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
@@ -56,7 +56,3 @@
     border: 1px solid #eee;
   }
 }
-
-.menuItemIndent {
-  margin-left: 0.75rem;
-}

--- a/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
@@ -20,7 +20,7 @@ export const NumberFormatMenu = () => {
   return (
     <Menu
       menuButton={
-        <Tooltip title="Number format" arrow>
+        <Tooltip title="Number format" arrow disableInteractive enterDelay={500} enterNextDelay={500}>
           <Button style={{ color: colors.darkGray }}>
             <span style={{ fontSize: '1rem' }}>123</span>
             <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -85,7 +85,7 @@ export const QuadraticMenu = (props: Props) => {
     <>
       <Menu
         menuButton={
-          <Tooltip title="Main Menu" arrow>
+          <Tooltip title="Main menu" arrow disableInteractive enterDelay={500} enterNextDelay={500}>
             <Button style={{ color: colors.darkGray }}>
               <img src="favicon.ico" height="22px" alt="Quadratic Icon" />
               <KeyboardArrowDown fontSize="small"></KeyboardArrowDown>


### PR DESCRIPTION
- Add clear all formatting to the command palette (with shortcut)

![CleanShot 2023-02-07 at 15 46 35@2x](https://user-images.githubusercontent.com/1316441/217384591-c26e4598-3ad2-43d4-b4a2-48d5c9bf5056.png)

- Removes stateful nature of bold/italic menus (we can bring this back one day, see #220)
- Removes (currently disabled) text alignment and text wrapping from formatting menu
- Fixes menu alignment/padding

<img width="823" alt="CleanShot 2023-02-07 at 15 48 27@2x" src="https://user-images.githubusercontent.com/1316441/217384537-16af46d8-a062-4355-bc0d-e3301c951a55.png">

- Fix so there's parity in ordering and grouping between format toolbar menu and format context menu

![CleanShot 2023-02-07 at 16 04 33@2x](https://user-images.githubusercontent.com/1316441/217387222-2679f9af-ef34-4017-9606-479683dbe0d6.png)

- Tries to resolve weirdness of top-level tooltips (tooltips could be interacted with, so it would show up even when your cursor went to the menu)
  - Tried to fix this the best I could with the fact that we're trying to make two different UI libraries (`mui` and `react-menu`) work together. It could be better, but I don't think it's worth spending the time on right now.

![Feb-07-2023 13-58-35](https://user-images.githubusercontent.com/1316441/217384930-df37750a-a8d3-44a8-9142-f764c3283f01.gif)