### PR TITLE
feat: color picker style enhancements

### DIFF
--- a/src/ui/components/qColorPicker.tsx
+++ b/src/ui/components/qColorPicker.tsx
@@ -2,7 +2,7 @@ import { ColorChangeHandler, CompactPicker } from 'react-color';
 
 interface IProps {
   onChangeComplete: ColorChangeHandler | undefined;
-  onClear?: any;
+  onClear: () => void;
 }
 
 export const QColorPicker = (props: IProps) => {

--- a/src/ui/components/qColorPicker.tsx
+++ b/src/ui/components/qColorPicker.tsx
@@ -2,62 +2,78 @@ import { ColorChangeHandler, CompactPicker } from 'react-color';
 
 interface IProps {
   onChangeComplete: ColorChangeHandler | undefined;
+  onClear?: any;
 }
 
 export const QColorPicker = (props: IProps) => {
   return (
-    <CompactPicker
-      onChangeComplete={props.onChangeComplete}
-      colors={[
-        '#F9D2CE' /* first row of colors */,
-        '#FFEAC8',
-        '#FFF3C1',
-        '#D8FFE8',
-        '#D5FFF7',
-        '#DAF0FF',
-        '#EBD7F3',
-        '#D9F2FA',
-        '#FFB4AC' /* second row of colors */,
-        '#FFDA9F',
-        '#F2E2A4',
-        '#AAF1C8',
-        '#ADEFE2',
-        '#AFD0E7',
-        '#D1B4DD',
-        '#B4D3DC',
-        '#EE8277' /* third row of colors */,
-        '#F8C97D',
-        '#F5D657',
-        '#86E3AE',
-        '#7BE9D3',
-        '#84BFE7',
-        '#C39BD3',
-        '#A1B9BA',
-        '#E74C3C' /* forth row of colors */,
-        '#F39C12',
-        '#F1C40F',
-        '#2ECC71',
-        '#17C8A5',
-        '#3498DB',
-        '#9B59B6',
-        '#698183',
-        '#963127' /* fifth row of colors */,
-        '#C46B1D',
-        '#B69100',
-        '#1C8347',
-        '#056D6D',
-        '#1F608B',
-        '#6F258E',
-        '#34495E',
-        '#000000' /* sixth row of colors */,
-        '#333333',
-        '#4d4d4d',
-        '#737373',
-        '#cccccc',
-        '#dddddd',
-        '#eeeeee',
-        '#ffffff',
-      ]}
-    />
+    <>
+      <CompactPicker
+        onChangeComplete={props.onChangeComplete}
+        styles={{
+          default: {
+            compact: {
+              // padding: '8px',
+            },
+            clear: {
+              background: 'red',
+            },
+          },
+        }}
+        colors={[
+          '#F9D2CE' /* first row of colors */,
+          '#FFEAC8',
+          '#FFF3C1',
+          '#D8FFE8',
+          '#D5FFF7',
+          '#DAF0FF',
+          '#EBD7F3',
+          '#D9F2FA',
+          '#FFB4AC' /* second row of colors */,
+          '#FFDA9F',
+          '#F2E2A4',
+          '#AAF1C8',
+          '#ADEFE2',
+          '#AFD0E7',
+          '#D1B4DD',
+          '#B4D3DC',
+          '#EE8277' /* third row of colors */,
+          '#F8C97D',
+          '#F5D657',
+          '#86E3AE',
+          '#7BE9D3',
+          '#84BFE7',
+          '#C39BD3',
+          '#A1B9BA',
+          '#E74C3C' /* forth row of colors */,
+          '#F39C12',
+          '#F1C40F',
+          '#2ECC71',
+          '#17C8A5',
+          '#3498DB',
+          '#9B59B6',
+          '#698183',
+          '#963127' /* fifth row of colors */,
+          '#C46B1D',
+          '#B69100',
+          '#1C8347',
+          '#056D6D',
+          '#1F608B',
+          '#6F258E',
+          '#34495E',
+          '#000000' /* sixth row of colors */,
+          '#333333',
+          '#4d4d4d',
+          '#737373',
+          '#cccccc',
+          '#dddddd',
+          '#eeeeee',
+          '#ffffff',
+        ]}
+      />
+      <div className="color-picker-clear">
+        <span onClick={props.onClear}>Clear</span>
+      </div>
+    </>
   );
 };

--- a/src/ui/components/qColorPicker.tsx
+++ b/src/ui/components/qColorPicker.tsx
@@ -10,16 +10,6 @@ export const QColorPicker = (props: IProps) => {
     <>
       <CompactPicker
         onChangeComplete={props.onChangeComplete}
-        styles={{
-          default: {
-            compact: {
-              // padding: '8px',
-            },
-            clear: {
-              background: 'red',
-            },
-          },
-        }}
         colors={[
           '#F9D2CE' /* first row of colors */,
           '#FFEAC8',

--- a/src/ui/components/qColorPicker.tsx
+++ b/src/ui/components/qColorPicker.tsx
@@ -2,7 +2,7 @@ import { ColorChangeHandler, CompactPicker } from 'react-color';
 
 interface IProps {
   onChangeComplete: ColorChangeHandler | undefined;
-  onClear: () => void;
+  onClear?: () => void;
 }
 
 export const QColorPicker = (props: IProps) => {
@@ -61,9 +61,11 @@ export const QColorPicker = (props: IProps) => {
           '#ffffff',
         ]}
       />
-      <div className="color-picker-clear">
-        <span onClick={props.onClear}>Clear</span>
-      </div>
+      {props.onClear && (
+        <div className="color-picker-clear">
+          <span onClick={props.onClear}>Clear</span>
+        </div>
+      )}
     </>
   );
 };

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -39,15 +39,8 @@ export const FloatingContextMenu = (props: Props) => {
 
   const menuDiv = useRef<HTMLDivElement>(null);
   const borders = useGetBorderMenu({ sheet: sheetController.sheet, app: app });
-  const {
-    changeFillColor,
-    removeFillColor,
-    clearFormatting,
-    changeBold,
-    changeItalic,
-    changeTextColor,
-    removeTextColor,
-  } = useFormatCells(sheetController, props.app);
+  const { changeFillColor, removeFillColor, clearFormatting, changeBold, changeItalic, changeTextColor } =
+    useFormatCells(sheetController, props.app);
   const { format } = useGetSelection(sheetController.sheet);
   const { clearBorders } = useBorders(sheetController.sheet, props.app);
 

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { GridInteractionState } from '../../../atoms/gridInteractionStateAtom';
 import { PixiApp } from '../../../core/gridGL/pixiApp/PixiApp';
 import { SheetController } from '../../../core/transaction/sheetController';
-import { Divider, IconButton, MenuItem, Paper, Toolbar } from '@mui/material';
+import { Divider, IconButton, Paper, Toolbar } from '@mui/material';
 import {
   BorderAll,
   ContentCopy,
@@ -251,12 +251,12 @@ export const FloatingContextMenu = (props: Props) => {
           }
         >
           <QColorPicker onChangeComplete={changeTextColor} />
-          <MenuItem onClick={removeTextColor}>Clear</MenuItem>
         </Menu>
 
         <MenuDivider />
 
         <Menu
+          className="color-picker-submenu"
           menuButton={
             <div>
               <TooltipHint title="Fill color">
@@ -267,8 +267,19 @@ export const FloatingContextMenu = (props: Props) => {
             </div>
           }
         >
-          <QColorPicker onChangeComplete={changeFillColor} />
-          <MenuItem onClick={removeFillColor}>Clear</MenuItem>
+          <QColorPicker onChangeComplete={changeFillColor} onClear={removeFillColor} />
+        </Menu>
+        <Menu
+          className="color-picker-submenu"
+          menuButton={
+            <div>
+              <TooltipHint title="Text color">
+                <IconButton>{<FormatColorText fontSize={iconSize}></FormatColorText>}</IconButton>
+              </TooltipHint>
+            </div>
+          }
+        >
+          <QColorPicker onChangeComplete={changeTextColor} onClear={removeTextColor} />
         </Menu>
         <Menu
           menuButton={

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -270,18 +270,6 @@ export const FloatingContextMenu = (props: Props) => {
           <QColorPicker onChangeComplete={changeFillColor} onClear={removeFillColor} />
         </Menu>
         <Menu
-          className="color-picker-submenu"
-          menuButton={
-            <div>
-              <TooltipHint title="Text color">
-                <IconButton>{<FormatColorText fontSize={iconSize}></FormatColorText>}</IconButton>
-              </TooltipHint>
-            </div>
-          }
-        >
-          <QColorPicker onChangeComplete={changeTextColor} onClear={removeTextColor} />
-        </Menu>
-        <Menu
           menuButton={
             <div>
               <TooltipHint title="Borders">

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -250,7 +250,7 @@ export const FloatingContextMenu = (props: Props) => {
             </div>
           }
         >
-          <QColorPicker onChangeComplete={changeTextColor} />
+          <QColorPicker onChangeComplete={changeTextColor} onClear={removeFillColor} />
         </Menu>
 
         <MenuDivider />

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
@@ -94,18 +94,15 @@ export const FormatMenu = (props: IProps) => {
         />
       </MenuItem>
       <SubMenu
+        className="color-picker-submenu"
         id="TextColorMenuID"
-        menuStyles={{
-          padding: '0px',
-        }}
         label={
           <>
             <FormatColorText style={menuItemIconStyles}></FormatColorText> Text color
           </>
         }
       >
-        <QColorPicker onChangeComplete={changeTextColor} />
-        <MenuItem onClick={removeTextColor}>Clear</MenuItem>
+        <QColorPicker onChangeComplete={changeTextColor} onClear={removeTextColor} />
       </SubMenu>
 
       {/* <MenuItem >
@@ -142,18 +139,15 @@ export const FormatMenu = (props: IProps) => {
 
       <MenuDivider />
       <SubMenu
+        className="color-picker-submenu"
         id="FillColorMenuID"
-        menuStyles={{
-          padding: '0px',
-        }}
         label={
           <>
             <FormatColorFill style={menuItemIconStyles}></FormatColorFill> Fill color
           </>
         }
       >
-        <QColorPicker onChangeComplete={changeFillColor} />
-        <MenuItem onClick={removeFillColor}>Clear</MenuItem>
+        <QColorPicker onChangeComplete={changeFillColor} onClear={removeFillColor} />
       </SubMenu>
 
       <SubMenu

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
@@ -1,5 +1,40 @@
-#FillColorMenuID > div > div {
+.color-picker-submenu .szh-menu {
+  padding: 4px;
+}
+.color-picker-submenu .szh-menu > div > div {
   box-shadow: none !important;
+}
+.color-picker-clear {
+  display: flex;
+  margin-bottom: 5px;
+  justify-content: center;
+  font-size: 0.875rem;
+}
+.color-picker-clear span {
+  text-indent: 20px;
+  position: relative;
+  cursor: pointer;
+}
+.color-picker-clear span:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: #fff;
+  border: 1px solid #eee;
+  height: 15px;
+  width: 15px;
+  overflow: hidden;
+}
+.color-picker-clear span:after {
+  content: '';
+  width: 2px;
+  height: calc(100% + 2px);
+  position: absolute;
+  top: 1px;
+  left: 0;
+  background: red;
+  transform: rotate(45deg) translate(4px, -6px);
 }
 
 .lineStyleBorder {
@@ -44,15 +79,27 @@
 
 .compact-picker {
   width: 160px !important;
-  margin-right: 5px;
-  margin-left: 5px;
 
   /* hides custom RBG input on color picker */
   .flexbox-fix {
     display: none !important;
   }
 
-  div span:last-of-type div {
-    border: 1px solid #eee;
+  div span div {
+    position: relative;
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  div span div:before {
+    content: '';
+    box-shadow: inset 0 0 0 1px rgba(0 0 0 / 10%);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+  }
+  div span div[style*='box-shadow'] {
+    box-shadow: 0 0 0 2px black;
   }
 }

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
@@ -1,5 +1,5 @@
 .color-picker-submenu .szh-menu {
-  padding: 4px;
+  padding: 4px !important;
 }
 
 .color-picker-submenu .szh-menu > div > div {

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/formatMenuStyles.scss
@@ -1,40 +1,45 @@
 .color-picker-submenu .szh-menu {
   padding: 4px;
 }
+
 .color-picker-submenu .szh-menu > div > div {
   box-shadow: none !important;
 }
+
 .color-picker-clear {
   display: flex;
   margin-bottom: 5px;
   justify-content: center;
   font-size: 0.875rem;
 }
+
 .color-picker-clear span {
   text-indent: 20px;
   position: relative;
   cursor: pointer;
-}
-.color-picker-clear span:before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  background: #fff;
-  border: 1px solid #eee;
-  height: 15px;
-  width: 15px;
-  overflow: hidden;
-}
-.color-picker-clear span:after {
-  content: '';
-  width: 2px;
-  height: calc(100% + 2px);
-  position: absolute;
-  top: 1px;
-  left: 0;
-  background: red;
-  transform: rotate(45deg) translate(4px, -6px);
+
+  &:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 1px;
+    background: #fff;
+    box-shadow: inset 0 0 0 1px rgba(0 0 0 / 10%);
+    height: 15px;
+    width: 15px;
+    overflow: hidden;
+  }
+  &:after {
+    content: '';
+    width: 2px;
+    height: calc(100% + 2px);
+    position: absolute;
+    top: 1px;
+    left: 0;
+    background: red;
+    transform: rotate(45deg) translate(3px, -6px);
+    border-radius: 2px;
+  }
 }
 
 .lineStyleBorder {
@@ -89,17 +94,15 @@
     position: relative;
     border-radius: 2px;
     overflow: hidden;
-  }
-  div span div:before {
-    content: '';
-    box-shadow: inset 0 0 0 1px rgba(0 0 0 / 10%);
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-  }
-  div span div[style*='box-shadow'] {
-    box-shadow: 0 0 0 2px black;
+
+    &:before {
+      content: '';
+      box-shadow: inset 0 0 0 1px rgba(0 0 0 / 10%);
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      bottom: 0;
+    }
   }
 }

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -198,7 +198,7 @@ export function useGetBorderMenu(props: Props): JSX.Element {
           }}
           label={<BorderColor style={{ ...menuItemIconStyles, color }}></BorderColor>}
         >
-          <QColorPicker onChangeComplete={handleChangeBorderColor} onClear={() => {}} />
+          <QColorPicker onChangeComplete={handleChangeBorderColor} />
         </SubMenu>
         <SubMenu
           id="BorderLineStyleMenuID"

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/useGetBorderMenu.tsx
@@ -191,14 +191,14 @@ export function useGetBorderMenu(props: Props): JSX.Element {
       </div>
       <div className="borderMenuFormatting">
         <SubMenu
-          className="borderSubmenu"
+          className="borderSubmenu color-picker-submenu"
           id="FillBorderColorMenuID"
           menuStyles={{
             padding: '0px',
           }}
           label={<BorderColor style={{ ...menuItemIconStyles, color }}></BorderColor>}
         >
-          <QColorPicker onChangeComplete={handleChangeBorderColor}></QColorPicker>
+          <QColorPicker onChangeComplete={handleChangeBorderColor} onClear={() => {}} />
         </SubMenu>
         <SubMenu
           id="BorderLineStyleMenuID"


### PR DESCRIPTION
- [x] Get rid of box-shadows inside color picker menus
- [x] Refines swatch styles
- [x] Adds a "clear" button that appears more incorporated to the picker
- [x] Works everywhere the color picker works (in both Floating Context menu and TopBar Formatting Menu)
  - Fill color
  - Text color

<img width="1029" alt="CleanShot 2023-02-07 at 17 31 40@2x" src="https://user-images.githubusercontent.com/1316441/217398205-86720dc0-798b-4f40-bbc3-25c8587f8147.png">
