### PR TITLE
feat: cmd + wheel to zoom in/out

### DIFF
--- a/src/core/gridGL/pixiApp/PixiApp.ts
+++ b/src/core/gridGL/pixiApp/PixiApp.ts
@@ -76,7 +76,12 @@ export class PixiApp {
       .drag({ pressDrag: isMobileOnly }) // enable drag on mobile, no where else
       .decelerate()
       .pinch()
-      .wheel({ trackpadPinch: true, wheelZoom: false, percent: 1.5 })
+      .wheel({
+        trackpadPinch: true,
+        wheelZoom: false,
+        percent: 1.5,
+        keyToPress: ['ControlRight', 'ControlLeft', 'MetaLeft', 'MetaRight'],
+      })
       .clampZoom({
         minScale: 0.01,
         maxScale: 10,


### PR DESCRIPTION
Currently, you can zoom in/out of the grid by holding down the control key and using the mouse wheel.

[Our research](https://www.notion.so/Navigation-Infinite-Canvas-Tools-23789227181b419e9a72444308343ccf) across other infinite canvas apps (like Figma) show that control + wheel _or_ command + wheel zooms in/out of the canvas.

This PR makes quadratic support zooming in/out with the mouse wheel and either command or control keys.