### PR TITLE
fix: update floating formatting bar

### DIFF
--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -371,9 +371,7 @@ function MenuDivider() {
       flexItem
       style={{
         // Style these to stand in contrast against with the vertical column lines
-        margin: '10px 6px',
-        borderStyle: 'dotted',
-        borderWidth: '1px',
+        margin: '6px 6px',
       }}
     />
   );

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -192,7 +192,7 @@ export const FloatingContextMenu = (props: Props) => {
     >
       <Toolbar
         style={{
-          padding: '0 6px',
+          padding: '2px 4px',
           minHeight: '0px',
         }}
       >
@@ -252,6 +252,7 @@ export const FloatingContextMenu = (props: Props) => {
           </IconButton>
         </TooltipHint>
         <Menu
+          className="color-picker-submenu"
           menuButton={
             <div>
               <TooltipHint title="Text color">
@@ -369,9 +370,10 @@ function MenuDivider() {
       orientation="vertical"
       flexItem
       style={{
-        // add padding left and right
-        paddingLeft: '4px',
-        marginRight: '4px',
+        // Style these to stand in contrast against with the vertical column lines
+        margin: '10px 6px',
+        borderStyle: 'dotted',
+        borderWidth: '1px',
       }}
     />
   );

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -370,8 +370,7 @@ function MenuDivider() {
       orientation="vertical"
       flexItem
       style={{
-        // Style these to stand in contrast against with the vertical column lines
-        margin: '6px 6px',
+        margin: '6px',
       }}
     />
   );


### PR DESCRIPTION
- Re-style the dividers in the formatting menu to contrast with the vertical column lines (so they don't blend in with each other) by 1) not letting them run to the edges of the widget, and 2) run lines perpendicular to column line
- Fix the 'text color' dropdown to not have box shadows (must've lost this change in a merge somewhere?)

![image](https://user-images.githubusercontent.com/1316441/218186918-31c5e89b-d8ec-4d55-8a9d-039aa6a57b86.png)
