### PR TITLE
feat: file menu reorganization

### DIFF
--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -87,29 +87,26 @@ export const QuadraticMenu = (props: Props) => {
         <MenuHeader>Quadratic</MenuHeader>
         <SubMenu label="File">
           <MenuItem onClick={() => setNewFileOpen(true)}>New grid</MenuItem>
-          <MenuItem onClick={() => SaveGridFile(sheet, true)}>Save grid</MenuItem>
-          <MenuItem onClick={() => openGridFile(sheetController)}>Open grid</MenuItem>
           <MenuDivider />
-          <SubMenu label="Sample files">
+          <MenuItem onClick={() => SaveGridFile(sheet, true)}>Save local copy</MenuItem>
+          <MenuDivider />
+          <MenuItem onClick={() => openGridFile(sheetController)}>Open local</MenuItem>
+          <SubMenu label="Open sample">
             {examples.map((filename) => (
               <MenuItem key={`sample-${filename}`} onClick={() => openExampleGridFile(filename, sheetController)}>
                 {filename}
               </MenuItem>
             ))}
           </SubMenu>
-          {fileList.length ? (
-            <>
-              <MenuDivider />
-              <MenuHeader>Recent Files</MenuHeader>
-            </>
-          ) : null}
-          {fileList.length
-            ? fileList.map((entry) => (
+          {fileList.length && (
+            <SubMenu label="Open recent">
+              {fileList.map((entry) => (
                 <MenuItem key={entry} onClick={() => openLocalGridFile(entry, sheetController)}>
                   {entry}
                 </MenuItem>
-              ))
-            : null}
+              ))}
+            </SubMenu>
+          )}
         </SubMenu>
         <SubMenu label="Import">
           <MenuItem disabled>CSV (coming soon)</MenuItem>


### PR DESCRIPTION
Re-organize the file menu and make it more standard in terms of organization and hierarchy (and match names/labels to what's in the command palette):

![image](https://user-images.githubusercontent.com/1316441/218202779-33de59b8-592e-4ce5-8af4-a43198202e7a.png)
![image](https://user-images.githubusercontent.com/1316441/218202791-7d73bfb7-cf79-4f80-b5d1-f9dc9899e2d3.png)
![image](https://user-images.githubusercontent.com/1316441/218202799-1e51659a-d2de-43df-bd38-9ba4d40262d1.png)
