### PR TITLE
fix double undo bug for clearing all formatting

### DIFF
--- a/src/core/gridGL/interaction/keyboard/useKeyboard.ts
+++ b/src/core/gridGL/interaction/keyboard/useKeyboard.ts
@@ -10,9 +10,9 @@ import { PixiApp } from '../../pixiApp/PixiApp';
 import { keyboardViewport } from './keyboardViewport';
 import { SheetController } from '../../../transaction/sheetController';
 import { keyboardUndoRedo } from './keyboardUndoRedo';
-import { useBorders } from '../../../../ui/menus/TopBar/SubMenus/useBorders';
 import { useFormatCells } from '../../../../ui/menus/TopBar/SubMenus/useFormatCells';
 import { useGetSelection } from '../../../../ui/menus/TopBar/SubMenus/useGetSelection';
+import { useClearAllFormatting } from '../../../../ui/menus/TopBar/SubMenus/useClearAllFormatting';
 
 interface IProps {
   interactionState: GridInteractionState;
@@ -35,12 +35,8 @@ export const useKeyboard = (props: IProps): { onKeyDown: (event: React.KeyboardE
     sheetController,
   } = props;
   const { format } = useGetSelection(sheetController.sheet);
-  const { clearFormatting, changeBold, changeItalic } = useFormatCells(sheetController, app);
-  const { clearBorders } = useBorders(sheetController.sheet, app);
-  const clearAllFormatting = useCallback(() => {
-    clearFormatting();
-    clearBorders();
-  }, [clearBorders, clearFormatting]);
+  const { changeBold, changeItalic } = useFormatCells(sheetController, app);
+  const { clearAllFormatting } = useClearAllFormatting(sheetController, app);
 
   const keyDownWindow = useCallback(
     (event: KeyboardEvent): void => {

--- a/src/ui/menus/CommandPalette/ListItems/Format.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Format.tsx
@@ -2,22 +2,20 @@ import { useFormatCells } from '../../TopBar/SubMenus/useFormatCells';
 import { CommandPaletteListItem } from '../CommandPaletteListItem';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
 import { AbcOutlined, AttachMoney, FormatClear, Functions, Percent } from '@mui/icons-material';
-import { useBorders } from '../../TopBar/SubMenus/useBorders';
 import { DecimalDecrease, DecimalIncrease, Icon123 } from '../../../icons';
+import { useClearAllFormatting } from '../../TopBar/SubMenus/useClearAllFormatting';
 
 const ListItems = [
   {
     label: 'Format: Clear all',
     Component: (props: any) => {
-      const { clearFormatting } = useFormatCells(props.sheetController, props.app);
-      const { clearBorders } = useBorders(props.sheetController.sheet, props.app);
+      const { clearAllFormatting } = useClearAllFormatting(props.sheetController, props.app);
       return (
         <CommandPaletteListItem
           {...props}
           icon={<FormatClear />}
           action={() => {
-            clearFormatting();
-            clearBorders();
+            clearAllFormatting();
           }}
           shortcut="\"
           shortcutModifiers={KeyboardSymbols.Command}

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -19,13 +19,13 @@ import {
 import { Menu } from '@szhsin/react-menu';
 import { useGetBorderMenu } from '../TopBar/SubMenus/FormatMenu/useGetBorderMenu';
 import { useFormatCells } from '../TopBar/SubMenus/useFormatCells';
-import { useBorders } from '../TopBar/SubMenus/useBorders';
 import { QColorPicker } from '../../components/qColorPicker';
 import { KeyboardSymbols } from '../../../helpers/keyboardSymbols';
 import { useGetSelection } from '../TopBar/SubMenus/useGetSelection';
 import { copyToClipboard, cutToClipboard, pasteFromClipboard } from '../../../core/actions/clipboard';
 import { TooltipHint } from '../../components/TooltipHint';
 import { DecimalDecrease, DecimalIncrease } from '../../icons';
+import { useClearAllFormatting } from '../TopBar/SubMenus/useClearAllFormatting';
 
 interface Props {
   interactionState: GridInteractionState;
@@ -45,7 +45,6 @@ export const FloatingContextMenu = (props: Props) => {
   const {
     changeFillColor,
     removeFillColor,
-    clearFormatting,
     changeBold,
     changeItalic,
     changeTextColor,
@@ -55,12 +54,7 @@ export const FloatingContextMenu = (props: Props) => {
     textFormatSetPercentage,
   } = useFormatCells(sheetController, props.app);
   const { format } = useGetSelection(sheetController.sheet);
-  const { clearBorders } = useBorders(sheetController.sheet, props.app);
-
-  const handleClearFormatting = useCallback(() => {
-    clearFormatting();
-    clearBorders();
-  }, [clearFormatting, clearBorders]);
+  const { clearAllFormatting } = useClearAllFormatting(sheetController, props.app);
 
   // Function used to move and scale the Input with the Grid
   const updateInputCSSTransform = useCallback(() => {
@@ -322,7 +316,7 @@ export const FloatingContextMenu = (props: Props) => {
 
         <MenuDivider />
         <TooltipHint title="Clear formatting" shortcut={KeyboardSymbols.Command + '\\'}>
-          <IconButton onClick={handleClearFormatting}>
+          <IconButton onClick={() => clearAllFormatting()}>
             <FormatClear fontSize={iconSize} />
           </IconButton>
         </TooltipHint>

--- a/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/FormatMenu/FormatMenu.tsx
@@ -21,7 +21,6 @@ import { Tooltip } from '@mui/material';
 import { QColorPicker } from '../../../../components/qColorPicker';
 import { useFormatCells } from '../useFormatCells';
 import { useGetBorderMenu } from './useGetBorderMenu';
-import { useBorders } from '../useBorders';
 import './formatMenuStyles.scss';
 
 import { PixiApp } from '../../../../../core/gridGL/pixiApp/PixiApp';
@@ -29,6 +28,7 @@ import { SheetController } from '../../../../../core/transaction/sheetController
 import { useGetSelection } from '../useGetSelection';
 import { MenuLineItem } from '../../MenuLineItem';
 import { KeyboardSymbols } from '../../../../../helpers/keyboardSymbols';
+import { useClearAllFormatting } from '../useClearAllFormatting';
 
 interface IProps {
   app: PixiApp;
@@ -37,16 +37,8 @@ interface IProps {
 
 export const FormatMenu = (props: IProps) => {
   const { format } = useGetSelection(props.sheet_controller.sheet);
-  const {
-    changeFillColor,
-    removeFillColor,
-    clearFormatting,
-    changeBold,
-    changeItalic,
-    changeTextColor,
-    removeTextColor,
-  } = useFormatCells(props.sheet_controller, props.app);
-  const { clearBorders } = useBorders(props.sheet_controller.sheet, props.app);
+  const { changeFillColor, removeFillColor, changeBold, changeItalic, changeTextColor, removeTextColor } =
+    useFormatCells(props.sheet_controller, props.app);
 
   // focus canvas after the format menu closes
   const onMenuChange = useCallback(
@@ -58,10 +50,7 @@ export const FormatMenu = (props: IProps) => {
 
   const borders = useGetBorderMenu({ sheet: props.sheet_controller.sheet, app: props.app });
 
-  const handleClearFormatting = useCallback(() => {
-    clearFormatting();
-    clearBorders();
-  }, [clearFormatting, clearBorders]);
+  const { clearAllFormatting } = useClearAllFormatting(props.sheet_controller, props.app);
 
   return (
     <Menu
@@ -133,7 +122,11 @@ export const FormatMenu = (props: IProps) => {
       <SubMenu label={<MenuLineItem primary="Border" Icon={BorderAll} />}>{borders}</SubMenu>
 
       <MenuDivider />
-      <MenuItem onClick={handleClearFormatting}>
+      <MenuItem
+        onClick={() => {
+          clearAllFormatting();
+        }}
+      >
         <MenuLineItem primary="Clear formatting" secondary={KeyboardSymbols.Command + '\\'} Icon={FormatClear} />
       </MenuItem>
     </Menu>

--- a/src/ui/menus/TopBar/SubMenus/useBorders.ts
+++ b/src/ui/menus/TopBar/SubMenus/useBorders.ts
@@ -19,7 +19,7 @@ export interface ChangeBorder {
 
 interface IResults {
   changeBorders: (options: ChangeBorder) => void;
-  clearBorders: () => void;
+  clearBorders: (args?: { create_transaction?: boolean }) => void;
 }
 
 export const useBorders = (sheet: Sheet, app: PixiApp): IResults => {
@@ -130,7 +130,7 @@ export const useBorders = (sheet: Sheet, app: PixiApp): IResults => {
     }
   };
 
-  const clearBorders = (): void => {
+  const clearBorders = (args?: { create_transaction?: boolean }): void => {
     const borderUpdate: Border[] = [];
     const borderDelete: Coordinate[] = [];
     for (let y = start.y; y <= end.y; y++) {
@@ -163,7 +163,7 @@ export const useBorders = (sheet: Sheet, app: PixiApp): IResults => {
     }
 
     // create transaction to update borders
-    sheet_controller.start_transaction();
+    args?.create_transaction ?? sheet_controller.start_transaction();
     if (borderDelete.length) {
       borderDelete.forEach((border_coord) => {
         sheet_controller.execute_statement({
@@ -186,7 +186,7 @@ export const useBorders = (sheet: Sheet, app: PixiApp): IResults => {
         });
       });
     }
-    sheet_controller.end_transaction();
+    args?.create_transaction ?? sheet_controller.end_transaction();
 
     app.cells.dirty = true;
     app.quadrants.quadrantChanged({ range: { start, end } });

--- a/src/ui/menus/TopBar/SubMenus/useClearAllFormatting.ts
+++ b/src/ui/menus/TopBar/SubMenus/useClearAllFormatting.ts
@@ -1,0 +1,24 @@
+import { PixiApp } from '../../../../core/gridGL/pixiApp/PixiApp';
+import { SheetController } from '../../../../core/transaction/sheetController';
+import { useBorders } from './useBorders';
+import { useFormatCells } from './useFormatCells';
+
+interface IResults {
+  clearAllFormatting: () => void;
+}
+
+export const useClearAllFormatting = (sheet_controller: SheetController, app: PixiApp): IResults => {
+  const { clearFormatting } = useFormatCells(sheet_controller, app);
+  const { clearBorders } = useBorders(sheet_controller.sheet, app);
+
+  const clearAllFormatting = () => {
+    sheet_controller.start_transaction();
+    clearFormatting({ create_transaction: false });
+    clearBorders({ create_transaction: false });
+    sheet_controller.end_transaction();
+  };
+
+  return {
+    clearAllFormatting,
+  };
+};

--- a/src/ui/menus/TopBar/SubMenus/useFormatCells.ts
+++ b/src/ui/menus/TopBar/SubMenus/useFormatCells.ts
@@ -12,7 +12,7 @@ export const FORMAT_SELECTION_EVENT = 'formatSelectionEvent';
 interface IResults {
   changeFillColor: (rgb: ColorResult) => void;
   removeFillColor: () => void;
-  clearFormatting: () => void;
+  clearFormatting: (args?: { create_transaction?: boolean }) => void;
   changeBold: (bold: boolean) => void;
   changeItalic: (italic: boolean) => void;
   changeTextColor: (rgb: ColorResult) => void;
@@ -91,7 +91,7 @@ export const useFormatCells = (sheet_controller: SheetController, app: PixiApp):
     onFormat({ fillColor: undefined });
   };
 
-  const clearFormatting = (): void => {
+  const clearFormatting = (args?: { create_transaction?: boolean }): void => {
     const formats: CellFormat[] = [];
     for (let y = start.y; y <= end.y; y++) {
       for (let x = start.x; x <= end.x; x++) {
@@ -100,7 +100,7 @@ export const useFormatCells = (sheet_controller: SheetController, app: PixiApp):
       }
     }
     // transaction to clear cell formats
-    sheet_controller.start_transaction();
+    args?.create_transaction ?? sheet_controller.start_transaction();
     formats.forEach((format) => {
       if (format.x !== undefined && format.y !== undefined)
         sheet_controller.execute_statement({
@@ -111,7 +111,7 @@ export const useFormatCells = (sheet_controller: SheetController, app: PixiApp):
           },
         });
     });
-    sheet_controller.end_transaction();
+    args?.create_transaction ?? sheet_controller.end_transaction();
 
     app?.quadrants.quadrantChanged({ range: { start, end } });
     localFiles.saveLastLocal(sheet_controller.sheet.export_file());


### PR DESCRIPTION
Bug:
1. Add some borders and formatting
2. Clear formatting
3. Press Undo

Previously it would be two Undos to get back, one for borders one for formatting. now it is one.