### PR TITLE
refactor: tweak top bar icon and style

### DIFF
--- a/src/ui/menus/TopBar/TopBar.tsx
+++ b/src/ui/menus/TopBar/TopBar.tsx
@@ -15,7 +15,7 @@ import { useLocalFiles } from '../../../hooks/useLocalFiles';
 import { SheetController } from '../../../grid/controller/sheetController';
 import { KeyboardSymbols } from '../../../helpers/keyboardSymbols';
 import { TooltipHint } from '../../components/TooltipHint';
-import { Search } from '@mui/icons-material';
+import { ManageSearch, Search } from '@mui/icons-material';
 import { focusGrid } from '../../../helpers/focusGrid';
 import { useGridSettings } from './SubMenus/useGridSettings';
 
@@ -130,7 +130,6 @@ export const TopBar = (props: IProps) => {
             )} */}
             <TooltipHint title="Show cell type outlines">
               <Switch
-                color="secondary"
                 checked={settings.showCellTypeOutlines}
                 onChange={() => {
                   settings.setShowCellTypeOutlines(!settings.showCellTypeOutlines);
@@ -139,7 +138,7 @@ export const TopBar = (props: IProps) => {
                 size="small"
               />
             </TooltipHint>
-            <TooltipHint title="Command Palette" shortcut={KeyboardSymbols.Command + 'P'}>
+            <TooltipHint title="Quick actions" shortcut={KeyboardSymbols.Command + 'P'}>
               <IconButton
                 onClick={() => {
                   setEditorInteractionState({
@@ -149,7 +148,7 @@ export const TopBar = (props: IProps) => {
                   focusGrid();
                 }}
               >
-                <Search />
+                <ManageSearch />
               </IconButton>
             </TooltipHint>
             {/* <Tooltip title="Coming soon" arrow>

--- a/src/ui/menus/TopBar/TopBar.tsx
+++ b/src/ui/menus/TopBar/TopBar.tsx
@@ -138,7 +138,7 @@ export const TopBar = (props: IProps) => {
                 size="small"
               />
             </TooltipHint>
-            <TooltipHint title="Quick actions" shortcut={KeyboardSymbols.Command + 'P'}>
+            <TooltipHint title="Command palette" shortcut={KeyboardSymbols.Command + 'P'}>
               <IconButton
                 onClick={() => {
                   setEditorInteractionState({


### PR DESCRIPTION
<img width="215" alt="CleanShot 2023-02-14 at 10 00 59@2x" src="https://user-images.githubusercontent.com/1316441/218807951-6e74ec5e-3762-4a85-84e8-f3033608719d.png">

- Change the "Command palette" icon from a pure search icon to an list/search icon (feels like this more closely matches the essence of the command bar’s functionality, e.g. 'search a list of actions')
- Change the 'show cell type outline' toggle to use primary color (we don't use the secondary color anywhere that i'm aware of, feels more cohesive with the rest of the app's accent color to use primary IMO)
- Change name from "Command palette" to "Quick actions"

---

Rationale:

Figma calls their feature ["Quick actions"](https://help.figma.com/hc/en-us/articles/360040328653-Use-shortcuts-and-quick-actions)

<img width="229" alt="CleanShot 2023-02-14 at 10 09 55@2x" src="https://user-images.githubusercontent.com/1316441/218808215-eea2d951-fe8c-400b-ad69-1be099c6c87c.png">


VSCode calls it the "Command palette"

<img width="228" alt="CleanShot 2023-02-14 at 10 02 03@2x" src="https://user-images.githubusercontent.com/1316441/218808291-d9808462-4650-4894-8ddc-ab372134e9d3.png">

Google Sheets calls their (equivalent) "Search the menus"

<img width="345" alt="CleanShot 2023-02-14 at 10 03 40@2x" src="https://user-images.githubusercontent.com/1316441/218808400-9fc61b92-1fd6-484e-9815-32a6dc6aff00.png">

Personally I like "Quick actions" as it feels less developer-y. If you're not familiar with VSCode, you probably have no idea what "Command palette" means or what the feature does, whereas if you saw "Quick actions" you could probably guess at what it is and does. For that reason, I like "Quick actions".
