### PR TITLE
feat: jump to active cell of editor

### DIFF
--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -54,7 +54,7 @@ export default function QuadraticUI(props: Props) {
         }}
       >
         <QuadraticGrid sheetController={sheetController} app={app} />
-        <CodeEditor editorInteractionState={editorInteractionState} sheet_controller={sheetController} />
+        <CodeEditor app={app} editorInteractionState={editorInteractionState} sheet_controller={sheetController} />
       </div>
 
       <BottomBar sheet={sheetController.sheet} />


### PR DESCRIPTION
Problem: I find myself editing code for a cell and if the grid moves or pans around, it's easy to get lost and not remember which cell is being edited. The code editor has a reference to the cell you're editing, but there's no way to quickly visualize it without seeing the reference, then trying to find it via the x/y axis headers.

Solution: this plays with the idea of the cell reference in the editor being a clickable "jump to" command that moves the cursor in the grid to the selected element and centers it.

![Feb-15-2023 14-25-36](https://user-images.githubusercontent.com/1316441/219172482-ac0a9073-64dc-4ab7-87f9-ad6d6913619d.gif)

Hurdles:

- Some kind of animation would help here based on the current state, e.g. if the editor cursor is the same as the grid cursor, that should be a different kind of animation than if they're different
- The grid's active cursor changing from light blue to the color of the cell is a little disorienting and makes it hard to find what the active cell of the editor is
- `moveViewport` doesn't account for whether the editor is open and therefore "centered" on screen won't Editor fly out 

![CleanShot 2023-02-15 at 14 27 48@2x](https://user-images.githubusercontent.com/1316441/219172529-c88abe81-dcf9-4cb6-96d1-6b992b21c623.png)

