### PR TITLE
ensures grid lines are cleared

### DIFF
--- a/src/gridGL/UI/GridLines.ts
+++ b/src/gridGL/UI/GridLines.ts
@@ -15,6 +15,8 @@ export class GridLines extends Graphics {
   update() {
     if (this.dirty) {
       this.dirty = false;
+      this.clear();
+
       if (!this.app.settings.showGridLines) {
         this.visible = false;
         this.app.setViewportDirty();
@@ -30,7 +32,6 @@ export class GridLines extends Graphics {
 
       this.alpha = gridAlpha;
       this.visible = true;
-      this.clear();
 
       this.lineStyle(1, colors.gridLines, 0.25, 0.5, true);
       const bounds = this.app.viewport.getVisibleBounds();


### PR DESCRIPTION
Fixes #285. I'm still not sure who sets gridLines.visible = true, but this patch ensures that even if they are visible, the grid line drawing is cleared.