### PR TITLE
feat: make presentation mode go full screen

### DIFF
--- a/src/gridGL/pixiApp/PixiApp.ts
+++ b/src/gridGL/pixiApp/PixiApp.ts
@@ -169,7 +169,7 @@ export class PixiApp {
     this.destroyed = true;
   }
 
-  private resize = (): void => {
+  resize(): void {
     if (!this.parent || this.destroyed) return;
     const width = this.parent.offsetWidth;
     const height = this.parent.offsetHeight;
@@ -182,7 +182,7 @@ export class PixiApp {
     this.headings.dirty = true;
     this.cursor.dirty = true;
     this.cells.dirty = true;
-  };
+  }
 
   setZoomState(value: number): void {
     zoomInOut(this.viewport, value);

--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -32,7 +32,10 @@ export default function QuadraticUI(props: Props) {
     sheetController.setApp(app);
   }, [sheetController, app]);
 
-  const showChrome = !presentationMode;
+  // Resize the canvas when user goes in/out of presentation mode
+  useEffect(() => {
+    app.resize();
+  }, [presentationMode, app]);
 
   return (
     <div
@@ -45,7 +48,7 @@ export default function QuadraticUI(props: Props) {
     >
       {editorInteractionState.showCellTypeMenu && <CellTypeMenu></CellTypeMenu>}
       {showDebugMenu && <DebugMenu sheet={sheetController.sheet} />}
-      {showChrome && <TopBar app={app} sheetController={sheetController} />}
+      {!presentationMode && <TopBar app={app} sheetController={sheetController} />}
       {editorInteractionState.showCommandPalette && <CommandPalette app={app} sheetController={sheetController} />}
       {editorInteractionState.showGoToMenu && <GoTo app={app} sheetController={sheetController} />}
 
@@ -62,8 +65,8 @@ export default function QuadraticUI(props: Props) {
         <CodeEditor editorInteractionState={editorInteractionState} sheet_controller={sheetController} />
       </div>
 
-      {showChrome && <BottomBar sheet={sheetController.sheet} />}
-      {!showChrome && <PresentationModeHint />}
+      {!presentationMode && <BottomBar sheet={sheetController.sheet} />}
+      {presentationMode && <PresentationModeHint />}
     </div>
   );
 }

--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -12,6 +12,8 @@ import { useEffect, useState } from 'react';
 import { PixiApp } from '../gridGL/pixiApp/PixiApp';
 import { SheetController } from '../grid/controller/sheetController';
 import CellTypeMenu from './menus/CellTypeMenu';
+import { useGridSettings } from './menus/TopBar/SubMenus/useGridSettings';
+import PresentationModeHint from './components/PresentationModeHint';
 
 interface Props {
   sheetController: SheetController;
@@ -20,6 +22,7 @@ interface Props {
 export default function QuadraticUI(props: Props) {
   const [showDebugMenu] = useLocalStorage('showDebugMenu', false);
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
+  const { presentationMode } = useGridSettings();
 
   const [app] = useState(() => new PixiApp(props.sheetController));
 
@@ -28,6 +31,8 @@ export default function QuadraticUI(props: Props) {
   useEffect(() => {
     sheetController.setApp(app);
   }, [sheetController, app]);
+
+  const showChrome = !presentationMode;
 
   return (
     <div
@@ -40,7 +45,7 @@ export default function QuadraticUI(props: Props) {
     >
       {editorInteractionState.showCellTypeMenu && <CellTypeMenu></CellTypeMenu>}
       {showDebugMenu && <DebugMenu sheet={sheetController.sheet} />}
-      <TopBar app={app} sheetController={sheetController} />
+      {showChrome && <TopBar app={app} sheetController={sheetController} />}
       {editorInteractionState.showCommandPalette && <CommandPalette app={app} sheetController={sheetController} />}
       {editorInteractionState.showGoToMenu && <GoTo app={app} sheetController={sheetController} />}
 
@@ -57,7 +62,8 @@ export default function QuadraticUI(props: Props) {
         <CodeEditor editorInteractionState={editorInteractionState} sheet_controller={sheetController} />
       </div>
 
-      <BottomBar sheet={sheetController.sheet} />
+      {showChrome && <BottomBar sheet={sheetController.sheet} />}
+      {!showChrome && <PresentationModeHint />}
     </div>
   );
 }

--- a/src/ui/components/PresentationModeHint.tsx
+++ b/src/ui/components/PresentationModeHint.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import { Snackbar } from '@mui/material';
+import { useGridSettings } from '../menus/TopBar/SubMenus/useGridSettings';
+import { KeyboardSymbols } from '../../helpers/keyboardSymbols';
+
+export default function PresentationModeHint() {
+  const { presentationMode } = useGridSettings();
+  const [open, setOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (presentationMode) {
+      setOpen(true);
+    }
+  }, [presentationMode]);
+
+  return (
+    <Snackbar
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      open={open}
+      onClose={() => {
+        setOpen(false);
+      }}
+      autoHideDuration={5000}
+      message={`Press “${KeyboardSymbols.Command}.” to exit presentation mode.`}
+    />
+  );
+}


### PR DESCRIPTION
Make the presentation mode go full screen by hiding header/footer and provide a little UI hint on how to get out of that mode that disappears after ~3 seconds

![Feb-27-2023 14-45-58](https://user-images.githubusercontent.com/1316441/221693310-c1909602-1ae4-4279-9d66-973cebb435e2.gif)

The code editor would stay open if it's already open

![Feb-27-2023 14-46-57](https://user-images.githubusercontent.com/1316441/221693367-66b7a877-9811-4c99-9e36-bb24ef1934af.gif)

---

Figma does this nicely when you're in a prototype and you show/hide the figma UI, it tells you how to exit and hides the message after `n ` seconds

<img width="1238" alt="CleanShot 2023-02-27 at 14 35 45@2x" src="https://user-images.githubusercontent.com/1316441/221693528-e30f96e5-8bbd-4ab3-be16-524241c76f65.png">
