### PR TITLE
fix: bind `this` to the correct context

### DIFF
--- a/src/gridGL/pixiApp/PixiApp.ts
+++ b/src/gridGL/pixiApp/PixiApp.ts
@@ -175,7 +175,7 @@ export class PixiApp {
     this.destroyed = true;
   }
 
-  resize(): void {
+  resize = (): void => {
     if (!this.parent || this.destroyed) return;
     const width = this.parent.offsetWidth;
     const height = this.parent.offsetHeight;
@@ -188,7 +188,7 @@ export class PixiApp {
     this.headings.dirty = true;
     this.cursor.dirty = true;
     this.cells.dirty = true;
-  }
+  };
 
   setZoomState(value: number): void {
     zoomInOut(this.viewport, value);


### PR DESCRIPTION
I broke grid resizing [here](https://github.com/quadratichq/quadratic/pull/326/commits/44b1dccf2bd1944e35b974c71aa9666f58557389#diff-07dfae82d5a245c6f7a92c5b147bca8506b4cc9938ffcd2c5e634ae8c73cd4aeL172) so right now when you resize the browser, the grid doesn't redraw (it stretches like a bitmap image).

But this fixes it by making sure `this` is bound to the pixi app (not the window)