### PR TITLE
Add array literals in formulas

### DIFF
--- a/quadratic-core/Cargo.lock
+++ b/quadratic-core/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quadratic-core"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Farkas <andrew.farkas@quadratic.to>"]
 edition = "2021"
 description = "Infinite data grid with Python, JavaScript, and SQL built-in"

--- a/quadratic-core/src/formulas/errors.rs
+++ b/quadratic-core/src/formulas/errors.rs
@@ -51,6 +51,7 @@ pub enum FormulaErrorMsg {
         expected: (usize, usize),
         got: (usize, usize),
     },
+    NonRectangularArray,
     BadArgumentCount,
     BadFunctionName,
     BadCellReference,
@@ -85,6 +86,9 @@ impl fmt::Display for FormulaErrorMsg {
             },
             Self::ArraySizeMismatch { expected, got } => {
                 write!(f, "Array size mismatch: expected {expected:?}, got {got:?}")
+            }
+            Self::NonRectangularArray => {
+                write!(f, "Array must be rectangular")
             }
             Self::BadArgumentCount => {
                 // TODO: give a nicer error message that says what the arguments

--- a/quadratic-core/src/formulas/lexer.rs
+++ b/quadratic-core/src/formulas/lexer.rs
@@ -130,8 +130,10 @@ pub enum Token {
     RBrace,
 
     // Separators
-    #[strum(to_string = "argument separator")]
+    #[strum(to_string = "argument separator (comma)")]
     ArgSep,
+    #[strum(to_string = "array row seperator (semicolon)")]
+    RowSep,
 
     // Comparison operators
     #[strum(to_string = "equals comparison")]
@@ -211,6 +213,7 @@ impl Token {
                 "]" => Self::RBracket,
                 "}" => Self::RBrace,
                 "," => Self::ArgSep,
+                ";" => Self::RowSep,
                 "=" | "==" => Self::Eql,
                 "<>" | "!=" => Self::Neq,
                 "<" => Self::Lt,

--- a/quadratic-core/src/formulas/value.rs
+++ b/quadratic-core/src/formulas/value.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use smallvec::{smallvec, SmallVec};
 use std::fmt;
 
@@ -26,7 +27,13 @@ impl fmt::Display for Value {
             Value::Number(n) => write!(f, "{n}"),
             Value::Bool(true) => write!(f, "TRUE"),
             Value::Bool(false) => write!(f, "FALSE"),
-            Value::Array(_) => write!(f, "[array]"),
+            Value::Array(rows) => {
+                write!(
+                    f,
+                    "{{{}}}",
+                    rows.iter().map(|row| row.iter().join(", ")).join("; "),
+                )
+            }
             Value::MissingErr => write!(f, "[missing]"),
         }
     }

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,5 +1,5 @@
 export const API_URL = 'http://localhost:8000';
 export const DOCUMENTATION_URL = 'https://docs.quadratichq.com';
 export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/reference/python-cell-reference`;
-export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}`; // TODO
+export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}/formulas`;
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';


### PR DESCRIPTION
Uses same syntax as Excel: e.g., `{1, 2, 3; 4, 5, 6}`

Empty arrays and nonrectangular arrays are not allowed

Also added link to new [formula docs](https://docs.quadratichq.com/formulas)