### PR TITLE
fix: links to docs

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,5 +1,5 @@
 export const API_URL = 'http://localhost:8000';
 export const DOCUMENTATION_URL = 'https://docs.quadratichq.com';
-export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/reference/python-cell-reference`;
+export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/python`;
 export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}/formulas`;
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -67,11 +67,8 @@ export function Console({ evalResult, editorMode }: ConsoleProps) {
             <>
               <p>Quadratic allows you to leverage the power of Python to fetch, script, and compute cell data.</p>
               <p>
-                <LinkNewTab href="https://pandas.pydata.org/">Pandas</LinkNewTab>,{' '}
-                <LinkNewTab href="https://numpy.org/">NumPy</LinkNewTab>, and{' '}
-                <LinkNewTab href="https://scipy.org/">SciPy</LinkNewTab> libraries are included by default.{' '}
-                <LinkNewTab href="https://github.com/pyodide/micropip">Micropip</LinkNewTab> is also available for
-                installing any third-party libraries you need.
+                Pandas, NumPy, and SciPy are included by default. Micropip is also available for installing any
+                third-party libraries you need.
               </p>
               <p>
                 <LinkNewTab href={DOCUMENTATION_PYTHON_URL}>Check out the docs</LinkNewTab> to learn more about using


### PR DESCRIPTION
Per [David's feedback in Slack](https://quadratichq.slack.com/archives/C03KXQTH5TP/p1678474296090159) update it so we only link to the Quadratic docs (which can then link to the individual libraries). Also fix the docs link.

<img width="539" alt="CleanShot 2023-03-10 at 15 05 53@2x" src="https://user-images.githubusercontent.com/1316441/224437106-e29b1e67-7346-47cc-a190-906c0a8cd414.png">

Also: added an extra part in our current docs about these packages.

<img width="669" alt="CleanShot 2023-03-10 at 15 00 48@2x" src="https://user-images.githubusercontent.com/1316441/224436533-9c25ae20-c8c9-440a-93b5-c8f61bdd2fd3.png">
