### PR TITLE
Fix an issue with subquadrant using texture size <= 0

### DIFF
--- a/src/gridGL/quadrants/Quadrant.ts
+++ b/src/gridGL/quadrants/Quadrant.ts
@@ -159,6 +159,10 @@ export class Quadrant extends Container {
 
           const textureWidth = (reducedDrawingRectangle.width - trimLeft - trimRight) * QUADRANT_SCALE;
           const textureHeight = (reducedDrawingRectangle.height - trimTop - trimBottom) * QUADRANT_SCALE;
+
+          // skip quadrants that have no size
+          if (textureWidth <= 0 || textureHeight <= 0) continue;
+
           const subQuadrant = this.getSubQuadrant(subQuadrantX, subQuadrantY, textureWidth, textureHeight);
 
           this.overflowLeft = !!trimLeft;


### PR DESCRIPTION
Fixes #331 

A more robust fix for this bug is found in #308, where it properly rebuilds the quadrants on a file load. This PR will fix the current bug to avoid the black bars.