### PR TITLE
fix: tweak async run indicator on code editor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { BrowserTracing } from '@sentry/tracing';
 import { Auth0Provider } from '@auth0/auth0-react';
 
 // Enable sentry only if SENTRY_DSN is in ENV
-if (process.env.REACT_APP_SENTRY_DSN)
+if (process.env.REACT_APP_SENTRY_DSN && process.env.REACT_APP_SENTRY_DSN !== 'none')
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     integrations: [new BrowserTracing()],

--- a/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -317,6 +317,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
           </span>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
+          {isRunningComputation && <CircularProgress size="1.125rem" sx={{ m: '0 .5rem' }} />}
           <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`}>
             <IconButton
               id="QuadraticCodeEditorRunButtonID"
@@ -325,7 +326,7 @@ export const CodeEditor = (props: CodeEditorProps) => {
               onClick={saveAndRunCell}
               disabled={isRunningComputation}
             >
-              {isRunningComputation ? <CircularProgress size="1rem" /> : <PlayArrow />}
+              <PlayArrow />
             </IconButton>
           </TooltipHint>
           <TooltipHint title="Close" shortcut="ESC">

--- a/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -319,15 +319,17 @@ export const CodeEditor = (props: CodeEditorProps) => {
         <div style={{ display: 'flex', alignItems: 'center', gap: '.5rem' }}>
           {isRunningComputation && <CircularProgress size="1.125rem" sx={{ m: '0 .5rem' }} />}
           <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`}>
-            <IconButton
-              id="QuadraticCodeEditorRunButtonID"
-              size="small"
-              color="primary"
-              onClick={saveAndRunCell}
-              disabled={isRunningComputation}
-            >
-              <PlayArrow />
-            </IconButton>
+            <span>
+              <IconButton
+                id="QuadraticCodeEditorRunButtonID"
+                size="small"
+                color="primary"
+                onClick={saveAndRunCell}
+                disabled={isRunningComputation}
+              >
+                <PlayArrow />
+              </IconButton>
+            </span>
           </TooltipHint>
           <TooltipHint title="Close" shortcut="ESC">
             <IconButton


### PR DESCRIPTION
Remove the layout shift when you hit the "Save & run" button by just disabling the icon and putting the async loading indicator next to it (with a little extra padding)

Before:

![Mar-28-2023 20-56-50](https://user-images.githubusercontent.com/1316441/228414987-f94135aa-3258-4b2b-9b5d-fc8327e50d26.gif)

After:

![Mar-28-2023 20-53-18](https://user-images.githubusercontent.com/1316441/228414718-55777530-c36b-468d-bb1b-257c0583e717.gif)

Subtle — but small things add up!