### PR TITLE
fix: border type enums as strings

### DIFF
--- a/src/storage/GridFile.test.ts
+++ b/src/storage/GridFile.test.ts
@@ -37,6 +37,28 @@ describe('validateFile()', () => {
         cell_dependency: undefined,
       })
     ).not.toBe(null);
+
+    const result = validateFile({
+      ...v1File,
+      borders: [
+        { x: 0, y: 0, horizontal: { type: 0 }, vertical: { type: 0 } },
+        { x: 1, y: 1, horizontal: { type: 1 } },
+        { x: 2, y: 2, horizontal: { type: 2 } },
+        { x: 3, y: 3, horizontal: { type: 3 } },
+        { x: 4, y: 4, horizontal: { type: 4 } },
+        { x: 5, y: 5, horizontal: { type: 5 } },
+        { x: 6, y: 6, horizontal: {} },
+      ],
+    });
+
+    expect(result).toHaveProperty('borders[0].horizontal.type', 'line1');
+    expect(result).toHaveProperty('borders[0].vertical.type', 'line1');
+    expect(result).toHaveProperty('borders[1].horizontal.type', 'line2');
+    expect(result).toHaveProperty('borders[2].horizontal.type', 'line3');
+    expect(result).toHaveProperty('borders[3].horizontal.type', 'dotted');
+    expect(result).toHaveProperty('borders[4].horizontal.type', 'dashed');
+    expect(result).toHaveProperty('borders[5].horizontal.type', 'double');
+    expect(result).toHaveProperty('borders[6].horizontal', {});
   });
 
   test('Upgrades a valid file from v1 to v1.1', () => {

--- a/src/storage/GridFile.ts
+++ b/src/storage/GridFile.ts
@@ -1,5 +1,5 @@
 import { Dependency } from '../grid/sheet/GridRenderDependency';
-import { BorderSchema, CellSchema, CellFormatSchema, BorderTypeEnum } from '../grid/sheet/gridTypes';
+import { BorderSchema, CellSchema, CellFormatSchema } from '../grid/sheet/gridTypes';
 import { v4 as uuid } from 'uuid';
 import z from 'zod';
 import { debugShowFileIO } from '../debugFlags';
@@ -101,20 +101,21 @@ export function validateFile(jsonFile: {}): GridFile | null {
 
     // The previous enums for borders were integers but now we use strings
     // So we have to change them all, e.g. from "3" to "dotted"
-    // The old enum integers map directly to the new strings positions in the enum array
-    // Old enums: { line1 = 0, line2 = 1, line3 = 2, dotted = 3, dashed = 4, double = 5 }
-    // New enums: ['line1', 'line2', 'line3', 'dotted', 'dashed', 'double']
     // https://github.com/quadratichq/quadratic/pull/308/files#diff-fb2ecd77a7c43aa1f68a862e8866d079391f51b6ae9665059d523221fdf5256fL44-R41
+    const enumMapping = {
+      0: 'line1',
+      1: 'line2',
+      2: 'line3',
+      3: 'dotted',
+      4: 'dashed',
+      5: 'double',
+    };
     if (jsonFile && jsonFile.borders && jsonFile.borders.length > 0) {
       ['horizontal', 'vertical'].forEach((key) => {
         for (let i = 0; i < jsonFile.borders.length; i++) {
-          if (
-            jsonFile.borders[i][key] &&
-            jsonFile.borders[i][key].type &&
-            typeof jsonFile.borders[i][key].type === 'number'
-          ) {
-            const oldEnum = jsonFile.borders[i][key].type;
-            jsonFile.borders[i][key].type = BorderTypeEnum.options[oldEnum];
+          if (jsonFile.borders[i][key] && typeof jsonFile.borders[i][key].type === 'number') {
+            const value: 0 | 1 | 2 | 3 | 4 | 5 = jsonFile.borders[i][key].type;
+            jsonFile.borders[i][key].type = enumMapping[value];
           }
         }
       });

--- a/src/storage/GridFile.ts
+++ b/src/storage/GridFile.ts
@@ -1,5 +1,5 @@
 import { Dependency } from '../grid/sheet/GridRenderDependency';
-import { BorderSchema, CellSchema, CellFormatSchema } from '../grid/sheet/gridTypes';
+import { BorderSchema, CellSchema, CellFormatSchema, BorderTypeEnum } from '../grid/sheet/gridTypes';
 import { v4 as uuid } from 'uuid';
 import z from 'zod';
 import { debugShowFileIO } from '../debugFlags';
@@ -97,6 +97,27 @@ export function validateFile(jsonFile: {}): GridFile | null {
     // If this value is missing, add it as an empty string
     if (jsonFile && !jsonFile.cell_dependency) {
       jsonFile.cell_dependency = '';
+    }
+
+    // The previous enums for borders were integers but now we use strings
+    // So we have to change them all, e.g. from "3" to "dotted"
+    // The old enum integers map directly to the new strings positions in the enum array
+    // Old enums: { line1 = 0, line2 = 1, line3 = 2, dotted = 3, dashed = 4, double = 5 }
+    // New enums: ['line1', 'line2', 'line3', 'dotted', 'dashed', 'double']
+    // https://github.com/quadratichq/quadratic/pull/308/files#diff-fb2ecd77a7c43aa1f68a862e8866d079391f51b6ae9665059d523221fdf5256fL44-R41
+    if (jsonFile && jsonFile.borders && jsonFile.borders.length > 0) {
+      ['horizontal', 'vertical'].forEach((key) => {
+        for (let i = 0; i < jsonFile.borders.length; i++) {
+          if (
+            jsonFile.borders[i][key] &&
+            jsonFile.borders[i][key].type &&
+            typeof jsonFile.borders[i][key].type === 'number'
+          ) {
+            const oldEnum = jsonFile.borders[i][key].type;
+            jsonFile.borders[i][key].type = BorderTypeEnum.options[oldEnum];
+          }
+        }
+      });
     }
 
     return jsonFile;

--- a/src/storage/useLocalFiles.ts
+++ b/src/storage/useLocalFiles.ts
@@ -101,7 +101,7 @@ export const useLocalFiles = (sheetController: SheetController): LocalFiles => {
       // Check if the JSON is a valid quadratic file
       const quadraticJson = validateFile(json);
       if (!quadraticJson) {
-        console.error('Failed to parse JSON as a valid Quadratic file', json);
+        console.error('Failed to parse JSON as a valid Quadratic file', json, contents);
         return false;
       }
 


### PR DESCRIPTION
The old file schema used integers as enums for border types whereas the new schema [introduced here](https://github.com/quadratichq/quadratic/pull/308/files#diff-fb2ecd77a7c43aa1f68a862e8866d079391f51b6ae9665059d523221fdf5256fL44-L51) uses human readable strings.

This results in old files with special borders having integers as values (instead of strings) and therefore not passing zod parsing

For example, the new file formats look like this:

```json
"borders": [
  {
    "x": 5,
    "y": 6,
    "vertical": {
      "type": "dashed"
    }
  }
]
```

Whereas the previous file format was:

```json
"borders": [
  {
    "x": 5,
    "y": 6,
    "vertical": {
      "type": 4
    }
  }
]
```

- [x] Update the v1 schema to reflect the old enums and add v1_1 to use the new strings method, with the updater function updating old values - WILL DO THIS IN ANOTHER PR
- [x] Add tests to denote this change