### PR TITLE
feat: add read-only dialog for mobile

### DIFF
--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -21,6 +21,8 @@ import { GetCellsDBSetSheet } from '../grid/sheet/Cells/GetCellsDB';
 import { PixiApp } from '../gridGL/pixiApp/PixiApp';
 import { SheetController } from '../grid/controller/sheetController';
 import { LocalFilesContext } from './QuadraticUIContext';
+import ReadOnlyDialog from './components/ReadOnlyDialog';
+import { IS_READONLY_MODE } from '../constants/app';
 
 export default function QuadraticUI({ app, sheetController }: { app: PixiApp; sheetController: SheetController }) {
   const [showDebugMenu] = useLocalStorage('showDebugMenu', false);
@@ -83,6 +85,8 @@ export default function QuadraticUI({ app, sheetController }: { app: PixiApp; sh
       {presentationMode && <PresentationModeHint />}
       <SnackBar {...snackBar} />
       {hasInitialPageLoadError && <InitialPageLoadError />}
+
+      {IS_READONLY_MODE && <ReadOnlyDialog />}
     </div>
   );
 }

--- a/src/ui/components/ReadOnlyDialog.tsx
+++ b/src/ui/components/ReadOnlyDialog.tsx
@@ -1,0 +1,30 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import useLocalStorage from '../../hooks/useLocalStorage';
+
+export default function ReadOnlyDialog() {
+  const [showReadOnlyMsg, setShowReadOnlyMsg] = useLocalStorage('showReadOnlyMsg', true);
+  const handleClose = () => {
+    setShowReadOnlyMsg(false);
+  };
+  return (
+    <Dialog
+      open={showReadOnlyMsg}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">Quadratic is built for desktop</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          On mobile, sheets are read-only. To edit sheets, run code, and use the full power of the app, open it on your
+          desktop computer.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} autoFocus>
+          Ok, thanks
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
For people who show up to the site on a mobile device, show a dialog indicating that the app is best on desktop.

To test:
- Should not fire for a desktop device
- Should only show the first time you come to the app (on mobile) and, once dismissed, you should never see this message again (unless you clear your cache, as it's stored in localStorage)

<img width="600" alt="CleanShot 2023-04-14 at 12 06 24@2x" src="https://user-images.githubusercontent.com/1316441/232124310-e1f03205-8e04-4fa3-9302-22dc391fe468.png">
