### PR TITLE
fix: only indicate "delete" on horizontal drag when you shrink the initial selection

### DIFF
--- a/src/gridGL/interaction/pointer/PointerAutoComplete/PointerAutoComplete.ts
+++ b/src/gridGL/interaction/pointer/PointerAutoComplete/PointerAutoComplete.ts
@@ -174,11 +174,19 @@ export class PointerAutoComplete {
           let isDelete = false;
           if (this.state.includes('shrink') && this.selection && this.endCell) {
             // Vertical delete
-            if (this.selection.height > 0 && this.endCell.y < this.selection.y + this.selection.height) {
+            if (
+              this.state.includes('shrinkVertical') &&
+              this.selection.height > 0 &&
+              this.endCell.y < this.selection.y + this.selection.height
+            ) {
               isDelete = true;
             }
             // Horizontal delete
-            if (this.selection.width > 0 && this.endCell.x <= this.selection.x + this.selection.width) {
+            if (
+              this.state.includes('shrinkHorizontal') &&
+              this.selection.width > 0 &&
+              this.endCell.x <= this.selection.x + this.selection.width
+            ) {
               isDelete = true;
             }
           }


### PR DESCRIPTION
Today when you drag the cursor on a horizontal selection _other than the very last row_, the UI communicates a "delete" action will happen on your initial selection (which isn't true).

![before](https://user-images.githubusercontent.com/1316441/234099575-df8ef0ca-f661-4408-95db-23eb43376d95.gif)

This PR fixes that so the "delete" UI indication only happens when you shrink your initial selection irregardless of row.

![after](https://user-images.githubusercontent.com/1316441/234099643-3ec352ca-d29d-4da3-a1a6-36b42044bde3.gif)
