### PR TITLE
refactor: swap out uuid lib for native randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@types/react": "^17.0.33",
         "@types/react-color": "^3.0.6",
         "@types/react-dom": "^17.0.10",
-        "@types/uuid": "^9.0.1",
         "ace-builds": "^1.4.13",
         "axios": "^0.24.0",
         "color": "^4.2.3",
@@ -52,7 +51,6 @@
         "recoil": "^0.6.0",
         "sass": "^1.56.2",
         "typescript": "^4.4.4",
-        "uuid": "^9.0.0",
         "web-vitals": "^1.0.1",
         "zod": "^3.21.4"
       },
@@ -5977,11 +5975,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -17299,9 +17292,8 @@
       }
     },
     "node_modules/quadratic-core": {
-      "version": "0.1.3",
-      "resolved": "file:quadratic-core/pkg",
-      "license": "MIT"
+      "resolved": "quadratic-core/pkg",
+      "link": true
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -21235,14 +21227,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -22204,6 +22188,10 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "quadratic-core/pkg": {
+      "version": "0.1.3",
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -26536,11 +26524,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
-    },
-    "@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -34773,7 +34756,7 @@
       }
     },
     "quadratic-core": {
-      "version": "0.1.3"
+      "version": "file:quadratic-core/pkg"
     },
     "querystringify": {
       "version": "2.2.0",
@@ -37732,11 +37715,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/react": "^17.0.33",
     "@types/react-color": "^3.0.6",
     "@types/react-dom": "^17.0.10",
-    "@types/uuid": "^9.0.1",
     "ace-builds": "^1.4.13",
     "axios": "^0.24.0",
     "color": "^4.2.3",
@@ -53,7 +52,6 @@
     "recoil": "^0.6.0",
     "sass": "^1.56.2",
     "typescript": "^4.4.4",
-    "uuid": "^9.0.0",
     "web-vitals": "^1.0.1",
     "zod": "^3.21.4"
   },

--- a/src/helpers/generateUUID.ts
+++ b/src/helpers/generateUUID.ts
@@ -1,0 +1,7 @@
+export const generateUUID = () => {
+  // We don't get types for randomUUID for free yet, so we'll just ignore this
+  // https://github.com/denoland/deno/issues/12754
+  // https://dev.to/amarok24/randomuuid-in-typescript-5h3i
+  // @ts-ignore
+  return window.crypto.randomUUID();
+};

--- a/src/hooks/useGenerateLocalFiles.tsx
+++ b/src/hooks/useGenerateLocalFiles.tsx
@@ -5,9 +5,9 @@ import { GridFileData, GridFile, GridFileSchema, GridFiles } from '../schemas';
 import { GridFileV1 } from '../schemas/GridFileV1';
 import { validateGridFile } from '../schemas/validateGridFile';
 import { debugShowFileIO } from '../debugFlags';
-import { v4 as uuid } from 'uuid';
 import { getURLParameter } from '../helpers/getURL';
 import { downloadFile } from '../helpers/downloadFile';
+import { generateUUID } from '../helpers/generateUUID';
 import { SheetController } from '../grid/controller/sheetController';
 import { useSetRecoilState } from 'recoil';
 import { editorInteractionStateAtom } from '../atoms/editorInteractionStateAtom';
@@ -118,7 +118,7 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
 
       // If it's a new file
       if (isNewFile) {
-        const newFileListItem = { filename, id: uuid(), modified: Date.now() };
+        const newFileListItem = { filename, id: generateUUID(), modified: Date.now() };
         const newFile = { ...quadraticJson, ...newFileListItem };
         setCurrentFileContents(newFile);
         setFileList((oldFileList) => [newFileListItem, ...oldFileList]);
@@ -185,7 +185,7 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
     const created = Date.now();
     const newFile: GridFile = {
       ...grid,
-      id: uuid(),
+      id: generateUUID(),
       created,
       version: GridFileSchema.shape.version.value,
       modified: created,

--- a/src/schemas/GridFileV1_1.ts
+++ b/src/schemas/GridFileV1_1.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 import { GridFileV1 } from './GridFileV1';
-import { v4 as uuid } from 'uuid';
 import { DEFAULT_FILE_NAME } from '../constants/app';
+import { generateUUID } from '../helpers/generateUUID';
 
 // Shared schemas
 const ArrayOutputSchema = z.array(z.union([z.string(), z.number(), z.boolean()]));
@@ -148,7 +148,7 @@ export function upgradeV1toV1_1(file: GridFileV1): GridFileV1_1 {
     version: '1.1',
     modified: date,
     created: date,
-    id: uuid(),
+    id: generateUUID(),
     filename: DEFAULT_FILE_NAME,
   } as GridFileV1_1;
 }


### PR DESCRIPTION
Generate a UUID via the browser's built-in [`crypto.randomUUID`](https://caniuse.com/mdn-api_crypto_randomuuid)

This results in less JS code to ship to the client.

Resolves #421 