### PR TITLE
feat: add a feedback widget

### DIFF
--- a/src/atoms/editorInteractionStateAtom.ts
+++ b/src/atoms/editorInteractionStateAtom.ts
@@ -8,6 +8,7 @@ export interface EditorInteractionState {
   showCommandPalette: boolean;
   showGoToMenu: boolean;
   showFileMenu: boolean;
+  showFeedbackMenu: boolean;
   selectedCell: Coordinate;
   mode: CellType;
 }
@@ -17,6 +18,7 @@ export const editorInteractionStateDefault: EditorInteractionState = {
   showCodeEditor: false,
   showCommandPalette: false,
   showGoToMenu: false,
+  showFeedbackMenu: false,
   showFileMenu: false,
   selectedCell: { x: 0, y: 0 },
   mode: 'TEXT',

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -4,3 +4,4 @@ export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/python`;
 export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}/formulas`;
 export const DOCUMENTATION_FILES_URL = `${DOCUMENTATION_URL}/files`;
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';
+export const DISCORD = 'https://discord.gg/quadratic';

--- a/src/gridGL/interaction/keyboard/keyboardViewport.ts
+++ b/src/gridGL/interaction/keyboard/keyboardViewport.ts
@@ -69,6 +69,7 @@ export function keyboardViewport(options: {
   if ((event.metaKey || event.ctrlKey) && (event.key === 'p' || event.key === 'k' || event.key === '/')) {
     setEditorInteractionState({
       ...editorInteractionState,
+      showFeedbackMenu: false,
       showCellTypeMenu: false,
       showGoToMenu: false,
       showCommandPalette: !editorInteractionState.showCommandPalette,
@@ -107,6 +108,7 @@ export function keyboardViewport(options: {
   if ((event.metaKey || event.ctrlKey) && (event.key === 'g' || event.key === 'j')) {
     setEditorInteractionState({
       ...editorInteractionState,
+      showFeedbackMenu: false,
       showCellTypeMenu: false,
       showCommandPalette: false,
       showGoToMenu: !editorInteractionState.showGoToMenu,

--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -21,6 +21,7 @@ import { SheetController } from '../grid/controller/sheetController';
 import ReadOnlyDialog from './components/ReadOnlyDialog';
 import { IS_READONLY_MODE } from '../constants/app';
 import { useLocalFiles } from './contexts/LocalFiles';
+import FeedbackMenu from './menus/FeedbackMenu';
 
 export default function QuadraticUI({ app, sheetController }: { app: PixiApp; sheetController: SheetController }) {
   const [showDebugMenu] = useLocalStorage('showDebugMenu', false);
@@ -74,6 +75,7 @@ export default function QuadraticUI({ app, sheetController }: { app: PixiApp; sh
       </div>
 
       {!presentationMode && <BottomBar sheet={sheetController.sheet} />}
+      {editorInteractionState.showFeedbackMenu && <FeedbackMenu />}
       {presentationMode && <PresentationModeHint />}
       {hasInitialPageLoadError && <InitialPageLoadError />}
 

--- a/src/ui/menus/BottomBar/BottomBar.tsx
+++ b/src/ui/menus/BottomBar/BottomBar.tsx
@@ -10,6 +10,7 @@ import { isMobileOnly } from 'react-device-detect';
 import { debugShowCacheFlag, debugShowFPS, debugShowRenderer, debugShowCacheCount } from '../../../debugFlags';
 import { Sheet } from '../../../grid/sheet/Sheet';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
+import { ChatBubbleOutline } from '@mui/icons-material';
 
 interface Props {
   sheet: Sheet;
@@ -125,6 +126,15 @@ export const BottomBar = (props: Props) => {
           gap: '1rem',
         }}
       >
+        <span
+          style={{ display: 'flex', alignItems: 'center', gap: '.25rem' }}
+          onClick={() => {
+            setEditorInteractionState((prevState) => ({ ...prevState, showFeedbackMenu: true }));
+          }}
+        >
+          <ChatBubbleOutline fontSize="inherit" />
+          Feedback
+        </span>
         {!isMobileOnly && <span>✓ Python 3.9.5</span>}
         <span>✓ Quadratic {process.env.REACT_APP_VERSION}</span>
         <span

--- a/src/ui/menus/CommandPalette/ListItems/Help.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Help.tsx
@@ -1,7 +1,9 @@
 import { CommandPaletteListItem } from '../CommandPaletteListItem';
-import { OpenInNew } from '@mui/icons-material';
-import { DOCUMENTATION_URL, BUG_REPORT_URL } from '../../../../constants/urls';
+import { ChatBubbleOutline, OpenInNew } from '@mui/icons-material';
+import { DOCUMENTATION_URL } from '../../../../constants/urls';
 import { CommandPaletteListItemSharedProps } from '../CommandPaletteListItem';
+import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
+import { useSetRecoilState } from 'recoil';
 
 const ListItems = [
   {
@@ -17,16 +19,19 @@ const ListItems = [
     ),
   },
   {
-    label: 'Help: Report a problem',
-    Component: (props: CommandPaletteListItemSharedProps) => (
-      <CommandPaletteListItem
-        {...props}
-        icon={<OpenInNew />}
-        action={() => {
-          window.open(BUG_REPORT_URL, '_blank')?.focus();
-        }}
-      />
-    ),
+    label: 'Help: Provide feedback',
+    Component: (props: CommandPaletteListItemSharedProps) => {
+      const setEditorInteractionState = useSetRecoilState(editorInteractionStateAtom);
+      return (
+        <CommandPaletteListItem
+          {...props}
+          icon={<ChatBubbleOutline />}
+          action={() => {
+            setEditorInteractionState((prevState) => ({ ...prevState, showFeedbackMenu: true }));
+          }}
+        />
+      );
+    },
   },
 ];
 

--- a/src/ui/menus/FeedbackMenu/FeedbackMenu.tsx
+++ b/src/ui/menus/FeedbackMenu/FeedbackMenu.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
+import { useTheme } from '@mui/system';
+import { useRecoilState } from 'recoil';
+import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
+import { LinkNewTab } from '../../components/LinkNewTab';
+import { BUG_REPORT_URL, DISCORD } from '../../../constants/urls';
+import useLocalStorage from '../../../hooks/useLocalStorage';
+import { useGlobalSnackbar } from '../../contexts/GlobalSnackbar';
+
+export const FeedbackMenu = () => {
+  const [editorInteractionState, setEditorInteractionState] = useRecoilState(editorInteractionStateAtom);
+  const { showFeedbackMenu } = editorInteractionState;
+  // We'll keep the user's state around unless they explicitly cancel or get a successful submit
+  const [value, setValue] = useLocalStorage('feedback-message', '');
+  const [loadState, setLoadState] = useState<'INITIAL' | 'LOADING' | 'LOAD_ERROR'>('INITIAL');
+  const theme = useTheme();
+  const { addGlobalSnackbar } = useGlobalSnackbar();
+
+  const closeMenu = () => {
+    setEditorInteractionState((state) => ({
+      ...state,
+      showFeedbackMenu: false,
+    }));
+  };
+
+  const onSubmit = () => {
+    setLoadState('LOADING');
+
+    // TODO post to DB
+    const postToServer = () =>
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve('');
+        }, 2000);
+      });
+
+    postToServer()
+      .then(() => {
+        setValue('');
+        closeMenu();
+        addGlobalSnackbar('Feedback submitted! Thank you.');
+      })
+      .catch((e) => {
+        console.error(e);
+        setLoadState('LOAD_ERROR');
+      });
+  };
+
+  const isLoading = loadState === 'LOADING';
+  const hasError = loadState === 'LOAD_ERROR';
+
+  return (
+    <Dialog open={showFeedbackMenu} onClose={closeMenu} fullWidth maxWidth={'sm'} BackdropProps={{ invisible: true }}>
+      <DialogTitle>Provide feedback</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          We’re listening on <LinkNewTab href={BUG_REPORT_URL}>GitHub</LinkNewTab> or{' '}
+          <LinkNewTab href={DISCORD}>Discord</LinkNewTab>. Or, provide feedback below (we read all feedback and may
+          follow up via email).
+        </DialogContentText>
+
+        <TextField
+          InputLabelProps={{ shrink: true }}
+          id="feedback"
+          label="Your feedback"
+          variant="outlined"
+          disabled={isLoading}
+          fullWidth
+          multiline
+          sx={{ mt: theme.spacing(2) }}
+          autoFocus
+          value={value}
+          onFocus={(event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            // If an error exists, reset
+            if (loadState === 'LOAD_ERROR') {
+              setLoadState('INITIAL');
+            }
+            // Ensure cursor position to the end on focus
+            if (value.length > 0) {
+              event.target.setSelectionRange(value.length, value.length);
+            }
+          }}
+          // Allow submit via keyboard CMD + Enter
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+              onSubmit();
+            }
+          }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            setValue(event.target.value);
+          }}
+          {...(hasError ? { error: true, helperText: 'Failed to send. Try again.' } : {})}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="text"
+          color="inherit"
+          onClick={() => {
+            setValue('');
+            closeMenu();
+          }}
+          disabled={isLoading}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="text"
+          sx={{ mr: theme.spacing(1) }}
+          onClick={onSubmit}
+          disabled={value.length === 0 || isLoading}
+        >
+          {isLoading ? 'Submitting…' : 'Submit'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/ui/menus/FeedbackMenu/index.tsx
+++ b/src/ui/menus/FeedbackMenu/index.tsx
@@ -1,0 +1,2 @@
+import { FeedbackMenu } from './FeedbackMenu';
+export default FeedbackMenu;

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -8,7 +8,7 @@ import { useGridSettings } from './useGridSettings';
 import { useAuth0 } from '@auth0/auth0-react';
 import useLocalStorage from '../../../../hooks/useLocalStorage';
 import { Tooltip } from '@mui/material';
-import { DOCUMENTATION_URL, BUG_REPORT_URL } from '../../../../constants/urls';
+import { DOCUMENTATION_URL } from '../../../../constants/urls';
 import { SheetController } from '../../../../grid/controller/sheetController';
 import { MenuLineItem } from '../MenuLineItem';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
@@ -210,7 +210,16 @@ export const QuadraticMenu = (props: Props) => {
 
         <SubMenu label="Help">
           <MenuItem onClick={() => window.open(DOCUMENTATION_URL, '_blank')}>Read the docs</MenuItem>
-          <MenuItem onClick={() => window.open(BUG_REPORT_URL, '_blank')}>Report a problem</MenuItem>
+          <MenuItem
+            onClick={() =>
+              setEditorInteractionState((prevState) => ({
+                ...prevState,
+                showFeedbackMenu: true,
+              }))
+            }
+          >
+            Provide feedback
+          </MenuItem>
         </SubMenu>
       </Menu>
     </>


### PR DESCRIPTION
Feedback widget that allows users to submit feedback to us.

<img width="975" alt="CleanShot 2023-04-28 at 14 26 49@2x" src="https://user-images.githubusercontent.com/1316441/235265043-b9e941e4-4efa-499e-87e3-a88725b21020.png">

Todos:

- [x] Triggers from all relevant places
- [x] Supports states: initial, submitting, submit error
- [x] Provides links to github issues and discord
- [ ] Submits to DB — @davidkircos 

Note that this feedback widget can now be triggered from:

The footer

![CleanShot 2023-04-28 at 14 26 33@2x](https://user-images.githubusercontent.com/1316441/235265099-eee62760-f05d-4cde-b0e3-de83c8c7bd46.png)

The command palette

<img width="702" alt="CleanShot 2023-04-28 at 16 34 52@2x" src="https://user-images.githubusercontent.com/1316441/235265118-08476db9-944f-4a8e-a99c-ee50c501566b.png">

The help menu

<img width="667" alt="CleanShot 2023-04-28 at 14 26 24@2x" src="https://user-images.githubusercontent.com/1316441/235265126-e0d17216-67ef-4ea8-98b1-ef509f568863.png">
