### PR TITLE
chore: update browserslist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7588,9 +7588,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001388",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
-      "integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==",
+      "version": "1.0.30001482",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
+      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7599,6 +7599,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -17299,9 +17303,8 @@
       }
     },
     "node_modules/quadratic-core": {
-      "version": "0.1.3",
-      "resolved": "file:quadratic-core/pkg",
-      "license": "MIT"
+      "resolved": "quadratic-core/pkg",
+      "link": true
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -22204,6 +22207,11 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "quadratic-core/pkg": {
+      "name": "quadratic-core",
+      "version": "0.1.3",
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -27716,9 +27724,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001388",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
-      "integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ=="
+      "version": "1.0.30001482",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
+      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -34773,7 +34781,7 @@
       }
     },
     "quadratic-core": {
-      "version": "0.1.3"
+      "version": "file:quadratic-core/pkg"
     },
     "querystringify": {
       "version": "2.2.0",


### PR DESCRIPTION
Running `npm run build` results in this output:

<img width="559" alt="CleanShot 2023-05-01 at 15 40 41@2x" src="https://user-images.githubusercontent.com/1316441/235538913-af1514ac-aad7-443b-b01d-7c02b8991ee3.png">

```
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

So I ran the command to do the update.