### PR TITLE
fix: support spaces when importing file from url

### DIFF
--- a/src/hooks/useGenerateLocalFiles.tsx
+++ b/src/hooks/useGenerateLocalFiles.tsx
@@ -146,7 +146,7 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
 
         // If there's no specified name, derive it's name from the URL
         if (!filename) {
-          filename = massageFilename(new URL(url).pathname.split('/').pop());
+          filename = decodeURIComponent(massageFilename(new URL(url).pathname.split('/').pop()));
         }
 
         return importQuadraticFile(file, filename);


### PR DESCRIPTION
If somebody links to a file with spaces in the url, e.g. `?file=file%20name.grid` make sure the file name shows as "file name" in the app once imported (not "file%20name")