### PR TITLE
fix: close editor when creating new file

### DIFF
--- a/src/hooks/useGenerateLocalFiles.tsx
+++ b/src/hooks/useGenerateLocalFiles.tsx
@@ -14,6 +14,7 @@ import { editorInteractionStateAtom } from '../atoms/editorInteractionStateAtom'
 import { DEFAULT_FILE_NAME, EXAMPLE_FILES, FILE_PARAM_KEY } from '../constants/app';
 import apiClientSingleton from '../api-client/apiClientSingleton';
 import mixpanel from 'mixpanel-browser';
+import { focusGrid } from '../helpers/focusGrid';
 const INDEX = 'file-list';
 
 export interface LocalFile {
@@ -84,6 +85,7 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
       sheetController.sheet.load_file(grid);
       sheetController.app?.rebuild();
       sheetController.app?.reset();
+      focusGrid();
       const searchParams = new URLSearchParams(window.location.search);
       // If `file` is in there from an intial page load, remove it
       if (searchParams.get('file')) {

--- a/src/hooks/useGenerateLocalFiles.tsx
+++ b/src/hooks/useGenerateLocalFiles.tsx
@@ -83,6 +83,7 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
       sheetController.clear();
       sheetController.sheet.load_file(grid);
       sheetController.app?.rebuild();
+      sheetController.app?.reset();
       const searchParams = new URLSearchParams(window.location.search);
       // If `file` is in there from an intial page load, remove it
       if (searchParams.get('file')) {

--- a/src/ui/QuadraticUI.tsx
+++ b/src/ui/QuadraticUI.tsx
@@ -56,7 +56,7 @@ export default function QuadraticUI({ app, sheetController }: { app: PixiApp; sh
       {!presentationMode && <TopBar app={app} sheetController={sheetController} />}
       {editorInteractionState.showCommandPalette && <CommandPalette app={app} sheetController={sheetController} />}
       {editorInteractionState.showGoToMenu && <GoTo app={app} sheetController={sheetController} />}
-      {editorInteractionState.showFileMenu && <FileMenu app={app} />}
+      {editorInteractionState.showFileMenu && <FileMenu />}
 
       <div
         style={{

--- a/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -134,9 +134,11 @@ export const CodeEditor = (props: CodeEditorProps) => {
   };
 
   useEffect(() => {
-    // focus editor on show editor change
-    editorRef.current?.focus();
-    editorRef.current?.setPosition({ lineNumber: 0, column: 0 });
+    if (editorInteractionState.showCodeEditor) {
+      // focus editor on show editor change
+      editorRef.current?.focus();
+      editorRef.current?.setPosition({ lineNumber: 0, column: 0 });
+    }
   }, [editorInteractionState.showCodeEditor]);
 
   // When cell changes

--- a/src/ui/menus/CommandPalette/ListItems/File.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/File.tsx
@@ -12,16 +12,7 @@ const ListItems = [
     label: 'File: New',
     Component: (props: CommandPaletteListItemSharedProps) => {
       const { createNewFile } = useLocalFiles();
-      return (
-        <CommandPaletteListItem
-          {...props}
-          icon={<NoteAddOutlined />}
-          action={async () => {
-            await createNewFile();
-            props.app.reset();
-          }}
-        />
-      );
+      return <CommandPaletteListItem {...props} icon={<NoteAddOutlined />} action={createNewFile} />;
     },
   },
   {

--- a/src/ui/menus/CommandPalette/ListItems/File.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/File.tsx
@@ -12,7 +12,16 @@ const ListItems = [
     label: 'File: New',
     Component: (props: CommandPaletteListItemSharedProps) => {
       const { createNewFile } = useLocalFiles();
-      return <CommandPaletteListItem {...props} icon={<NoteAddOutlined />} action={createNewFile} />;
+      return (
+        <CommandPaletteListItem
+          {...props}
+          icon={<NoteAddOutlined />}
+          action={async () => {
+            await createNewFile();
+            props.app.reset();
+          }}
+        />
+      );
     },
   },
   {

--- a/src/ui/menus/FileMenu/FileMenu.tsx
+++ b/src/ui/menus/FileMenu/FileMenu.tsx
@@ -36,19 +36,11 @@ import {
   LayoutColLeftWrapper,
   LayoutColRightWrapper,
 } from './FileMenuStyles';
-import { PixiApp } from '../../../gridGL/pixiApp/PixiApp';
 import { DOCUMENTATION_FILES_URL } from '../../../constants/urls';
 import { useLocalFiles } from '../../contexts/LocalFiles';
 import { useGlobalSnackbar } from '../../contexts/GlobalSnackbar';
 
-interface FileMenuProps {
-  app: PixiApp;
-}
-
-export type onCloseFn = (arg?: { reset: boolean }) => void;
-
-export function FileMenu(props: FileMenuProps) {
-  const { app } = props;
+export function FileMenu() {
   const setEditorInteractionState = useSetRecoilState(editorInteractionStateAtom);
   const {
     currentFileId,
@@ -61,11 +53,7 @@ export function FileMenu(props: FileMenuProps) {
   } = useLocalFiles();
   const { addGlobalSnackbar } = useGlobalSnackbar();
 
-  const onClose: onCloseFn = ({ reset } = { reset: false }) => {
-    if (reset) {
-      app.reset();
-    }
-
+  const onClose = () => {
     setEditorInteractionState((prevState) => ({
       ...prevState,
       showFileMenu: false,
@@ -76,7 +64,8 @@ export function FileMenu(props: FileMenuProps) {
 
   const onNewFile = async () => {
     await createNewFile();
-    onClose({ reset: true });
+    // No need to reset, as `createNewFile` does that itself
+    onClose();
   };
 
   // If there's an active file, set focus back to the grid when this unmounts
@@ -135,7 +124,7 @@ export function FileMenu(props: FileMenuProps) {
                         onClick={() => {
                           loadFileFromMemory(id).then((loaded) => {
                             if (loaded) {
-                              onClose({ reset: true });
+                              onClose();
                             } else {
                               addGlobalSnackbar('Failed to load file.');
                               Sentry.captureEvent({

--- a/src/ui/menus/FileMenu/FileMenu.tsx
+++ b/src/ui/menus/FileMenu/FileMenu.tsx
@@ -22,7 +22,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import FileMenuTabs from './FileMenuTabs';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
 import { focusGrid } from '../../../helpers/focusGrid';
@@ -49,7 +49,7 @@ export type onCloseFn = (arg?: { reset: boolean }) => void;
 
 export function FileMenu(props: FileMenuProps) {
   const { app } = props;
-  const [editorInteractionState, setEditorInteractionState] = useRecoilState(editorInteractionStateAtom);
+  const setEditorInteractionState = useSetRecoilState(editorInteractionStateAtom);
   const {
     currentFileId,
     currentFilename,
@@ -66,10 +66,10 @@ export function FileMenu(props: FileMenuProps) {
       app.reset();
     }
 
-    setEditorInteractionState({
-      ...editorInteractionState,
+    setEditorInteractionState((prevState) => ({
+      ...prevState,
       showFileMenu: false,
-    });
+    }));
   };
   const theme = useTheme();
   const styles = getStyles(theme);

--- a/src/ui/menus/FileMenu/FileMenu.tsx
+++ b/src/ui/menus/FileMenu/FileMenu.tsx
@@ -64,7 +64,6 @@ export function FileMenu() {
 
   const onNewFile = async () => {
     await createNewFile();
-    // No need to reset, as `createNewFile` does that itself
     onClose();
   };
 

--- a/src/ui/menus/FileMenu/FileMenuTabs.tsx
+++ b/src/ui/menus/FileMenu/FileMenuTabs.tsx
@@ -20,7 +20,6 @@ import { LinkNewTab } from '../../components/LinkNewTab';
 import { ChangeEvent, ReactNode, SyntheticEvent, useCallback, useRef, useState } from 'react';
 import { DOCUMENTATION_FILES_URL } from '../../../constants/urls';
 import { QuadraticLoading } from '../../loading/QuadraticLoading';
-import { onCloseFn } from './FileMenu';
 import { EXAMPLE_FILES } from '../../../constants/app';
 import { useLocalFiles } from '../../contexts/LocalFiles';
 
@@ -65,7 +64,7 @@ function a11yProps(index: number) {
 }
 
 interface FileMenuTabsProps {
-  onClose: onCloseFn;
+  onClose: () => void;
   onNewFile: () => void;
 }
 
@@ -85,7 +84,7 @@ export default function FileMenuTabs(props: FileMenuTabsProps) {
       const file = e.target.files?.[0];
       if (file) {
         const loaded = await loadFileFromDisk(file);
-        if (loaded) onClose({ reset: true });
+        if (loaded) onClose();
         else setImportLocalError(true);
       }
     },
@@ -100,7 +99,7 @@ export default function FileMenuTabs(props: FileMenuTabsProps) {
         setIsLoading(true);
         const loaded = await loadFileFromUrl(url);
         setIsLoading(false);
-        if (loaded) onClose({ reset: true });
+        if (loaded) onClose();
         else setImportURLError(true);
       }
     },
@@ -158,7 +157,7 @@ export default function FileMenuTabs(props: FileMenuTabsProps) {
                       .then((loaded) => {
                         setIsLoading(false);
                         if (loaded) {
-                          onClose({ reset: true });
+                          onClose();
                         }
                       })
                       .catch((e) => {

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -67,9 +67,9 @@ export const QuadraticMenu = (props: Props) => {
         <MenuDivider />
         <SubMenu label="File">
           <MenuItem
-            onClick={() => {
+            onClick={async () => {
+              await createNewFile();
               app.reset();
-              createNewFile();
             }}
           >
             New

--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -18,16 +18,14 @@ import { gridInteractionStateAtom } from '../../../../atoms/gridInteractionState
 import { isMac } from '../../../../utils/isMac';
 import { ContentCopy, ContentCut, ContentPaste, Undo, Redo } from '@mui/icons-material';
 import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
-import { PixiApp } from '../../../../gridGL/pixiApp/PixiApp';
 import { useLocalFiles } from '../../../contexts/LocalFiles';
 
 interface Props {
   sheetController: SheetController;
-  app: PixiApp;
 }
 
 export const QuadraticMenu = (props: Props) => {
-  const { app, sheetController } = props;
+  const { sheetController } = props;
   const [showDebugMenu, setShowDebugMenu] = useLocalStorage('showDebugMenu', false);
   const interactionState = useRecoilValue(gridInteractionStateAtom);
   const [editorInteractionState, setEditorInteractionState] = useRecoilState(editorInteractionStateAtom);
@@ -66,14 +64,7 @@ export const QuadraticMenu = (props: Props) => {
         </MenuItem>
         <MenuDivider />
         <SubMenu label="File">
-          <MenuItem
-            onClick={async () => {
-              await createNewFile();
-              app.reset();
-            }}
-          >
-            New
-          </MenuItem>
+          <MenuItem onClick={createNewFile}>New</MenuItem>
           <MenuItem onClick={() => downloadCurrentFile()}>Download local copy</MenuItem>
           <MenuItem
             onClick={() => {

--- a/src/ui/menus/TopBar/TopBar.tsx
+++ b/src/ui/menus/TopBar/TopBar.tsx
@@ -68,7 +68,7 @@ export const TopBar = (props: IProps) => {
           alignItems: 'center',
         }}
       >
-        <QuadraticMenu app={app} sheetController={sheetController} />
+        <QuadraticMenu sheetController={sheetController} />
         {!IS_READONLY_MODE && (
           <>
             <DataMenu></DataMenu>


### PR DESCRIPTION
Fixes #462 

Note: there are currently 3 different places that can create a new file:

1. Quadratic menu (File -> New)
2. Command palette
3. File menu (File -> Open -> Create file)

No. 2 & 3 suffer from this bug where if the code editor is open when you create a new file it doesn't disappear when the new file is opened.