### PR TITLE
Store formulas using RC notation

### DIFF
--- a/quadratic-core/Cargo.lock
+++ b/quadratic-core/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-core"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quadratic-core"
-version = "0.1.4"
+version = "0.1.6"
 authors = ["Andrew Farkas <andrew.farkas@quadratic.to>"]
 edition = "2021"
 description = "Infinite data grid with Python, JavaScript, and SQL built-in"

--- a/quadratic-core/src/formulas/mod.rs
+++ b/quadratic-core/src/formulas/mod.rs
@@ -1,5 +1,7 @@
 use crate::Pos;
 use ast::AstNode;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::wasm_bindgen;
 
 #[macro_use]
 mod errors;
@@ -18,12 +20,94 @@ pub use cell_ref::*;
 pub use ctx::Ctx;
 pub use errors::{FormulaError, FormulaErrorMsg};
 pub use grid_proxy::GridProxy;
-pub use parser::{find_cell_references, parse_formula};
+pub use parser::{find_cell_references, parse_formula, parse_formula_a1};
 pub use span::{Span, Spanned};
 pub use value::Value;
 
 /// Result of a `FormulaError`.
 pub type FormulaResult<T = Value> = Result<T, FormulaError>;
+
+/// Formula parser configuration.
+#[wasm_bindgen]
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ParseConfig {
+    pub pos: Pos,
+    pub cell_ref_notation: CellRefNotation,
+}
+#[wasm_bindgen]
+impl ParseConfig {
+    #[wasm_bindgen(constructor)]
+    pub fn new(pos: Pos, cell_ref_notation: CellRefNotation) -> Self {
+        Self {
+            pos,
+            cell_ref_notation,
+        }
+    }
+}
+impl ParseConfig {
+    fn is_a1(self) -> bool {
+        self.cell_ref_notation == CellRefNotation::A1
+    }
+    fn is_rc(self) -> bool {
+        self.cell_ref_notation == CellRefNotation::RC
+    }
+}
+
+/// Cell reference notation mode.
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+#[wasm_bindgen]
+pub enum CellRefNotation {
+    /// A1-style cell references. e.g., `$Bn6`
+    #[default]
+    A1,
+    /// RC-style cell references. e.g., `R[-6]C2`
+    RC,
+}
+
+/// Converts A1 cell references to RC notation, which can be copied to other
+/// cells. Invalid references and syntax errors remain unchanged.
+pub fn a1_to_rc(formula_string: &str, pos: Pos) -> String {
+    let cfg = ParseConfig {
+        pos,
+        cell_ref_notation: CellRefNotation::A1,
+    };
+    let mut ret = String::new();
+
+    for token in lexer::tokenize(formula_string, cfg) {
+        let token_str = token.span.of_str(formula_string);
+        if token.inner == lexer::Token::CellRefA1 {
+            if let Some(cell_ref) = CellRef::parse_a1(token_str, pos) {
+                ret.push_str(&cell_ref.rc_string());
+                continue;
+            }
+        }
+        ret.push_str(token_str);
+    }
+
+    ret
+}
+
+/// Converts RC cell references to A1 notation.
+pub fn rc_to_a1(formula_string: &str, pos: Pos) -> String {
+    let cfg = ParseConfig {
+        pos,
+        cell_ref_notation: CellRefNotation::RC,
+    };
+    let mut ret = String::new();
+
+    for token in lexer::tokenize(formula_string, cfg) {
+        let token_str = token.span.of_str(formula_string);
+        if token.inner == lexer::Token::CellRefRC {
+            if let Some(cell_ref) = CellRef::parse_rc(token_str) {
+                ret.push_str(&cell_ref.a1_string(pos));
+                continue;
+            }
+        }
+        ret.push_str(token_str);
+    }
+
+    ret
+}
 
 #[cfg(test)]
 mod tests;

--- a/quadratic-core/src/formulas/parser/rules/atoms.rs
+++ b/quadratic-core/src/formulas/parser/rules/atoms.rs
@@ -81,7 +81,7 @@ impl SyntaxRule for CellReference {
     }
     fn consume_match(&self, p: &mut Parser<'_>) -> FormulaResult<Self::Output> {
         p.next();
-        let Some(cell_ref) = CellRef::parse_a1(p.token_str(), p.cfg.pos) else {
+        let Some(cell_ref) = parse_current_cell_ref(p) else {
             return Err(FormulaErrorMsg::BadCellReference.with_span(p.span()));
         };
         Ok(AstNode {

--- a/quadratic-core/src/formulas/parser/rules/expression.rs
+++ b/quadratic-core/src/formulas/parser/rules/expression.rs
@@ -140,7 +140,8 @@ impl SyntaxRule for ExpressionWithPrecedence {
                 | Token::StringLiteral
                 | Token::UnterminatedStringLiteral
                 | Token::NumericLiteral
-                | Token::CellRef => true,
+                | Token::CellRefA1
+                | Token::CellRefRC => true,
 
                 Token::Whitespace => false,
                 Token::Unknown => false,

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -344,7 +344,7 @@ fn test_find_cell_references_a1() {
     // Test that RC-style cell references fail to parse.
     let cfg = ParseConfig {
         pos: base,
-        cell_ref_notation: CellRefNotation::RC,
+        cell_ref_notation: CellRefNotation::A1,
     };
     assert!(parse_formula("R1C1", cfg).is_err());
     assert!(parse_formula("R[1]C1", cfg).is_err());

--- a/quadratic-core/src/lib.rs
+++ b/quadratic-core/src/lib.rs
@@ -177,7 +177,7 @@ pub fn parse_formula(formula_string: &str, cfg: ParseConfig) -> JsValue {
 /// Replaces all valid A1-style references in a formula with RC-style
 /// references. Invalid references and syntax errors remain unchanged.
 #[wasm_bindgen]
-pub fn convert_formula_abs_to_rel(formula_string: &str, x: f64, y: f64) -> String {
+pub fn convert_formula_a1_to_rc(formula_string: &str, x: f64, y: f64) -> String {
     let x = x as i64;
     let y = y as i64;
     let pos = Pos { x, y };
@@ -188,7 +188,7 @@ pub fn convert_formula_abs_to_rel(formula_string: &str, x: f64, y: f64) -> Strin
 /// Replaces all valid RC-style references in a formula with A1-style
 /// references. Invalid references and syntax errors remain unchanged.
 #[wasm_bindgen]
-pub fn convert_formula_rel_to_abs(formula_string: &str, x: f64, y: f64) -> String {
+pub fn convert_formula_rc_to_a1(formula_string: &str, x: f64, y: f64) -> String {
     let x = x as i64;
     let y = y as i64;
     let pos = Pos { x, y };

--- a/quadratic-core/src/lib.rs
+++ b/quadratic-core/src/lib.rs
@@ -158,7 +158,7 @@ impl From<formulas::Spanned<formulas::RangeRef>> for JsCellRefSpan {
 /// `parse_error_msg` may be null, and `parse_error_span` may be null. Even if
 /// `parse_error_span`, `parse_error_msg` may still be present.
 #[wasm_bindgen]
-pub async fn parse_formula(formula_string: &str, cfg: ParseConfig) -> JsValue {
+pub fn parse_formula(formula_string: &str, cfg: ParseConfig) -> JsValue {
     let parse_error = formulas::parse_formula(formula_string, cfg).err();
 
     let result = JsFormulaParseResult {
@@ -177,7 +177,7 @@ pub async fn parse_formula(formula_string: &str, cfg: ParseConfig) -> JsValue {
 /// Replaces all valid A1-style references in a formula with RC-style
 /// references. Invalid references and syntax errors remain unchanged.
 #[wasm_bindgen]
-pub async fn convert_formula_abs_to_rel(formula_string: &str, x: f64, y: f64) -> String {
+pub fn convert_formula_abs_to_rel(formula_string: &str, x: f64, y: f64) -> String {
     let x = x as i64;
     let y = y as i64;
     let pos = Pos { x, y };
@@ -188,7 +188,7 @@ pub async fn convert_formula_abs_to_rel(formula_string: &str, x: f64, y: f64) ->
 /// Replaces all valid RC-style references in a formula with A1-style
 /// references. Invalid references and syntax errors remain unchanged.
 #[wasm_bindgen]
-pub async fn convert_formula_rel_to_abs(formula_string: &str, x: f64, y: f64) -> String {
+pub fn convert_formula_rel_to_abs(formula_string: &str, x: f64, y: f64) -> String {
     let x = x as i64;
     let y = y as i64;
     let pos = Pos { x, y };

--- a/quadratic-core/src/position.rs
+++ b/quadratic-core/src/position.rs
@@ -16,8 +16,11 @@ pub struct Pos {
 #[wasm_bindgen]
 impl Pos {
     #[wasm_bindgen(constructor)]
-    pub fn new(x: i64, y: i64) -> Self {
-        Self { x, y }
+    pub fn new(x: f64, y: f64) -> Self {
+        Self {
+            x: x as i64,
+            y: y as i64,
+        }
     }
 }
 impl Pos {

--- a/src/grid/computations/formulas/runFormula.ts
+++ b/src/grid/computations/formulas/runFormula.ts
@@ -12,7 +12,7 @@ export interface runFormulaReturnType {
 }
 
 export async function runFormula(formula_code: string, pos: Coordinate): Promise<runFormulaReturnType> {
-  const cfg = new ParseConfig(new Pos(pos.x, pos.y), CellRefNotation.A1);
+  const cfg = new ParseConfig(new Pos(pos.x, pos.y), CellRefNotation.RC);
   const output = await eval_formula(formula_code, GetCellsDB, cfg);
 
   return output as runFormulaReturnType;

--- a/src/grid/computations/formulas/runFormula.ts
+++ b/src/grid/computations/formulas/runFormula.ts
@@ -1,4 +1,4 @@
-import { eval_formula } from 'quadratic-core';
+import { eval_formula, CellRefNotation, ParseConfig, Pos } from 'quadratic-core';
 import { GetCellsDB } from '../../sheet/Cells/GetCellsDB';
 import { Coordinate } from '../../../gridGL/types/size';
 
@@ -12,7 +12,8 @@ export interface runFormulaReturnType {
 }
 
 export async function runFormula(formula_code: string, pos: Coordinate): Promise<runFormulaReturnType> {
-  const output = await eval_formula(formula_code, pos.x, pos.y, GetCellsDB);
+  const cfg = new ParseConfig(new Pos(pos.x, pos.y), CellRefNotation.A1);
+  const output = await eval_formula(formula_code, GetCellsDB, cfg);
 
   return output as runFormulaReturnType;
 }


### PR DESCRIPTION
`parse_formula()` and similar functions now take a `ParseConfig` which contains the position from which to parse/evaluate the formula and the reference notation, which is either A1 or RC.

- [x] Add `convert_formula_abs_to_rel()` and `convert_formula_rel_to_abs()`
- [x] Convert when opening editor and when saving formula
- [ ] Migrate file format to store relative references

Behavior that we want:
- [x] Autocompleting a range keeps references relative
- [ ] Moving cells keeps references absolute
- [ ] Copy/pasting cells keeps references absolute