### PR TITLE
Improve README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,26 +6,37 @@ Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approacha
 
 In this guide, you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
 
-## Getting started
+If you have any problems getting the project to run locally, please create an issue to document the problem. See ["Create an issue"](#create-an-issue) below.
 
-Make sure you can run Quadratic locally from the source.
+## Setup
 
-1. Install npm, [rustup](https://www.rust-lang.org/tools/install), and [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
-2. Run `rustup target add wasm32-unknown-unknown`
-3. Build the Rust/WASM `npm run build:wasm`
-4. run `npm install`
+1. Install NPM
+2. Install [rustup](https://www.rust-lang.org/tools/install)
+3. Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+4. `rustup target add wasm32-unknown-unknown` to install the WASM toolchain
 
-To run the web app: `npm start`
+## Run Quadratic locally
 
-To run the Electron app: `npm run dev`
+1. `npm run build:wasm` to compile the Rust code
+2. `npm install` to install dependencies (run again when updating Rust)
+3. `npm start` to run in browser or `npm run dev` to run with Electron
 
-If you have any problems getting the project to run locally, please create an issue to document the problem. See "Create an issue" below.
+### Run tests (TypeScript)
 
-### Issues for Feature Requests and Bugs
+1. `npm run build:wasm:nodejs` to compile the Rust code
+2. `npm install` to install dependencies (run again when updating Rust)
+3. `npm run test:all` to run all tests or `npm run test:unit` to run just unit tests
 
-Quadratic uses GitHub issues to track all feature requests and bugs.
+### Run tests (Rust)
 
-#### Create an issue
+1. `cd quadratic-core`
+2. `cargo test --workspace`
+
+## Feature requests and bugs
+
+Quadratic uses [GitHub issues](https://github.com/quadratichq/quadratic/issues) to track all feature requests and bugs.
+
+### Create an issue
 
 If you have a feature request or spot a problem, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue does not exist, please open a new issue!
 
@@ -37,34 +48,33 @@ When reporting a bug, please provide:
 - What's the actual result?
 - Additional details / screenshots
 
-#### Solve an issue
+### Solve an issue
 
 Scan through our [existing issues](https://github.com/quadratichq/quadratic/issues) to find one that interests you. You can narrow down the search using `labels` as filters. See [Labels](/contributing/how-to-use-labels.md) for more information.
 
-#### How to contribute code
+### How to contribute code
 
 1. Fork the repository.
-
-1. Run Quadratic locally. See "Getting Started" above.
-
-1. Create a new working branch and start making your changes!
-
-1. Lint and format your changes using Prettier.
+2. Run Quadratic locally. See "Getting Started" above.
+3. Create a new working branch and start making your changes!
+4. Lint and format your changes using Prettier.
 
 ### Pull Request
 
 When you're finished with your changes:
 
 1. Create a pull request.
-
-1. Link your PR to the GitHub Issue [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are working on an Issue.
-
-1. Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
+2. Link your PR to the GitHub Issue [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are working on an Issue.
+3. Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
 
 We review all PRs quickly, so we will give you feedback in short order!
 
 ### Your PR is merged
 
-Congratulations :tada::tada: Quadratic is better because of you :sparkles:.
+Congratulations! :tada::tada: Quadratic is better because of you. :sparkles:
 
 Once your PR is merged, contributors will be publicly visible on the GitHub Page.
+
+## Quadratic is hiring
+
+Check out our open roles ⟶ [careers.quadratichq.com](https://careers.quadratichq.com)

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Infinite data grid with Python, JavaScript, and SQL built-in. Data Connectors to
 
 Take your data and do something useful with it as quickly and easily as possible!
 
-<img width="1552" alt="Screenshot 2023-02-24 at 2 57 36 PM" src="https://user-images.githubusercontent.com/3479421/221301059-921ad96a-878e-4082-b3b9-e55a54185c5d.png">
+<img width="1552" alt="Quadratic in a standalone macOS window; on the left is a table of stock prices, and on the right is a code editor containing Python code to fetch the stock prices from Polygon's API" src="https://user-images.githubusercontent.com/3479421/221301059-921ad96a-878e-4082-b3b9-e55a54185c5d.png">
 
 ## Online demo
 
 We have a hosted version of the `main` branch available online.
 
-**Try it out! --> <https://app.quadratichq.com>**
+**Try it out! ⟶ <https://app.quadratichq.com>**
 
 ## Community
 
-Join the conversation on our Discord channel -> <https://discord.gg/quadratic>
+Join the conversation on our Discord channel ⟶ <https://discord.gg/quadratic>
 
 ## Documentation
 
-Read the documentation -> <https://docs.quadratichq.com>
+Read the documentation ⟶ <https://docs.quadratichq.com>
 
 # What is Quadratic?
 
@@ -39,20 +39,7 @@ Quadratic has no environment to configure. The grid runs entirely in the browser
 - Quickly mix data from different sources
 - Explore your data for new insights
 
-# Getting started
-
-### Run Quadratic locally
-
-1. Install npm, [rustup](https://www.rust-lang.org/tools/install), and [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
-2. Run `rustup target add wasm32-unknown-unknown`
-3. Build the Rust/WASM `npm run build:wasm`
-4. run `npm install`
-
-Run Web `npm start`
-
-Run Electron `npm run dev`
-
-# Development progress and roadmap
+## Development progress and roadmap
 
 _Quadratic is in ALPHA. For now, we do not recommend relying on Quadratic._
 
@@ -75,10 +62,10 @@ Want to learn more about how Quadratic works? Read the [How Quadratic Works](./d
 
 ## Examples
 
-There are more example files are in the application file menu. File > Open sample
+There are more example files are in the application file menu. File → Open sample
 
-You can download them and then open them in Quadratic via File > Open Grid
+You can download them and then open them in Quadratic via File → Open Grid
 
 ## Quadratic is hiring
 
-Check out our open roles -> [careers.quadratichq.com](https://careers.quadratichq.com)
+Check out our open roles ⟶ [careers.quadratichq.com](https://careers.quadratichq.com)


### PR DESCRIPTION
- Add instructions for running tests to `CONTRIBUTING.md`
- Add "Quadratic is hiring" message to the end of `CONTRIBUTING.md`
- Remove dev instructions from `README.md` (there's already a link to `CONTRIBUTING.md`)
- Add descriptive alt text to screenshot for accessibility
- Replace `-->`, `->`, and `>` with real arrows
- Minor formatting changes
