### PR TITLE
feat: add Open AI example file

### DIFF
--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -25,9 +25,9 @@ export const EXAMPLE_FILES = [
     description: 'Example of pulling data from the Mercury API.',
   },
   {
-    name: 'Open AI (example)',
+    name: 'OpenAI (example)',
     file: 'open_ai.grid',
-    description: 'Example prompt querying the Open AI API.',
+    description: 'Example prompt querying the OpenAI API.',
   },
   // Leaving this one out, as it has nothing useful for users
   // { name: 'Airports large (example)', file: 'airports_large.grid', description: 'Lorem ipsum santa dolor.' },

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -24,6 +24,11 @@ export const EXAMPLE_FILES = [
     file: 'mercury_bank.grid',
     description: 'Example of pulling data from the Mercury API.',
   },
+  {
+    name: 'Open AI (example)',
+    file: 'open_ai.grid',
+    description: 'Example prompt querying the Open AI API.',
+  },
   // Leaving this one out, as it has nothing useful for users
   // { name: 'Airports large (example)', file: 'airports_large.grid', description: 'Lorem ipsum santa dolor.' },
   {


### PR DESCRIPTION
Example file is already in the repo, so it's just a matter of registering it with the UI as an example.

<img width="838" alt="CleanShot 2023-05-22 at 19 58 46@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/05a3cd33-a946-4c98-9e84-3e94758cda68">
