### PR TITLE
fix: allow anything in `array_output`

### DIFF
--- a/src/schemas/GridFileV1_2.ts
+++ b/src/schemas/GridFileV1_2.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { GridFileV1_1 } from './GridFileV1_1';
 
 // Shared schemas
-const ArrayOutputBaseSchema = z.array(z.union([z.string(), z.number(), z.boolean(), z.null()]));
+const ArrayOutputBaseSchema = z.array(z.any());
 const BorderDirectionSchema = z.object({
   color: z.string().optional(),
   type: z.enum(['line1', 'line2', 'line3', 'dotted', 'dashed', 'double']).optional(),


### PR DESCRIPTION
Fixes #415 

I opted to just change the existing version `1.2` file schema, rather than create a new one, since this change is additive and merely accepts more kinds of data in `array_output` than what was being allowed previously. 

Previously: `array_output` was an optional 1 or 2d array of string, number, boolean, or null.
Now: `array_output` is an optional 1 or 2d array of anything.

### To Test

- Open a new file, name it "This shouldn't be busted"
- For a python cell, return the value `[[[1,2,3]]]`
  - <img width="523" alt="CleanShot 2023-06-13 at 13 50 58@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/683367ce-9858-4d82-9722-5181bcaf001b">
- For another python cell, return the value `[{1}, {2}]`
  - <img width="518" alt="CleanShot 2023-06-13 at 13 51 25@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/2cf4698e-5790-4ea6-b84a-a0b41697531f">
- Create another new file in the app and make 1 edit (anything)
- Reopen the "This shouldn't be busted" file and see that it opens and appears the same as when you closed it
  - <img width="259" alt="CleanShot 2023-06-13 at 13 51 54@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/8f95ea5a-1546-4c30-8160-2fc77aebb654">
