### PR TITLE
remove extra focusGrid call

### DIFF
--- a/src/hooks/useGenerateLocalFiles.tsx
+++ b/src/hooks/useGenerateLocalFiles.tsx
@@ -14,7 +14,6 @@ import { editorInteractionStateAtom } from '../atoms/editorInteractionStateAtom'
 import { DEFAULT_FILE_NAME, EXAMPLE_FILES, FILE_PARAM_KEY } from '../constants/app';
 import apiClientSingleton from '../api-client/apiClientSingleton';
 import mixpanel from 'mixpanel-browser';
-import { focusGrid } from '../helpers/focusGrid';
 const INDEX = 'file-list';
 
 export interface LocalFile {
@@ -85,7 +84,6 @@ export const useGenerateLocalFiles = (sheetController: SheetController): LocalFi
       sheetController.sheet.load_file(grid);
       sheetController.app?.rebuild();
       sheetController.app?.reset();
-      focusGrid();
       const searchParams = new URLSearchParams(window.location.search);
       // If `file` is in there from an intial page load, remove it
       if (searchParams.get('file')) {


### PR DESCRIPTION
Removes extra `focusGrid()` call in `useGenerateLocalFiles.ts` that threw a warning on load.