### PR TITLE
Fix `ATAN2(0, 0)` semantics

### DIFF
--- a/quadratic-core/Cargo.lock
+++ b/quadratic-core/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quadratic-core"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Andrew Farkas <andrew.farkas@quadratic.to>"]
 edition = "2021"
 description = "Infinite data grid with Python, JavaScript, and SQL built-in"

--- a/quadratic-core/src/formulas/functions/trigonometry.rs
+++ b/quadratic-core/src/formulas/functions/trigonometry.rs
@@ -102,7 +102,10 @@ fn get_functions() -> Vec<FormulaFunction> {
             /// function](https://en.wikipedia.org/wiki/Atan2).
             #[examples("ATAN2(2, 1)")]
             #[pure_zip_map]
-            fn ATAN2([x]: f64, [y]: f64) {
+            fn ATAN2(span: Span, [x]: f64, [y]: f64) {
+                if x == 0.0 && y == 0.0 {
+                    return Err(FormulaErrorMsg::DivideByZero.with_span(span));
+                }
                 f64::atan2(y, x)
             }
         ),
@@ -472,5 +475,18 @@ mod tests {
             (1.000161412, 1.5 * PI),
         ];
         test_trig_fn("ACOTH", test_cases);
+    }
+
+    #[test]
+    fn test_atan2() {
+        let g = &mut NoGrid;
+
+        assert_eq!("0", eval_to_string(g, "ATAN2(1, 0)"));
+        assert!(eval_to_string(g, "ATAN2(0, 1)").starts_with("1.57"));
+        assert!(eval_to_string(g, "ATAN2(1, 2)").starts_with("1.107"));
+        assert_eq!(
+            FormulaErrorMsg::DivideByZero,
+            eval_to_err(g, "ATAN2(0, 0)").msg,
+        );
     }
 }

--- a/quadratic-core/src/formulas/functions/trigonometry.rs
+++ b/quadratic-core/src/formulas/functions/trigonometry.rs
@@ -100,6 +100,8 @@ fn get_functions() -> Vec<FormulaFunction> {
             /// to the point `(x, y)`. Note that the argument order is reversed
             /// compared to the [typical `atan2()`
             /// function](https://en.wikipedia.org/wiki/Atan2).
+            ///
+            /// If both arguments are zero, returns zero.
             #[examples("ATAN2(2, 1)")]
             #[pure_zip_map]
             fn ATAN2(span: Span, [x]: f64, [y]: f64) {


### PR DESCRIPTION
In Excel, `ATAN(0, 0)` returns zero. This changes Quadratic's behavior to match Excel