### PR TITLE
Add boolean parsing in formulas

### DIFF
--- a/quadratic-core/Cargo.lock
+++ b/quadratic-core/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quadratic-core"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Andrew Farkas <andrew.farkas@quadratic.to>"]
 edition = "2021"
 description = "Infinite data grid with Python, JavaScript, and SQL built-in"

--- a/quadratic-core/src/formulas/ast.rs
+++ b/quadratic-core/src/formulas/ast.rs
@@ -29,6 +29,7 @@ pub enum AstNodeContents {
     CellRef(CellRef),
     String(String),
     Number(f64),
+    Bool(bool),
 }
 impl fmt::Display for AstNodeContents {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -53,6 +54,8 @@ impl fmt::Display for AstNodeContents {
             AstNodeContents::CellRef(cellref) => write!(f, "{cellref}"),
             AstNodeContents::String(s) => write!(f, "{s:?}"),
             AstNodeContents::Number(n) => write!(f, "{n:?}"),
+            AstNodeContents::Bool(false) => write!(f, "FALSE"),
+            AstNodeContents::Bool(true) => write!(f, "TRUE"),
         }
     }
 }
@@ -69,6 +72,7 @@ impl AstNodeContents {
             AstNodeContents::CellRef(_) => "cell reference",
             AstNodeContents::String(_) => "string literal",
             AstNodeContents::Number(_) => "numeric literal",
+            AstNodeContents::Bool(_) => "boolean literal",
         }
     }
 }
@@ -198,8 +202,8 @@ impl AstNode {
             }
 
             AstNodeContents::String(s) => Value::from(s.to_string()),
-
             AstNodeContents::Number(n) => Value::from(*n),
+            AstNodeContents::Bool(b) => Value::from(*b),
         };
 
         Ok(Spanned {

--- a/quadratic-core/src/formulas/functions/logic.rs
+++ b/quadratic-core/src/formulas/functions/logic.rs
@@ -17,6 +17,7 @@ fn get_functions() -> Vec<FormulaFunction> {
     vec![
         formula_fn!(
             /// Returns `TRUE`.
+            #[include_args_in_completion(false)]
             #[examples("TRUE()")]
             fn TRUE() {
                 true
@@ -24,6 +25,7 @@ fn get_functions() -> Vec<FormulaFunction> {
         ),
         formula_fn!(
             /// Returns `FALSE`.
+            #[include_args_in_completion(false)]
             #[examples("FALSE()")]
             fn FALSE() {
                 false

--- a/quadratic-core/src/formulas/functions/macros.rs
+++ b/quadratic-core/src/formulas/functions/macros.rs
@@ -107,7 +107,7 @@ macro_rules! formula_fn {
     ) => {
         $crate::formulas::functions::FormulaFunction {
             name: $fn_name,
-            arg_completion: "",
+            arg_completion: None,
             usage: "",
             examples: &[],
             doc: "",
@@ -122,14 +122,21 @@ macro_rules! formula_fn {
     (
         #[doc = $doc:expr]
         $(#[doc = $additional_doc:expr])*
+        $(#[include_args_in_completion($include_args_in_completion:expr)])?
         #[examples($($example_str:expr),+ $(,)?)]
         $(#[$($attr:tt)*])*
         fn $fn_name:ident( $($params:tt)* ) { $($body:tt)* }
     ) => {{
         let params_list = params_list!($($params)*);
+
+        // Default to `true`
+        let include_args_in_completion = [$($include_args_in_completion, )? true][0];
+
         $crate::formulas::functions::FormulaFunction {
             name: stringify!($fn_name),
-            arg_completion: $crate::formulas::params::arg_completion_string(&params_list),
+            arg_completion: include_args_in_completion.then(|| {
+                $crate::formulas::params::arg_completion_string(&params_list)
+            }),
             usage: $crate::formulas::params::usage_string(&params_list),
             examples: &[$($example_str),+],
             doc: concat!($doc $(, "\n", $additional_doc)*),

--- a/quadratic-core/src/formulas/functions/mod.rs
+++ b/quadratic-core/src/formulas/functions/mod.rs
@@ -116,7 +116,7 @@ pub type FormulaFn =
 /// Formula function with associated metadata.
 pub struct FormulaFunction {
     pub name: &'static str,
-    pub arg_completion: &'static str,
+    pub arg_completion: Option<&'static str>,
     pub usage: &'static str,
     pub examples: &'static [&'static str],
     pub doc: &'static str,
@@ -134,8 +134,10 @@ impl FormulaFunction {
     /// Returns the autocomplete snippet for this function.
     pub fn autocomplete_snippet(&self) -> String {
         let name = self.name;
-        let arg_completion = self.arg_completion;
-        format!("{name}({arg_completion})")
+        match self.arg_completion {
+            Some(arg_completion) => format!("{name}({arg_completion})"),
+            None => name.to_string(),
+        }
     }
 
     /// Returns the Markdown documentation for this function that should appear
@@ -161,4 +163,34 @@ pub struct FormulaFunctionCategory {
     pub name: &'static str,
     pub docs: &'static str,
     pub get_functions: fn() -> Vec<FormulaFunction>,
+}
+
+#[test]
+fn test_autocomplete_snippet() {
+    assert_eq!(
+        "TRUE",
+        ALL_FUNCTIONS.get("TRUE").unwrap().autocomplete_snippet(),
+    );
+    assert_eq!(
+        "PI()",
+        ALL_FUNCTIONS.get("PI").unwrap().autocomplete_snippet(),
+    );
+    assert_eq!(
+        "NOT(${1:boolean})",
+        ALL_FUNCTIONS.get("NOT").unwrap().autocomplete_snippet(),
+    );
+    assert_eq!(
+        "IF(${1:condition}, ${2:t}, ${3:f})",
+        ALL_FUNCTIONS.get("IF").unwrap().autocomplete_snippet(),
+    );
+    assert_eq!(
+        "IF(${1:condition}, ${2:t}, ${3:f})",
+        ALL_FUNCTIONS.get("IF").unwrap().autocomplete_snippet(),
+    );
+
+    // Optional
+    assert_eq!(
+        "SUMIF(${1:eval_range}, ${2:criteria}${3:, ${4:[numbers_range]}})",
+        ALL_FUNCTIONS.get("SUMIF").unwrap().autocomplete_snippet(),
+    );
 }

--- a/quadratic-core/src/formulas/lexer.rs
+++ b/quadratic-core/src/formulas/lexer.rs
@@ -1,7 +1,7 @@
 //! Functions for lossless tokenization.
 
 use lazy_static::lazy_static;
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 use strum_macros::Display;
 
 use super::{Span, Spanned};
@@ -75,6 +75,8 @@ const TOKEN_PATTERNS: &[&str] = &[
     UNTERMINATED_STRING_LITERAL_PATTERN,
     // Numeric literal.
     NUMERIC_LITERAL_PATTERN,
+    // Boolean literal (case-insensitive).
+    r#"false|true"#,
     // Function call.
     FUNCTION_CALL_PATTERN,
     // Reference to a cell.
@@ -89,7 +91,7 @@ lazy_static! {
     /// Single regex that matches any token, including comments and strings,
     /// by joining each member of `TOKEN_PATTERNS` with "|".
     pub static ref TOKEN_REGEX: Regex =
-        Regex::new(&TOKEN_PATTERNS.join("|")).unwrap();
+        RegexBuilder::new(&TOKEN_PATTERNS.join("|")).case_insensitive(true).build().unwrap();
 
     /// Regex that matches a valid function call.
     pub static ref FUNCTION_CALL_REGEX: Regex =
@@ -175,6 +177,12 @@ pub enum Token {
     #[strum(to_string = "ellipsis")]
     Ellipsis, // ...
 
+    // Booleans
+    #[strum(to_string = "FALSE")]
+    False,
+    #[strum(to_string = "TRUE")]
+    True,
+
     // Comments
     #[strum(to_string = "comment")]
     Comment,
@@ -231,6 +239,8 @@ impl Token {
             "%" => Self::Percent,
             ":" => Self::CellRangeOp,
             "..." => Self::Ellipsis,
+            s if s.eq_ignore_ascii_case("false") => Self::False,
+            s if s.eq_ignore_ascii_case("true") => Self::True,
 
             // Match a line comment.
             s if s.starts_with("//") => Self::Comment,

--- a/quadratic-core/src/formulas/lexer.rs
+++ b/quadratic-core/src/formulas/lexer.rs
@@ -239,8 +239,6 @@ impl Token {
             "%" => Self::Percent,
             ":" => Self::CellRangeOp,
             "..." => Self::Ellipsis,
-            s if s.eq_ignore_ascii_case("false") => Self::False,
-            s if s.eq_ignore_ascii_case("true") => Self::True,
 
             // Match a line comment.
             s if s.starts_with("//") => Self::Comment,
@@ -275,6 +273,8 @@ impl Token {
             s if FUNCTION_CALL_REGEX.is_match(s) => Self::FunctionCall,
             s if STRING_LITERAL_REGEX.is_match(s) => Self::StringLiteral,
             s if UNTERMINATED_STRING_LITERAL_REGEX.is_match(s) => Self::UnterminatedStringLiteral,
+            s if s.eq_ignore_ascii_case("false") => Self::False,
+            s if s.eq_ignore_ascii_case("true") => Self::True,
             s if NUMERIC_LITERAL_REGEX.is_match(s) => Self::NumericLiteral,
             s if A1_CELL_REFERENCE_REGEX.is_match(s) => Self::CellRef,
             s if s.trim().is_empty() => Self::Whitespace,

--- a/quadratic-core/src/formulas/lexer.rs
+++ b/quadratic-core/src/formulas/lexer.rs
@@ -75,10 +75,10 @@ const TOKEN_PATTERNS: &[&str] = &[
     UNTERMINATED_STRING_LITERAL_PATTERN,
     // Numeric literal.
     NUMERIC_LITERAL_PATTERN,
-    // Boolean literal (case-insensitive).
-    r#"false|true"#,
     // Function call.
     FUNCTION_CALL_PATTERN,
+    // Boolean literal (case-insensitive).
+    r#"false|true"#,
     // Reference to a cell.
     A1_CELL_REFERENCE_PATTERN,
     // Whitespace.

--- a/quadratic-core/src/formulas/parser/rules/atoms.rs
+++ b/quadratic-core/src/formulas/parser/rules/atoms.rs
@@ -127,3 +127,26 @@ impl SyntaxRule for CellRangeReference {
         })
     }
 }
+
+#[derive(Debug, Copy, Clone)]
+pub struct BoolExpression;
+impl_display!(for BoolExpression, "boolean, either 'TRUE' or 'FALSE'");
+impl SyntaxRule for BoolExpression {
+    type Output = AstNode;
+
+    fn prefix_matches(&self, mut p: Parser<'_>) -> bool {
+        matches!(p.next(), Some(Token::False | Token::True))
+    }
+
+    fn consume_match(&self, p: &mut Parser<'_>) -> FormulaResult<Self::Output> {
+        let b = match p.next() {
+            Some(Token::False) => false,
+            Some(Token::True) => true,
+            _ => p.expected(self)?,
+        };
+        return Ok(AstNode {
+            span: p.span(),
+            inner: ast::AstNodeContents::Bool(b),
+        });
+    }
+}

--- a/quadratic-core/src/formulas/parser/rules/expression.rs
+++ b/quadratic-core/src/formulas/parser/rules/expression.rs
@@ -134,6 +134,8 @@ impl SyntaxRule for ExpressionWithPrecedence {
                 | Token::CellRangeOp
                 | Token::Ellipsis => false,
 
+                Token::False | Token::True => true,
+
                 Token::Comment | Token::UnterminatedBlockComment => false,
 
                 Token::FunctionCall
@@ -161,6 +163,7 @@ impl SyntaxRule for ExpressionWithPrecedence {
                     NumericLiteral.map(Some),
                     ArrayLiteral.map(Some),
                     CellReference.map(Some),
+                    BoolExpression.map(Some),
                     ParenExpression.map(Some),
                     Epsilon.map(|_| None),
                 ],

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -219,6 +219,16 @@ fn test_array_parsing() {
 }
 
 #[test]
+fn test_bool_parsing() {
+    let g = &mut NoGrid;
+
+    assert_eq!("1", eval_to_string(g, "IF(TRUE, 1, 2)"));
+    assert_eq!("1", eval_to_string(g, "IF(true(), 1, 2)"));
+    assert_eq!("2", eval_to_string(g, "IF(False, 1, 2)"));
+    assert_eq!("2", eval_to_string(g, "IF(FALSE(), 1, 2)"));
+}
+
+#[test]
 fn test_leading_equals() {
     assert_eq!("7", eval_to_string(&mut NoGrid, "=3+4"));
     assert_eq!("7", eval_to_string(&mut NoGrid, "= 3+4"));

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -242,6 +242,7 @@ fn test_hyphen_after_cell_ref() {
     assert_eq!("25", eval_to_string(&mut g, "Z1-5"));
 }
 
+#[test]
 fn test_find_cell_references() {
     use CellRefCoord::{Absolute, Relative};
 


### PR DESCRIPTION
This PR makes `TRUE` and `FALSE` work directly in formulas. So `IF(TRUE(), 1, 2)` is equivalent to `IF(TRUE, 1, 2)`. This is consistent with Excel.