### PR TITLE
chore: upgrade API to node 20 and typescript 5

### DIFF
--- a/quadratic-api/package-lock.json
+++ b/quadratic-api/package-lock.json
@@ -25,10 +25,11 @@
         "openai": "^3.2.1",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^4.9.3",
+        "typescript": "^5.1.3",
         "zod": "^3.21.4"
       },
       "devDependencies": {
+        "@tsconfig/node20": "^1.0.1",
         "@types/cors": "^2.8.12",
         "dotenv-cli": "^7.1.0",
         "prisma": "^4.12.0"
@@ -205,6 +206,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-1.0.1.tgz",
+      "integrity": "sha512-ovd+Yu8j7zgVXA3jRfLRXGknScbVwg9p+R9k4/0EVJzymxokkyoib2Hjt1A2hGK5qehqBIwV8NYvUF/rG+2+wQ==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -1972,15 +1979,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undefsafe": {
@@ -2198,6 +2205,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
+    },
+    "@tsconfig/node20": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-1.0.1.tgz",
+      "integrity": "sha512-ovd+Yu8j7zgVXA3jRfLRXGknScbVwg9p+R9k4/0EVJzymxokkyoib2Hjt1A2hGK5qehqBIwV8NYvUF/rG+2+wQ==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -3532,9 +3545,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw=="
     },
     "undefsafe": {
       "version": "2.0.5",

--- a/quadratic-api/package.json
+++ b/quadratic-api/package.json
@@ -31,15 +31,16 @@
     "openai": "^3.2.1",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.9.3",
+    "typescript": "^5.1.3",
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@tsconfig/node20": "^1.0.1",
     "@types/cors": "^2.8.12",
     "dotenv-cli": "^7.1.0",
     "prisma": "^4.12.0"
   },
   "engines": {
-    "node": "18.x"
+    "node": "20.x"
   }
 }

--- a/quadratic-api/tsconfig.json
+++ b/quadratic-api/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist"
   },
-  "strict": true,
   "sourceMap": true,
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Previously, our typescript config was set to node 16, but our node engine was set to 18 (a mismatch).

This PR upgrades to node 20 (which [goes LTS in October](https://github.com/nodejs/release#release-schedule)), typescript 5, and a matching tsconfig that extends `@tsconfig/node20`.

To test (locally):

- Upgrade local version of node to v20.x
- `cd quadratic-api` and  `npm i` and `npm start`
- Ensure the app runs

<img width="603" alt="CleanShot 2023-06-22 at 12 02 26@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/bcbe758d-7950-4e9a-8469-61720e10705d">

To test (staging):

- Promote this branch in staging, and see that node 20 is installed and runs

<img width="437" alt="CleanShot 2023-06-22 at 12 12 35@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/6cf9fedd-ce63-44b0-9e7d-308fc24986ed">

**Merge note:** [Heroku says](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version) they key off the `engine` in `package.json` so, once merged, I'm assuming heroku will automatically update to node20.