### PR TITLE
fix: allow any for array_output in older versions of the schema

### DIFF
--- a/src/schemas/GridFileV1.ts
+++ b/src/schemas/GridFileV1.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-const ArrayOutputSchema = z.array(z.union([z.string(), z.number(), z.boolean()]));
+const ArrayOutputSchema = z.array(z.any());
 
 export enum BorderType {
   line1 = 0,

--- a/src/schemas/GridFileV1_1.ts
+++ b/src/schemas/GridFileV1_1.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { DEFAULT_FILE_NAME } from '../constants/app';
 
 // Shared schemas
-const ArrayOutputSchema = z.array(z.union([z.string(), z.number(), z.boolean()]));
+const ArrayOutputSchema = z.array(z.any());
 const BorderDirectionSchema = z.object({
   color: z.string().optional(),
   type: z.enum(['line1', 'line2', 'line3', 'dotted', 'dashed', 'double']).optional(),

--- a/src/schemas/validateGridFile.test.ts
+++ b/src/schemas/validateGridFile.test.ts
@@ -35,7 +35,27 @@ const v1File: GridFileV1 = {
 
 const v1_1File: GridFileV1_1 = {
   version: '1.1',
-  cells: [],
+  cells: [
+    // Test to allow `any` for `array_output`
+    {
+      x: 0,
+      y: 0,
+      type: 'PYTHON',
+      value: '1,2,3',
+      last_modified: '2023-06-27T16:54:40.619Z',
+      evaluation_result: {
+        success: true,
+        std_out: '',
+        output_value: '[[[1, 2, 3]]]',
+        cells_accessed: [],
+        array_output: [[[1, 2, 3]]],
+        formatted_code: '[[[1, 2, 3]]]\n',
+        error_span: null,
+      },
+      python_code: '[[[1,2,3]]]',
+      array_cells: [[0, 0]],
+    },
+  ],
   columns: [],
   rows: [],
   borders: [],

--- a/src/schemas/validateGridFile.ts
+++ b/src/schemas/validateGridFile.ts
@@ -44,7 +44,7 @@ export function validateGridFile(jsonFile: {}): GridFile | null {
   }
 
   if (!isValid) {
-    console.error('[validateGridFile] failed to validate file with zod.', errors);
+    if (debugShowFileIO) console.log('[validateGridFile] failed to validate file with zod.', errors);
     return null;
   }
 

--- a/src/schemas/validateGridFile.ts
+++ b/src/schemas/validateGridFile.ts
@@ -44,7 +44,7 @@ export function validateGridFile(jsonFile: {}): GridFile | null {
   }
 
   if (!isValid) {
-    if (debugShowFileIO) console.log('[validateGridFile] failed to validate file with zod.', errors);
+    console.error('[validateGridFile] failed to validate file with zod.', errors);
     return null;
   }
 


### PR DESCRIPTION
v1.2 version of the file schema allowed `any` for `array_output` to fix a bug (#561)

but if older versions of files have those same errors but are otherwise valid, they'll fail to load.

this makes it so (retroactively) we make previous file versions support `any` for `array_output` (as the code would, sometimes, support writing files out in an "invalid" way with more than just string|number|boolean in `array_output`)

**To test:**

- Try to import a v1.1 version of a file where the `array_output` is a value that's supported in v1.2 ([test-file.grid.txt](https://github.com/quadratichq/quadratic/files/11885332/test-file.grid.txt))
- Ensure that the file imports correctly