### PR TITLE
feat: enhance AI assistant ui/x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "ace-builds": "^1.4.13",
         "axios": "^0.24.0",
         "color": "^4.2.3",
+        "common-tags": "^1.8.2",
         "date-fns": "^2.28.0",
         "fontfaceobserver": "^2.3.0",
         "fuzzysort": "^2.0.4",
@@ -58,6 +59,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.22.2",
+        "@types/common-tags": "^1.8.1",
         "@types/lodash.debounce": "^4.0.7",
         "@types/mixpanel-browser": "^2.38.1",
         "@types/papaparse": "^5.3.7",
@@ -5634,6 +5636,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "node_modules/@types/common-tags": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.1.tgz",
+      "integrity": "sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==",
+      "dev": true
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
@@ -22210,7 +22218,7 @@
     },
     "quadratic-core/pkg": {
       "name": "quadratic-core",
-      "version": "0.1.0",
+      "version": "0.1.7",
       "license": "MIT"
     }
   },
@@ -26201,6 +26209,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/common-tags": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.1.tgz",
+      "integrity": "sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.35",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ace-builds": "^1.4.13",
     "axios": "^0.24.0",
     "color": "^4.2.3",
+    "common-tags": "^1.8.2",
     "date-fns": "^2.28.0",
     "fontfaceobserver": "^2.3.0",
     "fuzzysort": "^2.0.4",
@@ -108,6 +109,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.22.2",
+    "@types/common-tags": "^1.8.1",
     "@types/lodash.debounce": "^4.0.7",
     "@types/mixpanel-browser": "^2.38.1",
     "@types/papaparse": "^5.3.7",

--- a/src/ui/components/CodeSnippet.tsx
+++ b/src/ui/components/CodeSnippet.tsx
@@ -3,6 +3,7 @@ import Editor from '@monaco-editor/react';
 import { Box, IconButton, Stack, useTheme } from '@mui/material';
 import { ContentCopy } from '@mui/icons-material';
 import { TooltipHint } from './TooltipHint';
+import { codeEditorBaseStyles } from '../menus/CodeEditor/styles';
 
 interface Props {
   code: string;
@@ -28,14 +29,8 @@ export function CodeSnippet({ code, language = 'plaintext' }: Props) {
     editorRef.current = editor;
   };
 
-  // Mimic styles in the Monaco editor
-  const styles = {
-    fontFamily: `Menlo, Monaco, "Courier New", monospace`,
-    fontSize: '12px',
-  };
-
   return (
-    <Box style={styles}>
+    <Box style={codeEditorBaseStyles}>
       <Stack
         direction="row"
         justifyContent="space-between"

--- a/src/ui/components/CodeSnippet.tsx
+++ b/src/ui/components/CodeSnippet.tsx
@@ -39,8 +39,9 @@ export function CodeSnippet({ code, language = 'plaintext' }: Props) {
           backgroundColor: theme.palette.grey['100'],
           pt: theme.spacing(0.5),
           pb: theme.spacing(0.5),
-          pr: theme.spacing(2),
-          pl: theme.spacing(2),
+          // 10px on Monaco + 2px border
+          pr: '12px',
+          pl: '12px',
         }}
       >
         <Box sx={{ color: 'text.secondary' }}>{language}</Box>
@@ -80,6 +81,7 @@ export function CodeSnippet({ code, language = 'plaintext' }: Props) {
             lineNumbers: 'off',
             automaticLayout: true,
             folding: false,
+            renderLineHighlightOnlyWhenFocus: true,
           }}
           onMount={handleEditorDidMount}
         />

--- a/src/ui/components/CodeSnippet.tsx
+++ b/src/ui/components/CodeSnippet.tsx
@@ -16,7 +16,6 @@ export function CodeSnippet({ code, language = 'plaintext' }: Props) {
 
   const handleClick = (e: any) => {
     if (editorRef.current) {
-      console.log(editorRef.current);
       navigator.clipboard.writeText(code);
       setTooltipMsg('Copied!');
       setTimeout(() => {

--- a/src/ui/components/CodeSnippet.tsx
+++ b/src/ui/components/CodeSnippet.tsx
@@ -28,8 +28,14 @@ export function CodeSnippet({ code, language = 'plaintext' }: Props) {
     editorRef.current = editor;
   };
 
+  // Mimic styles in the Monaco editor
+  const styles = {
+    fontFamily: `Menlo, Monaco, "Courier New", monospace`,
+    fontSize: '12px',
+  };
+
   return (
-    <Box>
+    <Box style={styles}>
       <Stack
         direction="row"
         justifyContent="space-between"

--- a/src/ui/components/CodeSnippet.tsx
+++ b/src/ui/components/CodeSnippet.tsx
@@ -1,0 +1,90 @@
+import { useRef, useState } from 'react';
+import Editor from '@monaco-editor/react';
+import { Box, IconButton, Stack, useTheme } from '@mui/material';
+import { ContentCopy } from '@mui/icons-material';
+import { TooltipHint } from './TooltipHint';
+
+interface Props {
+  code: string;
+  language?: string;
+}
+
+export function CodeSnippet({ code, language = 'plaintext' }: Props) {
+  const [tooltipMsg, setTooltipMsg] = useState<string>('Click to copy');
+  const editorRef = useRef(null);
+  const theme = useTheme();
+
+  const handleClick = (e: any) => {
+    if (editorRef.current) {
+      console.log(editorRef.current);
+      navigator.clipboard.writeText(code);
+      setTooltipMsg('Copied!');
+      setTimeout(() => {
+        setTooltipMsg('Click to copy');
+      }, 2000);
+    }
+  };
+
+  const handleEditorDidMount = (editor: any) => {
+    editorRef.current = editor;
+  };
+
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        spacing={1}
+        sx={{
+          backgroundColor: theme.palette.grey['100'],
+          pt: theme.spacing(0.5),
+          pb: theme.spacing(0.5),
+          pr: theme.spacing(2),
+          pl: theme.spacing(2),
+        }}
+      >
+        <Box sx={{ color: 'text.secondary' }}>{language}</Box>
+
+        <TooltipHint title={tooltipMsg}>
+          <IconButton onClick={handleClick} size="small">
+            <ContentCopy fontSize="inherit" />
+          </IconButton>
+        </TooltipHint>
+      </Stack>
+      <div
+        style={{
+          // calculate height based on number of lines
+          height: `${Math.ceil(code.split('\n').length) * 19}px`,
+          position: 'relative',
+          border: `2px solid ${theme.palette.grey['100']}`,
+          borderTop: 'none',
+        }}
+      >
+        <Editor
+          language={language}
+          value={code}
+          height="100%"
+          width="100%"
+          options={{
+            readOnly: true,
+            minimap: { enabled: false },
+            overviewRulerLanes: 0,
+            hideCursorInOverviewRuler: true,
+            overviewRulerBorder: false,
+            scrollbar: {
+              vertical: 'hidden',
+              handleMouseWheel: false,
+            },
+            scrollBeyondLastLine: false,
+            wordWrap: 'off',
+            lineNumbers: 'off',
+            automaticLayout: true,
+            folding: false,
+          }}
+          onMount={handleEditorDidMount}
+        />
+      </div>
+    </Box>
+  );
+}

--- a/src/ui/menus/CodeEditor/AICodeBlockParser.test.ts
+++ b/src/ui/menus/CodeEditor/AICodeBlockParser.test.ts
@@ -1,0 +1,47 @@
+import { parseCodeBlocks } from './AICodeBlockParser';
+
+describe('parseCodeBlocks()', () => {
+  test('A string without code blocks returns one item', () => {
+    const result = parseCodeBlocks(`This is a string from AI.`);
+    expect(result).toHaveLength(1);
+    expect(typeof result[0]).toBe('string');
+  });
+
+  test('A string + 1 unclosed code block returns two items', () => {
+    const result = parseCodeBlocks(`
+A string of text with an open code block.
+
+\`\`\`js
+const foo = 'foo';`);
+    expect(result).toHaveLength(2);
+    expect(typeof result[0]).toBe('string');
+    expect(typeof result[1]).toBe('object');
+  });
+
+  test('A string + 1 code block returns two items', () => {
+    const result = parseCodeBlocks(`
+A string of text with a full code block.
+
+\`\`\`js
+const foo = 'foo';
+\`\`\``);
+    expect(result).toHaveLength(2);
+  });
+
+  test('A string + 1 full code block + a string returns three items', () => {
+    const result = parseCodeBlocks(`
+A string of text with a full code block.
+
+\`\`\`js
+const foo = 'foo';
+\`\`\`
+
+And another piece of text
+
+And more text here`);
+    expect(result).toHaveLength(3);
+    expect(typeof result[0]).toBe('string');
+    expect(typeof result[1]).toBe('object');
+    expect(typeof result[2]).toBe('string');
+  });
+});

--- a/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
+++ b/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
@@ -1,6 +1,5 @@
 import { Stack } from '@mui/material';
 import { CodeSnippet } from '../../components/CodeSnippet';
-// import monaco from 'monaco-editor';
 
 const CODE_BLOCK_REGEX = /```([a-z]+)?\n([\s\S]+?)(?:\n```|$)/g;
 

--- a/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
+++ b/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
@@ -24,7 +24,7 @@ function parseCodeBlocks(input: string): Array<string | JSX.Element> {
 
 export function CodeBlockParser({ input }: { input: string }): JSX.Element {
   return (
-    <Stack gap={2} style={{ whiteSpace: 'normal', lineHeight: '1.5' }}>
+    <Stack gap={2} style={{ whiteSpace: 'normal' }}>
       {parseCodeBlocks(input)}
     </Stack>
   );

--- a/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
+++ b/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
@@ -1,6 +1,8 @@
-import Editor from '@monaco-editor/react';
+import { Stack } from '@mui/material';
+import { CodeSnippet } from '../../components/CodeSnippet';
+// import monaco from 'monaco-editor';
 
-const CODE_BLOCK_REGEX = /```([a-z]+)?\n([\s\S]+?)\n```/g;
+const CODE_BLOCK_REGEX = /```([a-z]+)?\n([\s\S]+?)(?:\n```|$)/g;
 
 function parseCodeBlocks(input: string): Array<string | JSX.Element> {
   const blocks: Array<string | JSX.Element> = [];
@@ -12,39 +14,7 @@ function parseCodeBlocks(input: string): Array<string | JSX.Element> {
     if (lastIndex < match.index) {
       blocks.push(input.substring(lastIndex, match.index));
     }
-    blocks.push(
-      <div
-        key={lastIndex}
-        // calculate height based on number of lines
-        style={{
-          height: `${Math.ceil(code.split('\n').length) * 19}px`,
-          width: '100%',
-        }}
-      >
-        <Editor
-          language={language}
-          value={code}
-          height="100%"
-          width="100%"
-          options={{
-            readOnly: true,
-            minimap: { enabled: false },
-            overviewRulerLanes: 0,
-            hideCursorInOverviewRuler: true,
-            overviewRulerBorder: false,
-            scrollbar: {
-              vertical: 'hidden',
-              horizontal: 'hidden',
-              handleMouseWheel: false,
-            },
-            scrollBeyondLastLine: false,
-            wordWrap: 'off',
-            // lineNumbers: 'off',
-            automaticLayout: true,
-          }}
-        />
-      </div>
-    );
+    blocks.push(<CodeSnippet key={lastIndex} code={code} language={language} />);
     lastIndex = match.index + match[0].length;
   }
   if (lastIndex < input.length) {
@@ -54,5 +24,9 @@ function parseCodeBlocks(input: string): Array<string | JSX.Element> {
 }
 
 export function CodeBlockParser({ input }: { input: string }): JSX.Element {
-  return <>{parseCodeBlocks(input)}</>;
+  return (
+    <Stack gap={2} style={{ whiteSpace: 'normal', lineHeight: '1.5' }}>
+      {parseCodeBlocks(input)}
+    </Stack>
+  );
 }

--- a/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
+++ b/src/ui/menus/CodeEditor/AICodeBlockParser.tsx
@@ -3,7 +3,7 @@ import { CodeSnippet } from '../../components/CodeSnippet';
 
 const CODE_BLOCK_REGEX = /```([a-z]+)?\n([\s\S]+?)(?:\n```|$)/g;
 
-function parseCodeBlocks(input: string): Array<string | JSX.Element> {
+export function parseCodeBlocks(input: string): Array<string | JSX.Element> {
   const blocks: Array<string | JSX.Element> = [];
   let match;
   let lastIndex = 0;

--- a/src/ui/menus/CodeEditor/AITab.tsx
+++ b/src/ui/menus/CodeEditor/AITab.tsx
@@ -217,8 +217,6 @@ export const AITab = ({ evalResult, editorMode, editorContent }: Props) => {
         </FormControl>
       </div>
       <div
-        contentEditable="true"
-        suppressContentEditableWarning={true}
         spellCheck={false}
         onKeyDown={(e) => {
           if (((e.metaKey || e.ctrlKey) && e.key === 'a') || ((e.metaKey || e.ctrlKey) && e.key === 'c')) {
@@ -257,14 +255,9 @@ export const AITab = ({ evalResult, editorMode, editorContent }: Props) => {
               <div
                 key={index}
                 style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-start',
                   borderTop: index !== 0 ? `1px solid ${colors.lightGray}` : 'none',
                   marginTop: '1rem',
                   paddingTop: index !== 0 ? '1rem' : '0',
-                  paddingLeft: '1rem',
-                  paddingRight: '1rem',
                 }}
               >
                 {message.role === 'user' ? (
@@ -295,7 +288,7 @@ export const AITab = ({ evalResult, editorMode, editorContent }: Props) => {
                     <AI sx={{ color: colors.languageAI }}></AI>
                   </Avatar>
                 )}
-                <span>{CodeBlockParser({ input: message.content })}</span>
+                <CodeBlockParser input={message.content} />
               </div>
             ))}
             <div id="ai-streaming-output-anchor" key="ai-streaming-output-anchor" />

--- a/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -430,7 +430,12 @@ export const CodeEditor = (props: CodeEditorProps) => {
         {(editorInteractionState.mode === 'PYTHON' ||
           editorInteractionState.mode === 'FORMULA' ||
           editorInteractionState.mode === 'AI') && (
-          <Console evalResult={evalResult} editorMode={editorMode} editorContent={editorContent} />
+          <Console
+            evalResult={evalResult}
+            editorMode={editorMode}
+            editorContent={editorContent}
+            selectedCell={selectedCell}
+          />
         )}
       </div>
     </div>

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -1,13 +1,14 @@
 import { Box, Tabs, Tab, Chip } from '@mui/material';
-import { CSSProperties, useState } from 'react';
+import { useState } from 'react';
 import { CellEvaluationResult } from '../../../grid/computations/types';
 import { LinkNewTab } from '../../components/LinkNewTab';
 import { colors } from '../../../theme/colors';
 import { DOCUMENTATION_FORMULAS_URL, DOCUMENTATION_PYTHON_URL } from '../../../constants/urls';
 import { EditorInteractionState } from '../../../atoms/editorInteractionStateAtom';
-import { useTheme } from '@mui/system';
 import { AITab } from './AITab';
 import { useAuth0 } from '@auth0/auth0-react';
+import { CodeSnippet } from '../../components/CodeSnippet';
+import { stripIndent } from 'common-tags';
 
 interface ConsoleProps {
   editorMode: EditorInteractionState['mode'];
@@ -19,14 +20,7 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
   const { std_err = '', std_out = '' } = evalResult || {};
   let hasOutput = Boolean(std_err.length || std_out.length);
-  const theme = useTheme();
   const { isAuthenticated } = useAuth0();
-
-  const codeSampleStyles: CSSProperties = {
-    backgroundColor: colors.lightGray,
-    padding: theme.spacing(1),
-    whiteSpace: 'pre-wrap',
-  };
 
   if (editorMode === 'AI') {
     if (activeTabIndex !== 1) setActiveTabIndex(1);
@@ -66,7 +60,7 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
           ) : null}
         </Tabs>
       </Box>
-      <div style={{ flex: '2', overflow: 'scroll' }}>
+      <div style={{ flex: '2', overflow: 'scroll', fontSize: '.875rem' }}>
         <TabPanel value={activeTabIndex} index={0}>
           <div
             contentEditable="true"
@@ -82,7 +76,6 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
             style={{
               outline: 'none',
               fontFamily: 'monospace',
-              fontSize: '.875rem',
               lineHeight: '1.3',
               whiteSpace: 'pre-wrap',
             }}
@@ -106,46 +99,48 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
         <TabPanel value={activeTabIndex} index={1}>
           {editorMode === 'PYTHON' ? (
             <div style={{ overflow: 'scroll' }}>
-              <h3>Logging</h3>
+              <h4>Logging</h4>
               <p>`print()` statements and errors are logged in the CONSOLE tab.</p>
-              <h3>Returning data to the sheet</h3>
+              <h4>Returning data to the sheet</h4>
               <p>The last statement in your code is returned to the sheet.</p>
               <p>Example:</p>
-              <pre style={codeSampleStyles}>
-                <span style={{ color: 'grey' }}>1</span> <span style={{ color: 'blue' }}>2</span> *{' '}
-                <span style={{ color: 'blue' }}>2</span>
-                <br />
-                <span style={{ color: 'grey' }}>↳ 4 # number returned as the cell value</span>
-              </pre>
-              <p>Example:</p>
-              <pre style={codeSampleStyles}>
-                <span style={{ color: 'grey' }}>1</span> result = <span style={{ color: 'blue' }}>[]</span>
-                <br />
-                <span style={{ color: 'grey' }}>2</span> <span style={{ color: 'red' }}>for</span> x{' '}
-                <span style={{ color: 'red' }}>in </span>
-                <span style={{ color: 'blue' }}>range</span>(100):
-                <br></br>
-                <span style={{ color: 'grey' }}>3</span> {'  '}
-                result.<span style={{ color: 'blue' }}>append</span>(x)
-                <br />
-                <span style={{ color: 'grey' }}>4</span>
-                <br />
-                <span style={{ color: 'grey' }}>5</span> result
-                <br />
-                <span style={{ color: 'grey' }}>↳ [0, 1, 2, ..., 99] # returns 100 cells counting from 0 to 99</span>
-              </pre>
 
-              <h3>Referencing data from the sheet</h3>
+              <CodeSnippet
+                language="python"
+                code={stripIndent`
+                  2 * 2
+                  # Returns the value '4' to the active cell
+                `}
+              />
+
+              <p>Example:</p>
+
+              <CodeSnippet
+                language="python"
+                code={stripIndent`
+                  result = []
+                  for x in range(100):
+                      result.append(x)
+
+                  result
+                  # Returns a list of 100 numbers, from 0 to 99
+                  # [0, 1, 2, ..., 99]
+                `}
+              />
+
+              <h4>Referencing data from the sheet</h4>
               <p>Use the `cell(x, y)` function — or shorthand `c(x, y)` — to reference values in the sheet.</p>
               <p>Example:</p>
-              <pre style={codeSampleStyles}>
-                <span style={{ color: 'grey' }}>1</span> <span style={{ color: 'blue' }}>c</span>(1, 1) +{' '}
-                <span style={{ color: 'blue' }}>c</span>(2, 2)
-                <br />
-                <span style={{ color: 'grey' }}>↳ The sum of the cell values at x:1 y:1 and x:2 y:2</span>
-              </pre>
 
-              <h3>Advanced topics</h3>
+              <CodeSnippet
+                language="python"
+                code={stripIndent`
+                  c(1, 1) + c(2, 2)
+                  # Returns the sum of the cell values at (x:1, y:1) and (x:2, y:2)
+                `}
+              />
+
+              <h4>Advanced topics</h4>
               <ul>
                 <li>Fetching data from an API.</li>
                 <li>Using Pandas DataFrames.</li>
@@ -161,24 +156,24 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
               <br></br>
               <Chip label="Experimental" size="small" color="warning" variant="outlined" />
               <p>
-                Warning: AI in Quadratic as a cell type is currently experimental.<br></br> The implementation may
-                change without notice.
-                <span
-                  style={{
-                    fontStyle: 'italic',
-                  }}
-                >
-                  <br></br>Data generated by AI models needs to be validated as it is often incorrect.
-                </span>
+                <strong>Warning</strong>: AI in Quadratic as a cell type is currently experimental. The implementation
+                may change without notice.
               </p>
-              <h3>AI Docs</h3>
-              <h5>Generating New Data</h5>
+              <p
+                style={{
+                  fontStyle: 'italic',
+                }}
+              >
+                Data generated by AI models needs to be validated as it is often incorrect.
+              </p>
+
+              <h4>Generating New Data</h4>
               <p>
                 With GPT AI as a cell type, GPT AI can directly generate data and return it to the sheet. Whether you
                 need to generate a list of names, dates, or any other type of data, GPT AI can do it for you quickly and
                 easily, saving you valuable time and resources.
               </p>
-              <h5>Working With Existing Data</h5>
+              <h4>Working With Existing Data</h4>
               <p>
                 When you use GPT AI as a cell type, it has access to the data in your sheet and can use it to generate
                 new data or update existing data. This means that GPT AI can analyze the data in your sheet and generate
@@ -189,188 +184,68 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
             </>
           ) : (
             <>
-              <h3>Spreadsheet formulas</h3>
+              <h4>Spreadsheet formulas</h4>
               <p>Use the familiar language of spreadsheet formulas.</p>
               <p>Example:</p>
-              <pre style={codeSampleStyles}>
-                <span style={{ color: 'grey' }}>1</span> <span style={{ color: 'blue' }}>SUM</span>(A0:A99)
-                <br />
-                <span style={{ color: 'grey' }}>↳ Returns the SUM of cells A0 to A99</span>
-              </pre>
-              <h3>Referencing cells</h3>
+
+              <CodeSnippet language="formula" code={`SUM(A0:A99)`} />
+
+              <h4>Referencing cells</h4>
               <p>
                 In the positive quadrant, cells are referenced similar to other spreadsheets. In the negative quadrant,
                 cells are referenced using a `n` prefix.
               </p>
               <p>Examples:</p>
               <table>
+                <thead>
+                  <th style={{ textAlign: 'left' }}>
+                    <code>nAn0</code>
+                  </th>
+                  <th style={{ textAlign: 'left' }}>
+                    <code>(x, y)</code>
+                  </th>
+                </thead>
                 <tbody>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <strong>nAn0 notation</strong>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>
-                              <strong>(x, y)</strong>
-                            </code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>A0</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(0, 0)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>A1</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(0, 1)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>B1</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(1, 1)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>An1</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(0, -1)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>nA1</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(-1, 1)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>nAn1</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                    <td>
-                      <div>
-                        <span>
-                          <span>
-                            <code>(-1, -1)</code>
-                          </span>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
+                  {[
+                    ['A0', '(0,0)'],
+                    ['A1', '(0, 1)'],
+                    ['B1', '(1, 1)'],
+                    ['An1', '(0, -1)'],
+                    ['nA1', '(-1, 1)'],
+                    ['nAn1', '(-1, -1)'],
+                  ].map(([key, val]) => (
+                    <tr>
+                      <td>
+                        <code>{key}</code>
+                      </td>
+                      <td>
+                        <code>{val}</code>
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
-              <h3>Multiline formulas</h3>
+
+              <h4>Multiline formulas</h4>
               <p>
                 Line spaces are ignored when evaluating formulas. You can use them to make your formulas more readable.
               </p>
               <p>Example:</p>
-              <pre style={codeSampleStyles}>
-                <span style={{ color: 'grey' }}>1</span> <span style={{ color: 'blue' }}>IF</span>(A0 {'>'} 0,
-                <br></br>
-                <span style={{ color: 'grey' }}>2</span> <span style={{ color: 'blue' }}>&nbsp;&nbsp;IF</span>(B0 {'<'}{' '}
-                2,
-                <br></br>
-                <span style={{ color: 'grey' }}>3</span> &nbsp;&nbsp;&nbsp;&nbsp;"Valid Dataset",
-                <br></br>
-                <span style={{ color: 'grey' }}>3</span> &nbsp;&nbsp;&nbsp;&nbsp;"B0 is invalid",
-                <br></br>
-                <span style={{ color: 'grey' }}>4</span> &nbsp;&nbsp;),
-                <br></br>
-                <span style={{ color: 'grey' }}>3</span> &nbsp;&nbsp;"A0 is invalid",
-                <br></br>
-                <span style={{ color: 'grey' }}>5</span> )<br></br>
-              </pre>
-              <h3>More info</h3>
+
+              <CodeSnippet
+                language="formula"
+                code={stripIndent`
+                  IF(A0 > 0,
+                    IF(B0 < 2,
+                      "Valid Dataset",
+                      "B0 is invalid",
+                    ),
+                    "A0 is invalid",
+                  )
+                `}
+              />
+
+              <h4>More info</h4>
               <p>
                 <LinkNewTab href={DOCUMENTATION_FORMULAS_URL}>Check out the docs</LinkNewTab> to see a full list of
                 supported formulas and documentation for how to use specific formula functions.

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -242,9 +242,9 @@ export function Console({ evalResult, editorMode, editorContent, selectedCell }:
                   IF(A0 > 0,
                     IF(B0 < 2,
                       "Valid Dataset",
-                      "B0 is invalid",
+                      "B0 is invalid"
                     ),
-                    "A0 is invalid",
+                    "A0 is invalid"
                   )
                 `}
               />

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -1,5 +1,5 @@
 import { Box, Tabs, Tab, Chip } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CellEvaluationResult } from '../../../grid/computations/types';
 import { LinkNewTab } from '../../components/LinkNewTab';
 import { colors } from '../../../theme/colors';
@@ -9,22 +9,25 @@ import { AITab } from './AITab';
 import { useAuth0 } from '@auth0/auth0-react';
 import { CodeSnippet } from '../../components/CodeSnippet';
 import { stripIndent } from 'common-tags';
+import { Cell } from '../../../schemas';
 
 interface ConsoleProps {
   editorMode: EditorInteractionState['mode'];
   evalResult: CellEvaluationResult | undefined;
   editorContent: string | undefined;
+  selectedCell: Cell;
 }
 
-export function Console({ evalResult, editorMode, editorContent }: ConsoleProps) {
+export function Console({ evalResult, editorMode, editorContent, selectedCell }: ConsoleProps) {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
   const { std_err = '', std_out = '' } = evalResult || {};
   let hasOutput = Boolean(std_err.length || std_out.length);
   const { isAuthenticated } = useAuth0();
 
-  if (editorMode === 'AI') {
-    if (activeTabIndex !== 1) setActiveTabIndex(1);
-  }
+  // Whenever we change to a different cell, reset the active tab to the 1st
+  useEffect(() => {
+    setActiveTabIndex(0);
+  }, [selectedCell]);
 
   return (
     <>
@@ -197,12 +200,14 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
               <p>Examples:</p>
               <table>
                 <thead>
-                  <th style={{ textAlign: 'left' }}>
-                    <code>nAn0</code>
-                  </th>
-                  <th style={{ textAlign: 'left' }}>
-                    <code>(x, y)</code>
-                  </th>
+                  <tr>
+                    <th style={{ textAlign: 'left' }}>
+                      <code>nAn0</code>
+                    </th>
+                    <th style={{ textAlign: 'left' }}>
+                      <code>(x, y)</code>
+                    </th>
+                  </tr>
                 </thead>
                 <tbody>
                   {[
@@ -213,8 +218,8 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
                     ['nA1', '(-1, 1)'],
                     ['nAn1', '(-1, -1)'],
                   ].map(([key, val]) => (
-                    <tr>
-                      <td>
+                    <tr key={key}>
+                      <td style={{ minWidth: '5rem' }}>
                         <code>{key}</code>
                       </td>
                       <td>

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -60,7 +60,7 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
           ) : null}
         </Tabs>
       </Box>
-      <div style={{ flex: '2', overflow: 'scroll', fontSize: '.875rem' }}>
+      <div style={{ flex: '2', overflow: 'scroll', fontSize: '.875rem', lineHeight: '1.5' }}>
         <TabPanel value={activeTabIndex} index={0}>
           <div
             contentEditable="true"
@@ -76,7 +76,6 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
             style={{
               outline: 'none',
               fontFamily: 'monospace',
-              lineHeight: '1.3',
               whiteSpace: 'pre-wrap',
             }}
             // Disable Grammarly
@@ -255,7 +254,12 @@ export function Console({ evalResult, editorMode, editorContent }: ConsoleProps)
           )}
         </TabPanel>
         <TabPanel value={activeTabIndex} index={2}>
-          <AITab evalResult={evalResult} editorMode={editorMode} editorContent={editorContent}></AITab>
+          <AITab
+            evalResult={evalResult}
+            editorMode={editorMode}
+            editorContent={editorContent}
+            isActive={activeTabIndex === 2}
+          ></AITab>
         </TabPanel>
       </div>
     </>


### PR DESCRIPTION
A few enhancements to the interface for interacting with the AI assistant.

<img width="618" alt="CleanShot 2023-07-03 at 14 17 51@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/3dc65d92-62bf-4181-9172-ad4ab710f10b">

### Format code blocks as they stream in

Format code blocks, even before we get to the terminal backticks ```

Fixes #473

Before:

![before](https://github.com/quadratichq/quadratic/assets/1316441/72d488c8-f06d-477d-93d4-78731bd3e903)

After:

![after](https://github.com/quadratichq/quadratic/assets/1316441/9aee4313-d4d7-48d4-a43d-dfe3961cac39)

### Click to copy

Fixes #539 Copy contents of a block of code.

![Jun-28-2023 16-53-44](https://github.com/quadratichq/quadratic/assets/1316441/cc5b6bde-e70e-4d15-948b-41038c69a04c)

### Formatting

Cleaned up some spacing and alignment issues and [changed some config options of the editor](https://github.com/quadratichq/quadratic/pull/583/files#r1245905588) as well as tweaking the AI tab zero state.