### PR TITLE
feat: mixpanel proxy

### DIFF
--- a/src/quadratic/AnalyticsProvider.tsx
+++ b/src/quadratic/AnalyticsProvider.tsx
@@ -56,7 +56,7 @@ const loadMixPanelAnalytics = async (user: User | undefined) => {
     return;
   }
 
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: process.env.REACT_APP_MIXPANEL_ANALYTICS_URL });
+  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: "https://mixpanel-proxy.quadratichq.com" });
 
   mixpanel.register({
     email: user?.email,

--- a/src/quadratic/AnalyticsProvider.tsx
+++ b/src/quadratic/AnalyticsProvider.tsx
@@ -56,7 +56,7 @@ const loadMixPanelAnalytics = async (user: User | undefined) => {
     return;
   }
 
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: 'https://mixpanel.quadratichq.com' });
+  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY });
 
   mixpanel.register({
     email: user?.email,

--- a/src/quadratic/AnalyticsProvider.tsx
+++ b/src/quadratic/AnalyticsProvider.tsx
@@ -56,7 +56,7 @@ const loadMixPanelAnalytics = async (user: User | undefined) => {
     return;
   }
 
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY });
+  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: process.env.REACT_APP_MIXPANEL_ANALYTICS_URL });
 
   mixpanel.register({
     email: user?.email,

--- a/src/quadratic/AnalyticsProvider.tsx
+++ b/src/quadratic/AnalyticsProvider.tsx
@@ -56,7 +56,7 @@ const loadMixPanelAnalytics = async (user: User | undefined) => {
     return;
   }
 
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: "https://mixpanel-proxy.quadratichq.com" });
+  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: 'https://mixpanel-proxy.quadratichq.com' });
 
   mixpanel.register({
     email: user?.email,

--- a/src/quadratic/AnalyticsProvider.tsx
+++ b/src/quadratic/AnalyticsProvider.tsx
@@ -56,7 +56,7 @@ const loadMixPanelAnalytics = async (user: User | undefined) => {
     return;
   }
 
-  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY);
+  mixpanel.init(process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY, { api_host: 'https://mixpanel.quadratichq.com' });
 
   mixpanel.register({
     email: user?.email,


### PR DESCRIPTION
Fixes #581

Notes:

- [x] Setup [an NGINX proxy on Heroku](https://dashboard.heroku.com/apps/mixpanel-tracking-proxy)
- [x] Created [a GH repo that powers](https://github.com/quadratichq/tracking-proxy) the Heroku app
- [x] Stage vs. prod servers for this? Probably not, as we currently only have one mixpanel project, so there's no "staging" version of mixpanel to log data to (though we could change this if we want)
- [x] Add client-side configuration that points to heroku server