### PR TITLE
feat: show/hide cursor when browser window goes blur/focus

### DIFF
--- a/src/gridGL/UI/Cursor.ts
+++ b/src/gridGL/UI/Cursor.ts
@@ -32,6 +32,7 @@ export class Cursor extends Graphics {
   }
 
   private drawCursor(): void {
+    if (!document.hasFocus()) return;
     const { settings, viewport } = this.app;
     const { gridOffsets } = this.app.sheet;
     const { editorInteractionState } = this.app.settings;
@@ -120,6 +121,7 @@ export class Cursor extends Graphics {
   }
 
   private drawCursorIndicator(): void {
+    if (!document.hasFocus()) return;
     const { viewport } = this.app;
 
     if (viewport.scale.x > HIDE_INDICATORS_BELOW_SCALE) {

--- a/src/gridGL/UI/Cursor.ts
+++ b/src/gridGL/UI/Cursor.ts
@@ -93,6 +93,7 @@ export class Cursor extends Graphics {
   }
 
   private drawMultiCursor(): void {
+    if (!document.hasFocus()) return;
     const { settings } = this.app;
     const { gridOffsets } = this.app.sheet;
 

--- a/src/gridGL/pixiApp/PixiApp.ts
+++ b/src/gridGL/pixiApp/PixiApp.ts
@@ -199,7 +199,6 @@ export class PixiApp {
   handleFocus = (): void => {
     if (!this.parent || this.destroyed) return;
     this.cursor.dirty = true;
-    // this.cells.dirty = true;
   };
 
   resize = (): void => {

--- a/src/gridGL/pixiApp/PixiApp.ts
+++ b/src/gridGL/pixiApp/PixiApp.ts
@@ -133,6 +133,9 @@ export class PixiApp {
 
     window.addEventListener('resize', this.resize);
 
+    window.addEventListener('blur', this.handleFocus);
+    window.addEventListener('focus', this.handleFocus);
+
     console.log('[QuadraticGL] environment ready');
   }
 
@@ -192,6 +195,12 @@ export class PixiApp {
     this.viewport.destroy();
     this.destroyed = true;
   }
+
+  handleFocus = (): void => {
+    if (!this.parent || this.destroyed) return;
+    this.cursor.dirty = true;
+    // this.cells.dirty = true;
+  };
 
   resize = (): void => {
     if (!this.parent || this.destroyed) return;

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -115,6 +115,9 @@ export const FloatingContextMenu = (props: Props) => {
     if (interactionState.boxCells) {
       visibility = 'hidden';
     }
+    if (!document.hasFocus()) {
+      visibility = 'hidden';
+    }
 
     // Hide if it's not 1) a multicursor or, 2) an active right click
     if (!(interactionState.showMultiCursor || showContextMenu)) visibility = 'hidden';
@@ -172,11 +175,15 @@ export const FloatingContextMenu = (props: Props) => {
     viewport.on('moved', updateContextMenuCSSTransform);
     viewport.on('moved-end', updateContextMenuCSSTransform);
     document.addEventListener('pointerup', updateContextMenuCSSTransform);
+    window.addEventListener('blur', updateContextMenuCSSTransform);
+    window.addEventListener('focus', updateContextMenuCSSTransform);
 
     return () => {
       viewport.removeListener('moved', updateContextMenuCSSTransform);
       viewport.removeListener('moved-end', updateContextMenuCSSTransform);
       document.removeEventListener('pointerup', updateContextMenuCSSTransform);
+      window.removeEventListener('blur', updateContextMenuCSSTransform);
+      window.removeEventListener('focus', updateContextMenuCSSTransform);
     };
   }, [viewport, updateContextMenuCSSTransform]);
 


### PR DESCRIPTION
In a native app like Excel, when your window is focused you see the cursor, but when you focus another window (at the OS-level), the cursor disappears.

![Jul-03-2023 12-49-04](https://github.com/quadratichq/quadratic/assets/1316441/c896c68b-0e13-4529-8141-bf0f420078cc)

This mimics OS-level functionality for the UI/UX around windowing. It's useful, for example, on large monitors where you have two windows open side-by-side and you're copy/pasting information between the two documents. It helps you keep track of which window you're focused in and dealing with.

https://github.com/quadratichq/quadratic/assets/1316441/f6643f02-8843-4022-95eb-d7c0e55ff143

Thinking that it would be useful to do the same in Quadratic. In this prototype, I copied what excel does. The cursor should disappear when the browser window loses focus (single or multi cell selection)

![Jul-05-2023 15-52-35](https://github.com/quadratichq/quadratic/assets/1316441/2c18092f-86c8-4bee-92bb-f10ae0358340)
