### PR TITLE
refactor: tweak color of heading grid lines

### DIFF
--- a/src/gridGL/UI/gridHeadings/GridHeadings.ts
+++ b/src/gridGL/UI/gridHeadings/GridHeadings.ts
@@ -165,7 +165,7 @@ export class GridHeadings extends Container {
     for (let x = leftOffset; x <= rightOffset; x += currentWidth) {
       currentWidth = gridOffsets.getColumnWidth(column);
       if (gridAlpha !== 0) {
-        this.headingsGraphics.lineStyle(1, colors.cursorCell, 0.25 * gridAlpha, 0.5, true);
+        this.headingsGraphics.lineStyle(1, colors.gridHeadingBorder, 0.5 * gridAlpha, 0.5, true);
         this.headingsGraphics.moveTo(x, bounds.top);
         this.headingsGraphics.lineTo(x, bounds.top + cellHeight);
         this.gridLinesColumns.push({ column: column - 1, x, width: gridOffsets.getColumnWidth(column - 1) });
@@ -281,7 +281,7 @@ export class GridHeadings extends Container {
     for (let y = topOffset; y <= bottomOffset; y += currentHeight) {
       currentHeight = gridOffsets.getRowHeight(row);
       if (gridAlpha !== 0) {
-        this.headingsGraphics.lineStyle(1, colors.cursorCell, 0.25 * gridAlpha, 0.5, true);
+        this.headingsGraphics.lineStyle(1, colors.gridHeadingBorder, 0.5 * gridAlpha, 0.5, true);
         this.headingsGraphics.moveTo(bounds.left, y);
         this.headingsGraphics.lineTo(bounds.left + this.rowWidth, y);
         this.gridLinesRows.push({ row: row - 1, y, height: gridOffsets.getRowHeight(row - 1) });
@@ -345,7 +345,7 @@ export class GridHeadings extends Container {
     const { viewport } = this.app;
     const cellHeight = CELL_HEIGHT / viewport.scale.x;
     const bounds = viewport.getVisibleBounds();
-    this.headingsGraphics.lineStyle(1, colors.cursorCell, 0.25, 0.5, true);
+    this.headingsGraphics.lineStyle(1, colors.gridHeadingBorder, 1, 0.5, true);
     this.headingsGraphics.moveTo(bounds.left + this.rowWidth, viewport.top);
     this.headingsGraphics.lineTo(bounds.left + this.rowWidth, viewport.bottom);
     this.headingsGraphics.moveTo(bounds.left, bounds.top + cellHeight);

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -16,6 +16,7 @@ export const colors = {
   boxCellsDeleteColor: Number(`0x${red['400'].replace('#', '')}`),
   boxCellsColor: 0x6cd4ff,
   boxCellsAlpha: 0.333,
+  gridHeadingBorder: 0xcfd7de,
   defaultBorderColor: 0,
   lightGray: '#f6f8fa',
   mediumGray: '#cfd7de',


### PR DESCRIPTION
I never loved that the accent color (blue) is being used for the grid heading lines.

This changes it from being the accent color (used to indicate "active"-ness in the grid, e.g. cursor color, active cell heading background color, etc.) to our neutral "gray" which is used for the other heading lines.

<img width="1265" alt="CleanShot 2023-07-05 at 15 59 50@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/acb378b5-a8c2-4da0-a43c-0ed3d479a047">
