### PR TITLE
Rebuild Rust on `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "main": "public/electron.js",
   "scripts": {
+    "prestart": "npm run build:wasm",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build:wasm": "cd quadratic-core && wasm-pack build --target web --out-dir pkg",


### PR DESCRIPTION
This works, but I don't know if it's idiomatic. feels kinda hacky.

I know `cargo` is smart and only rebuilds what it needs to, so don't worry about unnecessary rebuilds