### PR TITLE
chore: add setting so VSCode automatically sorts imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
         "pixiapp",
         "subquadrant",
         "subquadrants"
-    ]
+    ],
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true,
+    }
 }


### PR DESCRIPTION
Reference: https://dev.to/shanesc/how-to-sort-and-cleanup-imports-on-save-in-vs-code-52p1

Example before:

<img width="723" alt="Before" src="https://github.com/quadratichq/quadratic/assets/1316441/30df3bfa-382b-4e69-85e7-3c336d29094a">

After:

<img width="727" alt="After" src="https://github.com/quadratichq/quadratic/assets/1316441/e516c9f6-a517-4691-a668-235d25d2f716">