### PR TITLE
fix: redirect to login when getting token silently fails

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -43,7 +43,7 @@ interface AuthClient {
   login(redirectTo: string): Promise<void>;
   handleSigninRedirect(): Promise<void>;
   logout(): Promise<void>;
-  getToken(): Promise<string>;
+  getToken(): Promise<string | void>;
 }
 
 export const authClient: AuthClient = {
@@ -87,8 +87,13 @@ export const authClient: AuthClient = {
   },
   async getToken() {
     const client = await getClient();
-    const token = await client.getTokenSilently();
-    return token;
+
+    try {
+      const token = await client.getTokenSilently();
+      return token;
+    } catch (e) {
+      return this.login(new URL(window.location.href).pathname);
+    }
   },
 };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -105,7 +105,6 @@ export const router = createBrowserRouter(
       <Route
         path={ROUTES.LOGIN}
         loader={async ({ request }) => {
-          document.title = 'Login - Quadratic';
           let isAuthenticated = await authClient.isAuthenticated();
 
           // If they’re authenticated, redirect home
@@ -126,7 +125,6 @@ export const router = createBrowserRouter(
       <Route
         path={ROUTES.LOGIN_RESULT}
         loader={async () => {
-          document.title = 'Login result - Quadratic';
           // try/catch here handles case where this _could_ error out and we
           // have no errorElement so we just redirect back to home
           try {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -136,8 +136,9 @@ export const router = createBrowserRouter(
             }
           } catch (e) {
             console.error(e);
-            return redirect('/');
           }
+
+          return redirect('/');
         }}
       />
       <Route

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -137,7 +137,6 @@ export const router = createBrowserRouter(
           } catch (e) {
             console.error(e);
           }
-
           return redirect('/');
         }}
       />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -105,6 +105,7 @@ export const router = createBrowserRouter(
       <Route
         path={ROUTES.LOGIN}
         loader={async ({ request }) => {
+          document.title = 'Login - Quadratic';
           let isAuthenticated = await authClient.isAuthenticated();
 
           // If they’re authenticated, redirect home
@@ -125,6 +126,7 @@ export const router = createBrowserRouter(
       <Route
         path={ROUTES.LOGIN_RESULT}
         loader={async () => {
+          document.title = 'Login result - Quadratic';
           // try/catch here handles case where this _could_ error out and we
           // have no errorElement so we just redirect back to home
           try {
@@ -136,8 +138,8 @@ export const router = createBrowserRouter(
             }
           } catch (e) {
             console.error(e);
+            return redirect('/');
           }
-          return redirect('/');
         }}
       />
       <Route


### PR DESCRIPTION
Was seeing this issue when you come back to the app after a day or so:

<img width="1203" alt="CleanShot 2023-08-25 at 13 40 02@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/d4315afd-d110-40b2-8ffd-5ffe7ebb001c">

The app renders because `isAuthenticated` comes back as true.

_But_, the `.getToken()` fails because, I believe, it has expired. Because of this, the app renders but the part of the UI that relies on an API call fails because the auth client fails to get the token.

The best way to simulate this is to login and change the expires time to something in the past (e.g. `0`). Then reload the app and you'll see the same error screen above.

![CleanShot 2023-08-25 at 13 44 46@2x](https://github.com/quadratichq/quadratic/assets/1316441/72a4f8bc-bb13-475c-886f-9e0dc9df0a7f)

This fixes this problem by redirecting the user to login if the `getToken` call fails