### PR TITLE
fix: hide autocomplete cursor indicator if user doesn't have permission to edit

### DIFF
--- a/src/gridGL/UI/Cursor.ts
+++ b/src/gridGL/UI/Cursor.ts
@@ -1,5 +1,6 @@
 import { Graphics, Rectangle } from 'pixi.js';
 import { isMobile } from 'react-device-detect';
+import { isEditorOrAbove } from '../../actions';
 import { convertColorStringToTint } from '../../helpers/convertColor';
 import { getCellFromFormulaNotation, isCellRangeTypeGuard } from '../../helpers/formulaNotation';
 import { colors } from '../../theme/colors';
@@ -129,6 +130,9 @@ export class Cursor extends Graphics {
 
   private drawCursorIndicator(): void {
     const { viewport } = this.app;
+
+    // TODO don't draw the indicator, but also finish drawing the rest of the box
+    if (!isEditorOrAbove(this.app.settings.editorInteractionState.permission)) return;
 
     if (viewport.scale.x > HIDE_INDICATORS_BELOW_SCALE) {
       const { editorInteractionState } = this.app.settings;

--- a/src/gridGL/UI/Cursor.ts
+++ b/src/gridGL/UI/Cursor.ts
@@ -53,7 +53,9 @@ export class Cursor extends Graphics {
     const editor_selected_cell = editorInteractionState.selectedCell;
 
     // draw cursor but leave room for cursor indicator if needed
-    const indicatorSize = Math.max(INDICATOR_SIZE / viewport.scale.x, 4);
+    const indicatorSize = isEditorOrAbove(this.app.settings.editorInteractionState.permission)
+      ? Math.max(INDICATOR_SIZE / viewport.scale.x, 4)
+      : 0;
     this.indicator.width = this.indicator.height = indicatorSize;
     const indicatorPadding = Math.max(INDICATOR_PADDING / viewport.scale.x, 1);
     const terminalPosition = settings.interactionState.multiCursorPosition.terminalPosition;
@@ -130,9 +132,6 @@ export class Cursor extends Graphics {
 
   private drawCursorIndicator(): void {
     const { viewport } = this.app;
-
-    // TODO don't draw the indicator, but also finish drawing the rest of the box
-    if (!isEditorOrAbove(this.app.settings.editorInteractionState.permission)) return;
 
     if (viewport.scale.x > HIDE_INDICATORS_BELOW_SCALE) {
       const { editorInteractionState } = this.app.settings;


### PR DESCRIPTION
Today people without edit access to a shared file can use the autocomplete  to edit the document.

What we want is to disallow that and hide the little square box if you can't edit a doc.

![CleanShot 2023-09-01 at 10 53 38@2x](https://github.com/quadratichq/quadratic/assets/1316441/f66d2350-494a-4b17-8d3b-f142f0fea2bf)
