### PR TITLE
feat: add signup button, fix 'back' button on login

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -40,7 +40,7 @@ async function getClient() {
 interface AuthClient {
   isAuthenticated(): Promise<boolean>;
   user(): Promise<undefined | User>;
-  login(redirectTo: string): Promise<void>;
+  login(redirectTo: string, isSignupFlow?: boolean): Promise<void>;
   handleSigninRedirect(): Promise<void>;
   logout(): Promise<void>;
   getToken(): Promise<string | void>;
@@ -57,10 +57,11 @@ export const authClient: AuthClient = {
     const user = await client.getUser();
     return user;
   },
-  async login(redirectTo: string) {
+  async login(redirectTo: string, isSignupFlow: boolean = false) {
     const client = await getClient();
     await client.loginWithRedirect({
       authorizationParams: {
+        screen_hint: isSignupFlow ? 'signup' : 'login',
         redirect_uri:
           window.location.origin +
           ROUTES.LOGIN_RESULT +

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   LOGOUT: '/logout',
   LOGIN: '/login',
   LOGIN_WITH_REDIRECT: () => '/login?from=' + encodeURIComponent(window.location.pathname),
+  SIGNUP_WITH_REDIRECT: () => '/login?signup&from=' + encodeURIComponent(window.location.pathname),
   LOGIN_RESULT: '/login-result',
   FILES: '/files',
   MY_FILES: '/files/mine',

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -133,8 +133,12 @@ export const router = createBrowserRouter(
           const redirectTo = url.searchParams.get('from') || '/';
           const isSignupFlow = url.searchParams.get('signup') !== null;
           await authClient.login(redirectTo, isSignupFlow);
+
           // auth0 will re-route us (above) but telling react-router where we
           // are re-routing to makes sure that this doesn't end up in the history stack
+          // but we have to add an artifical delay that's long enough for
+          // the auth0 navigation to take place
+          await new Promise((resolve) => setTimeout(resolve, 10000));
           return redirect(redirectTo);
         }}
       />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -127,11 +127,15 @@ export const router = createBrowserRouter(
           // If they’re not authenticated, send them to Auth0
           // Watch for a `from` query param, as unprotected routes will redirect
           // to here for them to auth first
+          // Also watch for the presence of a `signup` query param, which means
+          // send the user to sign up flow, not login
           const url = new URL(request.url);
-          const redirectTo = url.searchParams.get('from') || '';
-          await authClient.login(redirectTo);
-
-          return null;
+          const redirectTo = url.searchParams.get('from') || '/';
+          const isSignupFlow = url.searchParams.get('signup') !== null;
+          await authClient.login(redirectTo, isSignupFlow);
+          // auth0 will re-route us (above) but telling react-router where we
+          // are re-routing to makes sure that this doesn't end up in the history stack
+          return redirect(redirectTo);
         }}
       />
       <Route

--- a/src/ui/components/PermissionOverlay.tsx
+++ b/src/ui/components/PermissionOverlay.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Paper, useTheme } from '@mui/material';
+import { Alert, Button, Paper, Stack, useTheme } from '@mui/material';
 import React, { useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { Link, useSubmit } from 'react-router-dom';
@@ -14,6 +14,7 @@ export function PermissionOverlay() {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const { permission } = useRecoilValue(editorInteractionStateAtom);
   const { name, contents } = useFileContext();
+  const theme = useTheme();
   const submit = useSubmit();
 
   if ((permission === OWNER || permission === EDITOR) && isMobile && isOpen) {
@@ -34,15 +35,20 @@ export function PermissionOverlay() {
           severity="info"
           sx={{ width: '100%' }}
           action={
-            <Button
-              component={Link}
-              to={ROUTES.LOGIN_WITH_REDIRECT()}
-              variant="contained"
-              size="small"
-              disableElevation
-            >
-              Log in
-            </Button>
+            <Stack direction="row" gap={theme.spacing(1)}>
+              <Button component={Link} to={ROUTES.SIGNUP_WITH_REDIRECT()} variant="outlined" size="small">
+                Sign up
+              </Button>
+              <Button
+                component={Link}
+                to={ROUTES.LOGIN_WITH_REDIRECT()}
+                variant="contained"
+                size="small"
+                disableElevation
+              >
+                Log in
+              </Button>
+            </Stack>
           }
         >
           <strong>Welcome to Quadratic.</strong> You must log in to edit this file.

--- a/src/ui/components/PermissionOverlay.tsx
+++ b/src/ui/components/PermissionOverlay.tsx
@@ -36,17 +36,17 @@ export function PermissionOverlay() {
           sx={{ width: '100%' }}
           action={
             <Stack direction="row" gap={theme.spacing(1)}>
-              <Button component={Link} to={ROUTES.SIGNUP_WITH_REDIRECT()} variant="outlined" size="small">
-                Sign up
+              <Button component={Link} to={ROUTES.LOGIN_WITH_REDIRECT()} variant="outlined" size="small">
+                Log in
               </Button>
               <Button
                 component={Link}
-                to={ROUTES.LOGIN_WITH_REDIRECT()}
+                to={ROUTES.SIGNUP_WITH_REDIRECT()}
                 variant="contained"
                 size="small"
                 disableElevation
               >
-                Log in
+                Sign up
               </Button>
             </Stack>
           }


### PR DESCRIPTION
## Sign up

For users viewing a shared file who are not authenticated, we show a message saying they need to login.

If they hit "Log in" they get taken to the auth0 login page:

<img width="582" alt="CleanShot 2023-09-06 at 16 37 52@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/24d696b7-d044-4493-961e-278f70dcc1be">

Where they can login, or if they are new, sign up.

This PR adds an additional "Sign up" button

<img width="712" alt="CleanShot 2023-09-06 at 16 23 13@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/90c11e50-8d1e-4318-91ab-a184f84e91cd">

Which allows them to jump directly to the sign up page:

<img width="602" alt="CleanShot 2023-09-06 at 16 37 37@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/38334d95-cdc4-4a51-983f-6b9863f6e56a">

## 'Back' button on login

Previous behavior:

- Load a shared file as a logged out user
- Click "log in"
- [app sends user to `/login` which then redirects them to auth0]
- Hit the back button
- End up on auth0 again

When you hit the back button, it's navigating you to `/login` which automatically redirects you back to auth0. So you get stuck in this loop where hitting "back" doesn't take you back to the file.

New behavior:

- Load a shared file as a logged out user
- Click "log in"
- [app sends user to `/login` which then redirects them to auth0]
- Hit the back button
- End up on the shared file

This properly replaces the `/login` entry in the history stack so when the user hits "log in" and ends up on auth0, they can hit 'back' in the browser and end up back on the shared file they were just looking at.