### PR TITLE
feat: notification when app needs update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <meta content="True" name="HandheldFriendly" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <meta name="theme-color" content="#FFFFFF" />
+    <meta name="version" content="%REACT_APP_VERSION%" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/components/UpgradeApp.tsx
+++ b/src/components/UpgradeApp.tsx
@@ -29,7 +29,7 @@ export const UpgradeApp = () => {
             nextVersion
           );
           if (needsUpdate) {
-            // TODO pass custom actions to snackbar so the page will refresh
+            // TODO pass custom action to snackbar so user can click button on notification to refresh
             addGlobalSnackbar('Quadratic has updates! Please reload.');
           }
         });

--- a/src/components/UpgradeApp.tsx
+++ b/src/components/UpgradeApp.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
 import { useInterval } from '../hooks/useInterval';
 import { useGlobalSnackbar } from './GlobalSnackbarProvider';
 
 export const UpgradeApp = () => {
-  const [stopPolling, setStopPolling] = useState<boolean>(false);
   const { addGlobalSnackbar } = useGlobalSnackbar();
 
   useInterval(
@@ -32,12 +30,11 @@ export const UpgradeApp = () => {
           );
           if (needsUpdate) {
             // TODO pass custom actions to snackbar so the page will refresh
-            addGlobalSnackbar('Quadratic has updates! You should reload.');
-            setStopPolling(true);
+            addGlobalSnackbar('Quadratic has updates! Please reload.');
           }
         });
     },
-    stopPolling ? null : 5000 /*3_600_000*/ // one hour
+    10000 // one hour? 3_600_000
   );
 
   return null;

--- a/src/components/UpgradeApp.tsx
+++ b/src/components/UpgradeApp.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useInterval } from '../hooks/useInterval';
+import { useGlobalSnackbar } from './GlobalSnackbarProvider';
+
+export const UpgradeApp = () => {
+  const [stopPolling, setStopPolling] = useState<boolean>(false);
+  const { addGlobalSnackbar } = useGlobalSnackbar();
+
+  useInterval(
+    () => {
+      fetch('/')
+        .then((res) => res.text())
+        .then((html) => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+
+          const selector = "meta[name='version']";
+          const nextVersion = dom.querySelector(selector)?.getAttribute('content');
+          const currentVersion = document.querySelector(selector)?.getAttribute('content');
+
+          if (!(nextVersion && currentVersion)) {
+            // TODO fire event to sentry noting that versions aren't in the right place
+            return;
+          }
+
+          const needsUpdate = currentVersion !== nextVersion;
+          console.log(
+            '[<UpgradeApp>] needs update? %s | current version: %s | next version: %s',
+            needsUpdate,
+            currentVersion,
+            nextVersion
+          );
+          if (needsUpdate) {
+            // TODO pass custom actions to snackbar so the page will refresh
+            addGlobalSnackbar('Quadratic has updates! You should reload.');
+            setStopPolling(true);
+          }
+        });
+    },
+    stopPolling ? null : 5000 /*3_600_000*/ // one hour
+  );
+
+  return null;
+};

--- a/src/debugFlags.ts
+++ b/src/debugFlags.ts
@@ -70,4 +70,4 @@ export const debugGridSettings = debug && false;
 // UI
 // --------
 
-export const debugShowUILogs = debug && false;
+export const debugShowUILogs = true;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,6 +18,7 @@ import { authClient, protectedRouteLoaderWrapper } from './auth';
 import { Empty } from './components/Empty';
 import { GlobalSnackbarProvider } from './components/GlobalSnackbarProvider';
 import { Theme } from './components/Theme';
+import { UpgradeApp } from './components/UpgradeApp';
 import { SUPPORT_EMAIL } from './constants/appConstants';
 import { ROUTES, ROUTE_LOADER_IDS } from './constants/routes';
 import * as CloudFilesMigration from './dashboard/CloudFilesMigrationRoute';
@@ -171,7 +172,10 @@ function Root() {
   return (
     <Theme>
       <GlobalSnackbarProvider>
-        <Outlet />
+        <>
+          <UpgradeApp />
+          <Outlet />
+        </>
       </GlobalSnackbarProvider>
     </Theme>
   );


### PR DESCRIPTION
**What is this?**

Trigger a notification for the user when the app is out of date, e.g.

<img width="538" alt="CleanShot 2023-09-08 at 17 03 30@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/8448cb30-245d-4f6c-980a-faea52d4350a">

**How does it work?**

Every time the app changes, the "version" of the app is the current commit hash. This gets injected into the app in various ways (e.g. the footer)

<img width="365" alt="CleanShot 2023-09-08 at 17 08 25@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/6d522738-1190-4c7e-b608-8aa0ed5e85f4">

It also gets put in the `index.html` file as a meta tag. And the app sets up an interval to poll the root `index.html` file and look for the app version. If it matches the current version, nothing happens. If it doesn't match that means the app has changed and we trigger a notification to the user to reload (and it continues to notify them every time the polling interval triggers).

Question: will this muck up our analytics for requests to `index.html`? Because everyone is going to be requesting that file many times to check for the newest version...


**Todos**

- [ ] Notification needs a "Reload" button
- [ ] Determine proper timing

**To test**

Open the preview app, push a new commit to this branch and watch vercel build the app. Once the app rebuilds and deploys, the app should pop up this notification (within the polling time) because it sees a new version of the app.