### PR TITLE
fix FloatingContextMenu when switching tabs

### DIFF
--- a/src/grid/controller/Sheets.ts
+++ b/src/grid/controller/Sheets.ts
@@ -28,8 +28,8 @@ class Sheets {
       this.sheets.push(sheet);
     });
     this.sort();
-    this.current = this.sheets[0].id;
     pixiApp.create();
+    this.current = this.sheets[0].id;
   }
 
   // ensures there's a Sheet.ts for every Sheet.rs

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -60,8 +60,7 @@ export const FloatingContextMenu = (props: Props) => {
   const menuDiv = useRef<HTMLDivElement>(null);
   const moreMenuButtonRef = useRef(null);
   const borders = useGetBorderMenu();
-  const sheet = sheets.sheet;
-  const cursor = sheet.cursor;
+
   const textColorRef = useRef<MenuInstance>(null);
   const fillColorRef = useRef<MenuInstance>(null);
 
@@ -75,6 +74,9 @@ export const FloatingContextMenu = (props: Props) => {
     if (!container || !menuDiv.current) return '';
 
     const { viewport } = pixiApp;
+
+    const sheet = sheets.sheet;
+    const cursor = sheet.cursor;
 
     // Calculate position of input based on cell
     const cell_offsets = sheet.gridOffsets.getCell(
@@ -158,16 +160,7 @@ export const FloatingContextMenu = (props: Props) => {
       setTimeout(updateContextMenuCSSTransform, 100);
     } else menuDiv.current.style.pointerEvents = 'auto';
     return transform;
-  }, [
-    container,
-    sheet.gridOffsets,
-    cursor.multiCursor,
-    cursor.cursorPosition.x,
-    cursor.cursorPosition.y,
-    cursor.boxCells,
-    showContextMenu,
-    editorInteractionState.permission,
-  ]);
+  }, [container, showContextMenu, editorInteractionState.permission]);
 
   useEffect(() => {
     const { viewport } = pixiApp;
@@ -195,7 +188,7 @@ export const FloatingContextMenu = (props: Props) => {
 
   const iconSize = 'small';
 
-  const formatPrimaryCell = sheet.getFormatPrimaryCell();
+  const formatPrimaryCell = sheets.sheet.getFormatPrimaryCell();
 
   return (
     <Paper

--- a/src/ui/menus/SheetBar/SheetBarTab.tsx
+++ b/src/ui/menus/SheetBar/SheetBarTab.tsx
@@ -59,7 +59,10 @@ export const SheetBarTab = (props: Props): JSX.Element => {
       data-id={sheet.id}
       data-order={sheet.order}
       data-actual-order={order}
-      onPointerDown={(event) => onPointerDown({ event, sheet })}
+      onPointerDown={(event) => {
+        if (isRenaming) return;
+        onPointerDown({ event, sheet });
+      }}
       onDoubleClick={() => {
         if (hasPermission) {
           setIsRenaming(true);

--- a/src/ui/menus/SheetBar/SheetBarTab.tsx
+++ b/src/ui/menus/SheetBar/SheetBarTab.tsx
@@ -178,6 +178,7 @@ function TabName({
         minWidth: '1rem',
         fontWeight: 'bold',
         outline: 0,
+        cursor: 'text',
       }}
       ref={contentEditableRef}
       onKeyDown={(event) => {


### PR DESCRIPTION
- [x] Fixes FloatingContextMenu for multiple tabs
- [x] Fix: allow using the mouse to select text when editing a tab name.
- [X] Uses text editing cursor when editing Tab Name