### PR TITLE
fix: copy PNG to clipboard from command palette

### DIFF
--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -42,4 +42,3 @@ export const EXAMPLE_FILES: { [id: string]: { name: string; description: string 
   },
 };
 export const CSV_IMPORT_MESSAGE = 'Drag and drop a CSV file on the grid to import it.';
-export const PNG_MESSAGE = 'Copied selection as PNG to clipboard';

--- a/src/gridGL/interaction/keyboard/keyboardClipboard.ts
+++ b/src/gridGL/interaction/keyboard/keyboardClipboard.ts
@@ -2,7 +2,6 @@ import { isEditorOrAbove } from '../../../actions';
 import { EditorInteractionState } from '../../../atoms/editorInteractionStateAtom';
 import { GridInteractionState } from '../../../atoms/gridInteractionStateAtom';
 import { GlobalSnackbar } from '../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../constants/appConstants';
 import {
   copySelectionToPNG,
   copyToClipboard,
@@ -31,8 +30,7 @@ export function keyboardClipboard(props: {
 
   // Command + Shift + C
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === 'c') {
-    copySelectionToPNG(app);
-    addGlobalSnackbar(PNG_MESSAGE);
+    copySelectionToPNG(app, addGlobalSnackbar);
     event.preventDefault();
     event.stopPropagation();
     return true;

--- a/src/ui/menus/CommandPalette/ListItems/Edit.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Edit.tsx
@@ -3,9 +3,12 @@ import { useRecoilState } from 'recoil';
 import { copy, cut, paste, redo, undo } from '../../../../actions';
 import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../../constants/appConstants';
-import { copyToClipboard, cutToClipboard, pasteFromClipboard } from '../../../../grid/actions/clipboard/clipboard';
-import { copyAsPNG } from '../../../../gridGL/pixiApp/copyAsPNG';
+import {
+  copySelectionToPNG,
+  copyToClipboard,
+  cutToClipboard,
+  pasteFromClipboard,
+} from '../../../../grid/actions/clipboard/clipboard';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
 import { isMac } from '../../../../utils/isMac';
 import { CopyAsPNG } from '../../../icons';
@@ -118,8 +121,7 @@ const ListItems = [
         <CommandPaletteListItem
           {...props}
           action={() => {
-            copyAsPNG(props.app);
-            addGlobalSnackbar(PNG_MESSAGE);
+            copySelectionToPNG(props.app, addGlobalSnackbar);
           }}
           icon={<CopyAsPNG />}
           shortcut="C"

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -20,7 +20,6 @@ import { isEditorOrAbove } from '../../../actions';
 import { EditorInteractionState } from '../../../atoms/editorInteractionStateAtom';
 import { GridInteractionState } from '../../../atoms/gridInteractionStateAtom';
 import { useGlobalSnackbar } from '../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../constants/appConstants';
 import { copySelectionToPNG } from '../../../grid/actions/clipboard/clipboard';
 import { SheetController } from '../../../grid/controller/sheetController';
 import { PixiApp } from '../../../gridGL/pixiApp/PixiApp';
@@ -188,9 +187,8 @@ export const FloatingContextMenu = (props: Props) => {
   }, [viewport, updateContextMenuCSSTransform]);
 
   const copyAsPNG = useCallback(async () => {
-    await copySelectionToPNG(app);
+    await copySelectionToPNG(app, addGlobalSnackbar);
     moreMenuToggle();
-    addGlobalSnackbar(PNG_MESSAGE);
   }, [app, moreMenuToggle, addGlobalSnackbar]);
 
   // If we don't have a viewport, we can't continue.


### PR DESCRIPTION
## Problem

"Copy as PNG" was working from the floating context menu but not from the command palette.

When you choose "Copy as PNG" from the command palette, the little toast notification would pop up saying it was copied

<img width="433" alt="CleanShot 2023-09-22 at 12 41 10@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/a8d2edd6-920e-4644-a7fb-206ba87a7165">

But if you went to paste that PNG somewhere (e.g. Slack) that image was not in your clipboard.

## Fix

It looks like the command palette version of "copy as PNG" was pointing to some old code, whereas the floating context menu (and SHIFT + CMD + C) were using the right functions. So I had it use the same function.

I also noticed that they all were doing the same thing (e.g. copy to clipboard, then fire a toast notification) so I moved all of that functionality into the main function body. Now it's one function call from all three places.

I also added checks in case the "copy as PNG" fails, then we trigger a toast that shows as an error (and fire an event off to sentry).

<img width="605" alt="CleanShot 2023-09-22 at 12 23 43@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/773819b8-7ebd-4837-81ec-c9366bec9c45">
