### PR TITLE
fix: copy PNG to clipboard from command palette

### DIFF
--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -42,4 +42,3 @@ export const EXAMPLE_FILES: { [id: string]: { name: string; description: string 
   },
 };
 export const CSV_IMPORT_MESSAGE = 'Drag and drop a CSV file on the grid to import it.';
-export const PNG_MESSAGE = 'Copied selection as PNG to clipboard';

--- a/src/gridGL/interaction/keyboard/keyboardClipboard.ts
+++ b/src/gridGL/interaction/keyboard/keyboardClipboard.ts
@@ -1,6 +1,5 @@
 import { GlobalSnackbar } from '../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../constants/appConstants';
-import { copySelectionToPNG } from '../../../grid/actions/clipboard/clipboard';
+import { copySelectionToPNG, fullClipboardSupport } from '../../../grid/actions/clipboard/clipboard';
 
 export function keyboardClipboard(props: {
   event: React.KeyboardEvent<HTMLElement>;
@@ -9,9 +8,8 @@ export function keyboardClipboard(props: {
   const { addGlobalSnackbar, event } = props;
 
   // Command + Shift + C
-  if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === 'c') {
-    copySelectionToPNG();
-    addGlobalSnackbar(PNG_MESSAGE);
+  if (fullClipboardSupport() && (event.metaKey || event.ctrlKey) && event.shiftKey && event.key === 'c') {
+    copySelectionToPNG(addGlobalSnackbar);
     event.preventDefault();
     event.stopPropagation();
     return true;

--- a/src/ui/menus/CommandPalette/ListItems/Edit.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Edit.tsx
@@ -3,10 +3,14 @@ import { useRecoilState } from 'recoil';
 import { copy, cut, paste, redo, undo } from '../../../../actions';
 import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../../constants/appConstants';
-import { copyToClipboard, cutToClipboard, pasteFromClipboard } from '../../../../grid/actions/clipboard/clipboard';
+import {
+  copySelectionToPNG,
+  copyToClipboard,
+  cutToClipboard,
+  fullClipboardSupport,
+  pasteFromClipboard,
+} from '../../../../grid/actions/clipboard/clipboard';
 import { grid } from '../../../../grid/controller/Grid';
-import { copyAsPNG } from '../../../../gridGL/pixiApp/copyAsPNG';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
 import { isMac } from '../../../../utils/isMac';
 import { CopyAsPNG } from '../../../icons';
@@ -89,14 +93,14 @@ const ListItems = [
   },
   {
     label: 'Copy selection as PNG',
+    isAvailable: () => fullClipboardSupport(),
     Component: (props: CommandPaletteListItemSharedProps) => {
       const { addGlobalSnackbar } = useGlobalSnackbar();
       return (
         <CommandPaletteListItem
           {...props}
           action={() => {
-            copyAsPNG();
-            addGlobalSnackbar(PNG_MESSAGE);
+            copySelectionToPNG(addGlobalSnackbar);
           }}
           icon={<CopyAsPNG />}
           shortcut="C"

--- a/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/src/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -21,7 +21,6 @@ import { useRecoilValue } from 'recoil';
 import { isEditorOrAbove } from '../../../actions';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
 import { useGlobalSnackbar } from '../../../components/GlobalSnackbarProvider';
-import { PNG_MESSAGE } from '../../../constants/appConstants';
 import { copySelectionToPNG, fullClipboardSupport } from '../../../grid/actions/clipboard/clipboard';
 import { sheets } from '../../../grid/controller/Sheets';
 import { pixiApp } from '../../../gridGL/pixiApp/PixiApp';
@@ -178,9 +177,8 @@ export const FloatingContextMenu = (props: Props) => {
   }, [updateContextMenuCSSTransform]);
 
   const copyAsPNG = useCallback(async () => {
-    await copySelectionToPNG();
+    await copySelectionToPNG(addGlobalSnackbar);
     moreMenuToggle();
-    addGlobalSnackbar(PNG_MESSAGE);
   }, [moreMenuToggle, addGlobalSnackbar]);
 
   // set input's initial position correctly


### PR DESCRIPTION
## Problem

"Copy as PNG" was working from the floating context menu but not from the command palette.

When you choose "Copy as PNG" from the command palette, the little toast notification would pop up saying it was copied

<img width="433" alt="CleanShot 2023-09-22 at 12 41 10@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/a8d2edd6-920e-4644-a7fb-206ba87a7165">

But if you went to paste that PNG somewhere (e.g. Slack) that image was not in your clipboard.

## Fix

It looks like the command palette version of "copy as PNG" was pointing to some old code, whereas the floating context menu (and SHIFT + CMD + C) were using the right functions. So I had it use the same function.

I also noticed that they all were doing the same thing (e.g. copy to clipboard, then fire a toast notification) so I moved all of that functionality into the main function body. Now it's one function call from all three places.

I also added checks in case the "copy as PNG" fails, then we trigger a toast that shows as an error (and fire an event off to sentry).

<img width="605" alt="CleanShot 2023-09-22 at 12 23 43@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/773819b8-7ebd-4837-81ec-c9366bec9c45">

And for browsers that don't support this (e.g. Firefox) you never see the functionality in the app _and the keyboard shortcuts don't work_.

<img width="680" alt="CleanShot 2023-09-22 at 14 03 08@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/7c2a362f-2989-42f2-a363-1354e953a1cd">


Whereas browsers that do support it, you'll see it:

<img width="629" alt="CleanShot 2023-09-22 at 14 03 33@2x" src="https://github.com/quadratichq/quadratic/assets/1316441/0034e6cb-23e2-4e2b-abfc-cd3ff8717611">

