### PR TITLE
feat: improved sheet switcher in command palette

### DIFF
--- a/src/ui/menus/CommandPalette/ListItems/Sheets.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Sheets.tsx
@@ -3,13 +3,14 @@ import { grid } from '../../../../grid/controller/Grid';
 import { sheets } from '../../../../grid/controller/Sheets';
 import { focusGrid } from '../../../../helpers/focusGrid';
 import { CommandPaletteListItem } from '../CommandPaletteListItem';
+import { Commands } from '../getCommandPaletteListItems';
 
 const ListItems = () => {
   // used to trigger changes in sheets
   const [trigger, setTrigger] = useState(0);
 
   const items = useMemo(() => {
-    const items = [
+    const items: Commands[] = [
       {
         label: 'Sheet: Create',
         Component: (props: any) => {
@@ -41,9 +42,30 @@ const ListItems = () => {
     ];
     sheets.forEach((sheet) => {
       items.push({
-        label: `Sheet: Switch to ${sheet.name}`,
+        label: `Sheet: Switch to “${sheet.name}”`,
+        isAvailable: () => sheets.current !== sheet.id,
         Component: (props: any) => {
-          return <CommandPaletteListItem {...props} action={() => (sheets.current = sheet.id)} />;
+          return (
+            <CommandPaletteListItem
+              {...props}
+              icon={
+                sheet.color ? (
+                  <div style={{ width: '24px', height: '24px', display: 'flex', alignItems: 'center' }}>
+                    <div
+                      style={{
+                        // FWIW: these styles match the syltes of the 3rd-party color picker swatches
+                        width: '15px',
+                        height: '15px',
+                        backgroundColor: sheet.color,
+                        borderRadius: '2px',
+                      }}
+                    />
+                  </div>
+                ) : undefined
+              }
+              action={() => (sheets.current = sheet.id)}
+            />
+          );
         },
       });
     });

--- a/src/ui/menus/CommandPalette/ListItems/Sheets.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Sheets.tsx
@@ -53,11 +53,10 @@ const ListItems = () => {
                   <div style={{ width: '24px', height: '24px', display: 'flex', alignItems: 'center' }}>
                     <div
                       style={{
-                        // FWIW: these styles match the syltes of the 3rd-party color picker swatches
-                        width: '15px',
-                        height: '15px',
+                        width: '24px',
+                        height: '3px',
                         backgroundColor: sheet.color,
-                        borderRadius: '2px',
+                        borderRadius: '1px',
                       }}
                     />
                   </div>


### PR DESCRIPTION
Updates the command palette to:

1. Exclude the _current sheet_ from the list of sheets you can switch to
2. For sheets that have a color highlight, show it in the command palette as well

![CleanShot 2023-09-22 at 15 25 15@2x](https://github.com/quadratichq/quadratic/assets/1316441/540b83ef-5034-44c5-b926-0d1ef1f49835)


[Slack convo](https://quadratichq.slack.com/archives/C03VC0Q1MPA/p1695415884523609)