### PR TITLE
feat: add sheets analytics

### DIFF
--- a/src/ui/menus/SheetBar/SheetBar.tsx
+++ b/src/ui/menus/SheetBar/SheetBar.tsx
@@ -1,5 +1,6 @@
 import { Add, ChevronLeft, ChevronRight } from '@mui/icons-material';
 import { Stack, useTheme } from '@mui/material';
+import mixpanel from 'mixpanel-browser';
 import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useRecoilValue } from 'recoil';
@@ -422,6 +423,7 @@ export const SheetBar = (): JSX.Element => {
       {hasPermission && (
         <SheetBarButton
           onClick={() => {
+            mixpanel.track('[Sheets].add');
             sheets.createNew();
             focusGrid();
           }}

--- a/src/ui/menus/SheetBar/SheetBarTabContextMenu.tsx
+++ b/src/ui/menus/SheetBar/SheetBarTabContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { ControlledMenu, MenuDivider, MenuItem, SubMenu } from '@szhsin/react-menu';
+import mixpanel from 'mixpanel-browser';
 import { ColorResult } from 'react-color';
 import { sheets } from '../../../grid/controller/Sheets';
 import { convertReactColorToString } from '../../../helpers/convertColor';
@@ -26,6 +27,7 @@ export const SheetBarTabContextMenu = (props: Props): JSX.Element => {
           onClick={() => {
             if (!contextMenu) return;
             if (window.confirm(`Are you sure you want to delete ${contextMenu.name}?`)) {
+              mixpanel.track('[Sheets].delete');
               sheets.deleteSheet(sheets.sheet.id);
               handleClose();
             }
@@ -38,6 +40,7 @@ export const SheetBarTabContextMenu = (props: Props): JSX.Element => {
         <MenuItem
           onClick={handleClose}
           onClickCapture={() => {
+            mixpanel.track('[Sheets].duplicate');
             sheets.duplicate();
             focusGrid();
           }}


### PR DESCRIPTION
I suppose we could add analytics for tons of stuff related to sheets (e.g. was it renamed? was its order moved? was a color assigned? etc.)

But I went with just adding basic event tracking around whether people are using it at all, e.g. events for:

- Add a sheet
- Duplicate a sheet
- Delete a sheet