### PR TITLE
fix: proper version comparison

### DIFF
--- a/src/dashboard/FileRoute.tsx
+++ b/src/dashboard/FileRoute.tsx
@@ -17,7 +17,7 @@ import { Empty } from '../components/Empty';
 import { ROUTE_LOADER_IDS } from '../constants/routes';
 import { grid } from '../grid/controller/Grid';
 import init, { hello } from '../quadratic-core/quadratic_core';
-import { compareVersions } from '../schemas/compareVersions';
+import { VersionComparisonResult, compareVersions } from '../schemas/compareVersions';
 import { validateAndUpgradeGridFile } from '../schemas/validateAndUpgradeGridFile';
 import QuadraticApp from '../ui/QuadraticApp';
 
@@ -59,13 +59,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs): Promise<F
   hello();
   grid.init();
 
-  // If the file version is newer than what is supported by the current version
-  // of the app, do a (hard) reload.
-  if (compareVersions(contents.version, grid.getVersion()) === 1) {
+  // If the file is newer than the app, do a (hard) reload.
+  const fileVersion = contents.version;
+  const gridVersion = grid.getVersion();
+  if (compareVersions(fileVersion, gridVersion) === VersionComparisonResult.GreaterThan) {
     Sentry.captureEvent({
-      message: `User opened a file at version ${
-        contents.version
-      } but the app is at version ${grid.getVersion()}. The app will automatically reload.`,
+      message: `User opened a file at version ${fileVersion} but the app is at version ${gridVersion}. The app will automatically reload.`,
       level: Sentry.Severity.Log,
     });
     // @ts-expect-error hard reload via `true` only works in some browsers

--- a/src/dashboard/FileRoute.tsx
+++ b/src/dashboard/FileRoute.tsx
@@ -17,6 +17,7 @@ import { Empty } from '../components/Empty';
 import { ROUTE_LOADER_IDS } from '../constants/routes';
 import { grid } from '../grid/controller/Grid';
 import init, { hello } from '../quadratic-core/quadratic_core';
+import { compareVersions } from '../schemas/compareVersions';
 import { validateAndUpgradeGridFile } from '../schemas/validateAndUpgradeGridFile';
 import QuadraticApp from '../ui/QuadraticApp';
 
@@ -60,7 +61,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs): Promise<F
 
   // If the file version is newer than what is supported by the current version
   // of the app, do a (hard) reload.
-  if (contents.version > grid.getVersion()) {
+  if (compareVersions(contents.version, grid.getVersion()) === 1) {
     Sentry.captureEvent({
       message: `User opened a file at version ${
         contents.version

--- a/src/schemas/compareVersions.test.ts
+++ b/src/schemas/compareVersions.test.ts
@@ -1,0 +1,15 @@
+import { compareVersions } from './compareVersions';
+
+describe('compare version strings', () => {
+  test('higher versions return 1', () => {
+    expect(compareVersions('1.1', '1.0')).toBe(1);
+    expect(compareVersions('1.10', '1.9')).toBe(1);
+  });
+  test('lower versions return -1', () => {
+    expect(compareVersions('1.0', '1.1')).toBe(-1);
+    expect(compareVersions('0.9', '1.0')).toBe(-1);
+  });
+  test('equal versions return 0', () => {
+    expect(compareVersions('1.0', '1.0')).toBe(0);
+  });
+});

--- a/src/schemas/compareVersions.test.ts
+++ b/src/schemas/compareVersions.test.ts
@@ -1,15 +1,15 @@
-import { compareVersions } from './compareVersions';
+import { compareVersions, VersionComparisonResult } from './compareVersions';
 
 describe('compare version strings', () => {
   test('higher versions return 1', () => {
-    expect(compareVersions('1.1', '1.0')).toBe(1);
-    expect(compareVersions('1.10', '1.9')).toBe(1);
+    expect(compareVersions('1.1', '1.0')).toBe(VersionComparisonResult.GreaterThan);
+    expect(compareVersions('1.10', '1.9')).toBe(VersionComparisonResult.GreaterThan);
   });
   test('lower versions return -1', () => {
-    expect(compareVersions('1.0', '1.1')).toBe(-1);
-    expect(compareVersions('0.9', '1.0')).toBe(-1);
+    expect(compareVersions('1.0', '1.1')).toBe(VersionComparisonResult.LessThan);
+    expect(compareVersions('0.9', '1.0')).toBe(VersionComparisonResult.LessThan);
   });
   test('equal versions return 0', () => {
-    expect(compareVersions('1.0', '1.0')).toBe(0);
+    expect(compareVersions('1.0', '1.0')).toBe(VersionComparisonResult.Equal);
   });
 });

--- a/src/schemas/compareVersions.ts
+++ b/src/schemas/compareVersions.ts
@@ -1,0 +1,31 @@
+/**
+ * Takes two version strings and compares whether the first one is greater than,
+ * less than, or equal to the second one.
+ *
+ * Examples:
+ *
+ * ("1.1", "1.2")  ->  -1 (less than)
+ *
+ * ("1.1", "1.1")  ->  0 (equal)
+ *
+ * ("1.10", "1.2") ->  1 (greater than)
+ */
+export function compareVersions(version1: string, version2: string) {
+  const parts1 = version1.split('.').map(Number);
+  const parts2 = version2.split('.').map(Number);
+
+  const maxLength = Math.max(parts1.length, parts2.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const num1 = parts1[i] || 0;
+    const num2 = parts2[i] || 0;
+
+    if (num1 < num2) {
+      return -1; // less than
+    } else if (num1 > num2) {
+      return 1; // greater than
+    }
+  }
+
+  return 0; // equal
+}

--- a/src/schemas/compareVersions.ts
+++ b/src/schemas/compareVersions.ts
@@ -1,3 +1,9 @@
+export enum VersionComparisonResult {
+  GreaterThan = 1,
+  LessThan = -1,
+  Equal = 0,
+}
+
 /**
  * Takes two version strings and compares whether the first one is greater than,
  * less than, or equal to the second one.
@@ -21,11 +27,11 @@ export function compareVersions(version1: string, version2: string) {
     const num2 = parts2[i] || 0;
 
     if (num1 < num2) {
-      return -1; // less than
+      return VersionComparisonResult.LessThan;
     } else if (num1 > num2) {
-      return 1; // greater than
+      return VersionComparisonResult.GreaterThan;
     }
   }
 
-  return 0; // equal
+  return VersionComparisonResult.Equal;
 }


### PR DESCRIPTION
The old version comparison would fail (in the future) for a version comparison like:

"1.10" > "1.8"

This is fixed in this PR with the `compareVersions` function (which includes tests).