### PR TITLE
Add sheet info to `parse_formula()`

### DIFF
--- a/quadratic-core/src/controller/formula.rs
+++ b/quadratic-core/src/controller/formula.rs
@@ -127,18 +127,6 @@ mod tests {
         assert_eq!(result.parse_error_msg, None);
         assert_eq!(result.parse_error_span, None);
         assert_eq!(result.cell_refs.len(), 1);
-
-        // todo
-        // assert_eq!(result.cell_refs[0].span, Span { start: 0, end: 12 });
-        // assert_eq!(
-        //     result.cell_refs[0].cell_ref,
-        //     RangeRef::Cell {
-        //         pos: CellRef {
-        //             sheet: Some("Sheet 2".to_string()),
-        //             x: CellRefCoord::Relative(0),
-        //             y: CellRefCoord::Relative(0)
-        //         }
-        //     }
-        // );
+        // `cell_refs` output is tested elsewhere
     }
 }

--- a/quadratic-core/src/formulas/parser/rules/expression.rs
+++ b/quadratic-core/src/formulas/parser/rules/expression.rs
@@ -162,7 +162,7 @@ impl SyntaxRule for ExpressionWithPrecedence {
                 p,
                 [
                     FunctionCall.map(Some),
-                    CellReference.map(Some),
+                    CellReferenceExpression.map(Some),
                     StringLiteralExpression.map(Some),
                     NumericLiteral.map(Some),
                     ArrayLiteral.map(Some),
@@ -340,6 +340,21 @@ impl SyntaxRule for FunctionCall {
             span: Span::merge(func.span, spanned_args.span),
             inner: ast::AstNodeContents::FunctionCall { func, args },
         })
+    }
+}
+
+/// Matches a single cell reference.
+#[derive(Debug, Copy, Clone)]
+pub struct CellReferenceExpression;
+impl_display!(for CellReferenceExpression, "cell reference, such as 'A6' or '$ZB$3'");
+impl SyntaxRule for CellReferenceExpression {
+    type Output = AstNode;
+
+    fn prefix_matches(&self, p: Parser<'_>) -> bool {
+        CellReference.prefix_matches(p)
+    }
+    fn consume_match(&self, p: &mut Parser<'_>) -> CodeResult<Self::Output> {
+        Ok(p.parse(CellReference)?.map(ast::AstNodeContents::CellRef))
     }
 }
 

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -1,8 +1,9 @@
+use itertools::Itertools;
+
 pub(crate) use super::*;
 pub(crate) use crate::grid::Grid;
 pub(crate) use crate::values::*;
-use crate::SheetPos;
-pub(crate) use crate::{array, CodeResult, Error, ErrorMsg, Pos};
+pub(crate) use crate::{array, CodeResult, Error, ErrorMsg, Pos, SheetPos, Spanned};
 
 pub(crate) fn try_eval_at(grid: &Grid, pos: SheetPos, s: &str) -> CodeResult<Value> {
     println!("Evaluating formula {s:?} at {pos:?}");
@@ -251,67 +252,72 @@ fn test_formula_blank_to_string() {
 
 #[test]
 fn test_find_cell_references() {
-    use CellRefCoord::{Absolute, Relative};
+    #[track_caller]
+    fn a1(s: &str) -> CellRef {
+        CellRef::parse_a1(s, Pos::ORIGIN).expect("bad cell reference")
+    }
 
-    // Evaluate at D4.
-    let base = pos![D4];
-    let refs = find_cell_references("SUM($C$4, $A0 : nQ7, :D$n6, A0:, ZB2)", base);
-    let mut iter = refs.into_iter().map(|r| r.inner);
-
-    // $C$4
-    assert_eq!(
-        iter.next(),
-        Some(RangeRef::from(CellRef::absolute(None, pos![C4]))),
-    );
-
-    // $A0:nQ7
-    assert_eq!(
-        iter.next(),
-        Some(RangeRef::CellRange {
-            start: CellRef {
-                sheet: None,
-                x: Absolute(col![A]),
-                y: Relative(0 - base.y),
+    // Another test checks that `parse_a1()` is correct.
+    let test_cases = [
+        // Basic cell reference
+        ("$A$1", RangeRef::Cell { pos: a1("$A$1") }),
+        // Range
+        (
+            "An1:A3",
+            RangeRef::CellRange {
+                start: a1("An1"),
+                end: a1("A3"),
             },
-            end: CellRef {
-                sheet: None,
-                x: Relative(col![nQ] - base.x),
-                y: Relative(7 - base.y),
+        ),
+        // Range with spaces
+        (
+            "A$2 : Bn2",
+            RangeRef::CellRange {
+                start: a1("A$2"),
+                end: a1("Bn2"),
             },
-        }),
-    );
-
-    // D$n6
-    assert_eq!(
-        iter.next(),
-        Some(RangeRef::from(CellRef {
-            sheet: None,
-            x: Relative(col![D] - base.x),
-            y: Absolute(-6),
-        })),
-    );
-
-    // A0
-    assert_eq!(
-        iter.next(),
-        Some(RangeRef::from(CellRef {
-            sheet: None,
-            x: Relative(col![A] - base.x),
-            y: Relative(0 - base.y),
-        })),
-    );
-
-    // ZB2
-    assert_eq!(
-        iter.next(),
-        Some(RangeRef::from(CellRef {
-            sheet: None,
-            x: Relative(col![ZB] - base.x),
-            y: Relative(2 - base.y),
-        })),
-    );
-
-    assert_eq!(iter.next(), None);
+        ),
+        // Unquoted sheet reference
+        (
+            "apple!A$1",
+            RangeRef::Cell {
+                pos: a1("apple!A$1"),
+            },
+        ),
+        // Unquoted sheet reference range with spaces
+        (
+            "orange ! A2: $Q9",
+            RangeRef::CellRange {
+                start: a1("orange ! A2"),
+                end: a1("$Q9"),
+            },
+        ),
+        // Quoted sheet reference range
+        (
+            "'banana'!$A1:QQ$222",
+            RangeRef::CellRange {
+                start: a1("'banana'!$A1"),
+                end: a1("QQ$222"),
+            },
+        ),
+        // Quoted sheet reference with spaces
+        (
+            "\"plum\" ! $A1",
+            RangeRef::Cell {
+                pos: a1("\"plum\"!$A1"),
+            },
+        ),
+    ];
+    let formula_string = test_cases.iter().map(|(string, _)| string).join(" + ");
+    let cell_references_found = find_cell_references(&formula_string, Pos::ORIGIN)
+        .into_iter()
+        .map(|Spanned { span, inner }| (span.of_str(&formula_string), inner))
+        .collect_vec();
+    // Assert each individual one for better error messages on test failure.
+    for i in 0..test_cases.len() {
+        assert_eq!(&cell_references_found[i], &test_cases[i]);
+    }
+    assert_eq!(cell_references_found.len(), test_cases.len());
 }
 
 #[test]

--- a/quadratic-core/src/span.rs
+++ b/quadratic-core/src/span.rs
@@ -112,4 +112,13 @@ impl<T> Spanned<T> {
             inner: &self.inner,
         }
     }
+
+    /// Merges two spans using `Span::merge()` and merges the inner values using
+    /// the provided function.
+    pub fn merge<U, V>(a: Spanned<U>, b: Spanned<V>, merge: impl FnOnce(U, V) -> T) -> Spanned<T> {
+        Spanned {
+            span: Span::merge(a.span, b.span),
+            inner: merge(a.inner, b.inner),
+        }
+    }
 }

--- a/src/gridGL/pixiApp/highlightedCells.ts
+++ b/src/gridGL/pixiApp/highlightedCells.ts
@@ -86,6 +86,6 @@ export class HighlightedCells {
   }
 
   getHighlightedCells(): HighlightedCellRange[] {
-    return Array.from(this.highlightedCells.values()).filter((cell) => cell.sheet === sheets.sheet.id);
+    return Array.from(this.highlightedCells.values()).filter((cell) => cell.sheet === sheets.sheet.name);
   }
 }


### PR DESCRIPTION
The params & return value stay the same. `parse_formula()` just does parsing, no semantics, so it only knows sheet names given by the user, not sheet IDs or the current sheet. E.g., `SUM(A1:A10)` would have `sheet: null` for the cell reference `A1:A10` but `SUM(MySheet!A1:A10)` would have `sheet: "MySheet"` for the cell reference `MySheet!A1:A10`.

To review:
- Look over the new tests and see if anything's missing.
