### PR TITLE
Update Docs Links

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,6 +1,6 @@
 export const DOCUMENTATION_URL = 'https://docs.quadratichq.com';
-export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/python`;
-export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}/formulas`;
+export const DOCUMENTATION_PYTHON_URL = `${DOCUMENTATION_URL}/writing-python/getting-started`;
+export const DOCUMENTATION_FORMULAS_URL = `${DOCUMENTATION_URL}/writing-formulas/getting-started`;
 export const DOCUMENTATION_FILES_URL = `${DOCUMENTATION_URL}/files`;
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';
 export const DISCORD = 'https://discord.gg/quadratic';

--- a/src/ui/components/TooltipHint.tsx
+++ b/src/ui/components/TooltipHint.tsx
@@ -11,7 +11,6 @@ interface TooltipHintProps {
 export const TooltipHint = ({ title, shortcut, children, ...rest }: TooltipHintProps) => {
   return (
     <Tooltip
-      {...rest}
       arrow
       placement="top"
       title={
@@ -20,6 +19,7 @@ export const TooltipHint = ({ title, shortcut, children, ...rest }: TooltipHintP
         </>
       }
       disableInteractive
+      {...rest}
     >
       {children}
     </Tooltip>

--- a/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -1,4 +1,4 @@
-import { Close, FiberManualRecord, PlayArrow, Subject } from '@mui/icons-material';
+import { Close, FiberManualRecord, HelpOutline, PlayArrow, Subject } from '@mui/icons-material';
 import { CircularProgress, IconButton, useTheme } from '@mui/material';
 import { useRecoilValue } from 'recoil';
 import { loadedStateAtom } from '../../../atoms/loadedStateAtom';
@@ -7,6 +7,7 @@ import { KeyboardSymbols } from '../../../helpers/keyboardSymbols';
 // import { CodeCellValue } from '../../../quadratic-core/types';
 import { isEditorOrAbove } from '../../../actions';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
+import { DOCUMENTATION_FORMULAS_URL, DOCUMENTATION_PYTHON_URL, DOCUMENTATION_URL } from '../../../constants/urls';
 import { colors } from '../../../theme/colors';
 import { TooltipHint } from '../../components/TooltipHint';
 import { Formula, Python } from '../../icons';
@@ -87,8 +88,22 @@ export const CodeEditorHeader = (props: Props) => {
             <CircularProgress color="inherit" size="1.125rem" sx={{ m: '0 .5rem' }} />
           </div>
         )}
+        <TooltipHint title="Read the docs" placement="bottom">
+          <IconButton
+            aria-label="docs"
+            size="small"
+            color="primary"
+            onClick={() => {
+              if (language === 'FORMULA') window.open(DOCUMENTATION_FORMULAS_URL, '_blank');
+              else if (language === 'PYTHON') window.open(DOCUMENTATION_PYTHON_URL, '_blank');
+              else window.open(DOCUMENTATION_URL, '_blank');
+            }}
+          >
+            <HelpOutline fontSize="small" />
+          </IconButton>
+        </TooltipHint>
         {hasPermission && (
-          <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`}>
+          <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`} placement="bottom">
             <span>
               <IconButton
                 id="QuadraticCodeEditorRunButtonID"
@@ -102,7 +117,7 @@ export const CodeEditorHeader = (props: Props) => {
             </span>
           </TooltipHint>
         )}
-        <TooltipHint title="Close" shortcut="ESC">
+        <TooltipHint title="Close" shortcut="ESC" placement="bottom">
           <IconButton id="QuadraticCodeEditorCloseButtonID" size="small" onClick={closeEditor}>
             <Close />
           </IconButton>

--- a/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -92,7 +92,6 @@ export const CodeEditorHeader = (props: Props) => {
           <IconButton
             aria-label="docs"
             size="small"
-            color="primary"
             onClick={() => {
               if (language === 'FORMULA') window.open(DOCUMENTATION_FORMULAS_URL, '_blank');
               else if (language === 'PYTHON') window.open(DOCUMENTATION_PYTHON_URL, '_blank');

--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -1,16 +1,12 @@
 import { Box, Tab, Tabs } from '@mui/material';
 import { useTheme } from '@mui/system';
-import { stripIndent } from 'common-tags';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { isViewerOrAbove } from '../../../actions';
 import { EditorInteractionState, editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
-import { DOCUMENTATION_FORMULAS_URL, DOCUMENTATION_PYTHON_URL } from '../../../constants/urls';
 // import { CodeCellRunOutput, CodeCellValue } from '../../../quadratic-core/types';
 import { Circle } from '@mui/icons-material';
 import { colors } from '../../../theme/colors';
-import { CodeSnippet } from '../../components/CodeSnippet';
-import { LinkNewTab } from '../../components/LinkNewTab';
 import { AITab } from './AITab';
 import { codeEditorBaseStyles, codeEditorCommentStyles } from './styles';
 
@@ -52,12 +48,6 @@ export function Console({ consoleOutput, editorMode, editorContent, evaluationRe
             aria-controls="console-tabpanel-0"
             icon={hasOutput ? <Circle sx={{ fontSize: 8 }}></Circle> : undefined}
             iconPosition="end"
-          ></Tab>
-          <Tab
-            style={{ minHeight: '32px' }}
-            label="Documentation"
-            id="console-tab-1"
-            aria-controls="console-tabpanel-1"
           ></Tab>
           {editorMode === 'PYTHON' && isViewerOrAbove(permission) && (
             <Tab
@@ -109,135 +99,6 @@ export function Console({ consoleOutput, editorMode, editorContent, evaluationRe
               </div>
             )}
           </div>
-        </TabPanel>
-        <TabPanel value={activeTabIndex} index={1}>
-          {editorMode === 'PYTHON' ? (
-            <div style={{ overflow: 'scroll' }}>
-              <h4>Logging</h4>
-              <p>`print()` statements and errors are logged in the CONSOLE tab.</p>
-              <h4>Returning data to the sheet</h4>
-              <p>The last statement in your code is returned to the sheet.</p>
-              <p>Example:</p>
-
-              <CodeSnippet
-                language="python"
-                code={stripIndent`
-                  2 * 2
-                  # Returns the value '4' to the active cell
-                `}
-              />
-
-              <p>Example:</p>
-
-              <CodeSnippet
-                language="python"
-                code={stripIndent`
-                  result = []
-                  for x in range(100):
-                      result.append(x)
-
-                  result
-                  # Returns a list of 100 numbers, from 0 to 99
-                  # [0, 1, 2, ..., 99]
-                `}
-              />
-
-              <h4>Referencing data from the sheet</h4>
-              <p>Use the `cell(x, y)` function — or shorthand `c(x, y)` — to reference values in the sheet.</p>
-              <p>Example:</p>
-
-              <CodeSnippet
-                language="python"
-                code={stripIndent`
-                  c(1, 1) + c(2, 2)
-                  # Returns the sum of the cell values at (x:1, y:1) and (x:2, y:2)
-                `}
-              />
-
-              <h4>Advanced topics</h4>
-              <ul>
-                <li>Fetching data from an API.</li>
-                <li>Using Pandas DataFrames.</li>
-                <li>Installing third-party packages.</li>
-              </ul>
-              <p>
-                <LinkNewTab href={DOCUMENTATION_PYTHON_URL}>Learn more in our documentation</LinkNewTab>.
-              </p>
-              <br />
-            </div>
-          ) : (
-            <>
-              <h4>Spreadsheet formulas</h4>
-              <p>Use the familiar language of spreadsheet formulas.</p>
-              <p>Example:</p>
-
-              <CodeSnippet language="formula" code={`SUM(A0:A99)`} />
-
-              <h4>Referencing cells</h4>
-              <p>
-                In the positive quadrant, cells are referenced similar to other spreadsheets. In the negative quadrant,
-                cells are referenced using a `n` prefix.
-              </p>
-              <p>Examples:</p>
-              <table>
-                <thead>
-                  <tr>
-                    <th style={{ textAlign: 'left' }}>
-                      <code>nAn0</code>
-                    </th>
-                    <th style={{ textAlign: 'left' }}>
-                      <code>(x, y)</code>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {[
-                    ['A0', '(0,0)'],
-                    ['A1', '(0, 1)'],
-                    ['B1', '(1, 1)'],
-                    ['An1', '(0, -1)'],
-                    ['nA1', '(-1, 1)'],
-                    ['nAn1', '(-1, -1)'],
-                  ].map(([key, val]) => (
-                    <tr key={key}>
-                      <td style={{ minWidth: '5rem' }}>
-                        <code>{key}</code>
-                      </td>
-                      <td>
-                        <code>{val}</code>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-
-              <h4>Multiline formulas</h4>
-              <p>
-                Line spaces are ignored when evaluating formulas. You can use them to make your formulas more readable.
-              </p>
-              <p>Example:</p>
-
-              <CodeSnippet
-                language="formula"
-                code={stripIndent`
-                  IF(A0 > 0,
-                    IF(B0 < 2,
-                      "Valid Dataset",
-                      "B0 is invalid"
-                    ),
-                    "A0 is invalid"
-                  )
-                `}
-              />
-
-              <h4>More info</h4>
-              <p>
-                <LinkNewTab href={DOCUMENTATION_FORMULAS_URL}>Check out the docs</LinkNewTab> to see a full list of
-                supported formulas and documentation for how to use specific formula functions.
-              </p>
-              <br></br>
-            </>
-          )}
         </TabPanel>
         <TabPanel value={activeTabIndex} index={2}>
           <AITab


### PR DESCRIPTION
closes #798

- updated docs URLS
- Remove documentation tab from CodeEditor
- Add docs link in CodeEditorHeader

![CleanShot 2023-11-14 at 16 28 34@2x](https://github.com/quadratichq/quadratic/assets/3479421/88c01a41-e70c-4be8-82e9-f4f71b251820)
