### PR TITLE
Fix blank grid loading on mobile

### DIFF
--- a/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/QuadraticMenu.tsx
@@ -26,6 +26,7 @@ import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider
 import { ROUTES } from '../../../../constants/routes';
 import { copyToClipboard, cutToClipboard, pasteFromClipboard } from '../../../../grid/actions/clipboard/clipboard';
 import { grid } from '../../../../grid/controller/Grid';
+import { pixiApp } from '../../../../gridGL/pixiApp/PixiApp';
 import { focusGrid } from '../../../../helpers/focusGrid';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
 import { useRootRouteLoaderData } from '../../../../router';
@@ -51,6 +52,7 @@ export const QuadraticMenu = () => {
   useEffect(() => {
     if (isMobile) {
       settings.setShowHeadings(false);
+      pixiApp.viewportChanged();
     }
     // eslint-disable-next-line
   }, []);


### PR DESCRIPTION
Fixes #815

When loading documents on mobile, they previously show up blank until moving the viewport.