### PR TITLE
refactor: remove icons from UI

### DIFF
--- a/src/ui/menus/CommandPalette/ListItems/Borders.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Borders.tsx
@@ -1,15 +1,3 @@
-import {
-  BorderAll,
-  BorderBottom,
-  BorderClear,
-  BorderHorizontal,
-  BorderInner,
-  BorderLeft,
-  BorderOuter,
-  BorderRight,
-  BorderTop,
-  BorderVertical,
-} from '@mui/icons-material';
 import { isEditorOrAbove } from '../../../../actions';
 import { BorderSelection } from '../../../../quadratic-core/quadratic_core';
 import { ChangeBorder, useBorders } from '../../TopBar/SubMenus/useBorders';
@@ -18,45 +6,40 @@ import { CommandPaletteListItem, CommandPaletteListItemSharedProps } from '../Co
 const ListItems = [
   // Convenience to generate all the border component variations
   ...[
-    { label: 'Borders: Apply all', icon: <BorderAll />, changeBordersArgs: { borderAll: true } },
+    {
+      label: 'Borders: Apply all',
+      changeBordersArgs: { borderAll: true },
+    },
     {
       label: 'Borders: Apply outer',
-      icon: <BorderOuter />,
       changeBordersArgs: { selection: BorderSelection.Outer },
     },
     {
       label: 'Borders: Apply inner',
-      icon: <BorderInner />,
       changeBordersArgs: { selection: BorderSelection.Inner },
     },
     {
       label: 'Borders: Apply vertical',
-      icon: <BorderVertical />,
       changeBordersArgs: { selection: BorderSelection.Vertical },
     },
     {
       label: 'Borders: Apply horizontal',
-      icon: <BorderHorizontal />,
       changeBordersArgs: { selection: BorderSelection.Horizontal },
     },
     {
       label: 'Borders: Apply left',
-      icon: <BorderLeft />,
       changeBordersArgs: { selection: BorderSelection.Left },
     },
     {
       label: 'Borders: Apply right',
-      icon: <BorderRight />,
       changeBordersArgs: { selection: BorderSelection.Right },
     },
     {
       label: 'Borders: Apply top',
-      icon: <BorderTop />,
       changeBordersArgs: { selection: BorderSelection.Top },
     },
     {
       label: 'Borders: Apply bottom',
-      icon: <BorderBottom />,
       changeBordersArgs: { selection: BorderSelection.Bottom },
     },
   ].map(generateListItem),
@@ -71,7 +54,6 @@ const ListItems = [
           action={() => {
             clearBorders();
           }}
-          icon={<BorderClear />}
         />
       );
     },

--- a/src/ui/menus/CommandPalette/ListItems/Edit.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Edit.tsx
@@ -1,4 +1,3 @@
-import { ContentCopy, ContentCut, ContentPaste, East, Redo, Undo } from '@mui/icons-material';
 import { useRecoilState } from 'recoil';
 import { copy, cut, paste, redo, undo } from '../../../../actions';
 import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
@@ -13,7 +12,6 @@ import {
 import { grid } from '../../../../grid/controller/Grid';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
 import { isMac } from '../../../../utils/isMac';
-import { CopyAsPNG } from '../../../icons';
 import { CommandPaletteListItem, CommandPaletteListItemSharedProps } from '../CommandPaletteListItem';
 
 const ListItems = [
@@ -24,7 +22,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<Undo />}
           action={grid.undo}
           shortcut="Z"
           shortcutModifiers={[KeyboardSymbols.Command]}
@@ -39,7 +36,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<Redo />}
           action={grid.redo}
           shortcut={isMac ? 'Z' : 'Y'}
           shortcutModifiers={isMac ? [KeyboardSymbols.Command, KeyboardSymbols.Shift] : [KeyboardSymbols.Command]}
@@ -55,7 +51,6 @@ const ListItems = [
         <CommandPaletteListItem
           {...props}
           action={cutToClipboard}
-          icon={<ContentCut />}
           shortcut="X"
           shortcutModifiers={[KeyboardSymbols.Command]}
         />
@@ -69,7 +64,6 @@ const ListItems = [
         <CommandPaletteListItem
           {...props}
           action={copyToClipboard}
-          icon={<ContentCopy />}
           shortcut="C"
           shortcutModifiers={[KeyboardSymbols.Command]}
         />
@@ -84,7 +78,6 @@ const ListItems = [
         <CommandPaletteListItem
           {...props}
           action={pasteFromClipboard}
-          icon={<ContentPaste />}
           shortcut="V"
           shortcutModifiers={[KeyboardSymbols.Command]}
         />
@@ -102,7 +95,6 @@ const ListItems = [
           action={() => {
             copySelectionToPNG(addGlobalSnackbar);
           }}
-          icon={<CopyAsPNG />}
           shortcut="C"
           shortcutModifiers={[KeyboardSymbols.Command, KeyboardSymbols.Shift]}
         />
@@ -123,7 +115,6 @@ const ListItems = [
               showGoToMenu: true,
             });
           }}
-          icon={<East />}
           shortcut="G"
           shortcutModifiers={[KeyboardSymbols.Command]}
         />

--- a/src/ui/menus/CommandPalette/ListItems/File.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/File.tsx
@@ -23,7 +23,7 @@ const ListItems = [
       const action = () => {
         duplicateFile.run({ name, submit });
       };
-      return <CommandPaletteListItem {...props} icon={<FileCopyOutlined />} action={action} />;
+      return <CommandPaletteListItem {...props} action={action} />;
     },
   },
   {

--- a/src/ui/menus/CommandPalette/ListItems/File.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/File.tsx
@@ -1,4 +1,3 @@
-import { DeleteOutline, FileCopyOutlined, FileDownloadOutlined, InsertDriveFileOutlined } from '@mui/icons-material';
 import { useNavigate, useParams } from 'react-router-dom';
 import { createNewFile, deleteFile, downloadFile, duplicateFile } from '../../../../actions';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
@@ -13,7 +12,7 @@ const ListItems = [
     Component: (props: CommandPaletteListItemSharedProps) => {
       const navigate = useNavigate();
       const action = () => createNewFile.run({ navigate });
-      return <CommandPaletteListItem {...props} icon={<InsertDriveFileOutlined />} action={action} />;
+      return <CommandPaletteListItem {...props} action={action} />;
     },
   },
   {
@@ -22,7 +21,7 @@ const ListItems = [
     Component: (props: CommandPaletteListItemSharedProps) => {
       const navigate = useNavigate();
       const action = () => navigate(ROUTES.CREATE_FILE);
-      return <CommandPaletteListItem {...props} icon={<FileCopyOutlined />} action={action} />;
+      return <CommandPaletteListItem {...props} action={action} />;
     },
   },
   {
@@ -30,9 +29,7 @@ const ListItems = [
     isAvailable: downloadFile.isAvailable,
     Component: (props: CommandPaletteListItemSharedProps) => {
       const { name } = useFileContext();
-      return (
-        <CommandPaletteListItem {...props} icon={<FileDownloadOutlined />} action={() => downloadFile.run({ name })} />
-      );
+      return <CommandPaletteListItem {...props} action={() => downloadFile.run({ name })} />;
     },
   },
   {
@@ -42,7 +39,7 @@ const ListItems = [
       const { uuid } = useParams() as { uuid: string };
       const { addGlobalSnackbar } = useGlobalSnackbar();
       const action = () => deleteFile.run({ uuid, addGlobalSnackbar });
-      return <CommandPaletteListItem {...props} icon={<DeleteOutline />} action={action} />;
+      return <CommandPaletteListItem {...props} action={action} />;
     },
   },
 ];

--- a/src/ui/menus/CommandPalette/ListItems/Format.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Format.tsx
@@ -1,7 +1,5 @@
-import { AttachMoney, FormatClear, Functions, ModeEditOutline, Percent } from '@mui/icons-material';
 import { isEditorOrAbove } from '../../../../actions';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
-import { DecimalDecrease, DecimalIncrease, Icon123 } from '../../../icons';
 import {
   clearFormattingAndBorders,
   removeCellNumericFormat,
@@ -22,7 +20,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<FormatClear />}
           action={clearFormattingAndBorders}
           shortcut="\"
           shortcutModifiers={KeyboardSymbols.Command}
@@ -34,49 +31,49 @@ const ListItems = [
     label: 'Format: Number as automatic',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<Icon123 />} action={removeCellNumericFormat} />;
+      return <CommandPaletteListItem {...props} action={removeCellNumericFormat} />;
     },
   },
   {
     label: 'Format: Number as currency',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<AttachMoney />} action={textFormatSetCurrency} />;
+      return <CommandPaletteListItem {...props} action={textFormatSetCurrency} />;
     },
   },
   {
     label: 'Format: Number as percentage',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<Percent />} action={textFormatSetPercentage} />;
+      return <CommandPaletteListItem {...props} action={textFormatSetPercentage} />;
     },
   },
   {
     label: 'Format: Number as scientific',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<Functions />} action={textFormatSetExponential} />;
+      return <CommandPaletteListItem {...props} action={textFormatSetExponential} />;
     },
   },
   {
     label: 'Format: Number toggle commas',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<ModeEditOutline />} action={toggleCommas} />;
+      return <CommandPaletteListItem {...props} action={toggleCommas} />;
     },
   },
   {
     label: 'Format: Increase decimal place',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<DecimalIncrease />} action={textFormatIncreaseDecimalPlaces} />;
+      return <CommandPaletteListItem {...props} action={textFormatIncreaseDecimalPlaces} />;
     },
   },
   {
     label: 'Format: Decrease decimal place',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<DecimalDecrease />} action={textFormatDecreaseDecimalPlaces} />;
+      return <CommandPaletteListItem {...props} action={textFormatDecreaseDecimalPlaces} />;
     },
   },
 ];

--- a/src/ui/menus/CommandPalette/ListItems/Help.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Help.tsx
@@ -1,4 +1,4 @@
-import { ChatBubbleOutline, OpenInNew } from '@mui/icons-material';
+import { OpenInNew } from '@mui/icons-material';
 import { useSetRecoilState } from 'recoil';
 import { provideFeedback, viewDocs } from '../../../../actions';
 import { editorInteractionStateAtom } from '../../../../atoms/editorInteractionStateAtom';
@@ -25,7 +25,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<ChatBubbleOutline />}
           action={() => {
             provideFeedback.run({ setEditorInteractionState });
           }}

--- a/src/ui/menus/CommandPalette/ListItems/Import.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Import.tsx
@@ -1,4 +1,3 @@
-import { UploadFile } from '@mui/icons-material';
 import { isEditorOrAbove } from '../../../../actions';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
 import { CSV_IMPORT_MESSAGE } from '../../../../constants/appConstants';
@@ -14,7 +13,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<UploadFile />}
           action={() => {
             addGlobalSnackbar(CSV_IMPORT_MESSAGE);
           }}

--- a/src/ui/menus/CommandPalette/ListItems/Text.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/Text.tsx
@@ -1,4 +1,3 @@
-import { FormatAlignCenter, FormatAlignLeft, FormatAlignRight, FormatBold, FormatItalic } from '@mui/icons-material';
 import { isEditorOrAbove } from '../../../../actions';
 import { sheets } from '../../../../grid/controller/Sheets';
 import { KeyboardSymbols } from '../../../../helpers/keyboardSymbols';
@@ -13,7 +12,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<FormatBold />}
           action={() => {
             setBold(!sheets.sheet.getFormatPrimaryCell()?.bold);
           }}
@@ -30,7 +28,6 @@ const ListItems = [
       return (
         <CommandPaletteListItem
           {...props}
-          icon={<FormatItalic />}
           action={() => {
             setItalic(!sheets.sheet.getFormatPrimaryCell()?.italic);
           }}
@@ -44,21 +41,21 @@ const ListItems = [
     label: 'Text: Align left',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<FormatAlignLeft />} action={() => setAlignment('left')} />;
+      return <CommandPaletteListItem {...props} action={() => setAlignment('left')} />;
     },
   },
   {
     label: 'Text: Align center',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<FormatAlignCenter />} action={() => setAlignment('center')} />;
+      return <CommandPaletteListItem {...props} action={() => setAlignment('center')} />;
     },
   },
   {
     label: 'Text: Align right',
     isAvailable: isEditorOrAbove,
     Component: (props: any) => {
-      return <CommandPaletteListItem {...props} icon={<FormatAlignRight />} action={() => setAlignment('right')} />;
+      return <CommandPaletteListItem {...props} action={() => setAlignment('right')} />;
     },
   },
 ];

--- a/src/ui/menus/TopBar/SubMenus/DataMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/DataMenu.tsx
@@ -1,11 +1,5 @@
-import {
-  CloudDownloadOutlined,
-  DataObjectOutlined,
-  InsertDriveFile,
-  StorageOutlined,
-  UploadFile,
-} from '@mui/icons-material';
-import { Menu, MenuHeader, MenuItem } from '@szhsin/react-menu';
+import { DataObjectOutlined } from '@mui/icons-material';
+import { Menu, MenuDivider, MenuHeader, MenuItem } from '@szhsin/react-menu';
 import '@szhsin/react-menu/dist/index.css';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
 import { CSV_IMPORT_MESSAGE } from '../../../../constants/appConstants';
@@ -30,17 +24,18 @@ export const DataMenu = () => {
             addGlobalSnackbar(CSV_IMPORT_MESSAGE);
           }}
         >
-          <MenuLineItem primary="CSV" Icon={UploadFile} />
+          <MenuLineItem primary="CSV" />
         </MenuItem>
         <MenuItem disabled>
-          <MenuLineItem primary="Excel (coming soon)" Icon={InsertDriveFile} />
+          <MenuLineItem primary="Excel (coming soon)" />
         </MenuItem>
+        <MenuDivider />
         <MenuHeader>Connect</MenuHeader>
         <MenuItem disabled>
-          <MenuLineItem primary="SaaS (coming soon)" Icon={CloudDownloadOutlined} />
+          <MenuLineItem primary="SaaS (coming soon)" />
         </MenuItem>
         <MenuItem disabled>
-          <MenuLineItem primary="Database (coming soon)" Icon={StorageOutlined} />
+          <MenuLineItem primary="Database (coming soon)" />
         </MenuItem>
       </Menu>
     </>

--- a/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
+++ b/src/ui/menus/TopBar/SubMenus/NumberFormatMenu.tsx
@@ -1,8 +1,7 @@
 import { Menu, MenuDivider, MenuItem } from '@szhsin/react-menu';
 
-import { AttachMoney, Functions, ModeEditOutline, Percent } from '@mui/icons-material';
 import '@szhsin/react-menu/dist/index.css';
-import { DecimalDecrease, DecimalIncrease, Icon123 } from '../../../icons';
+import { Icon123 } from '../../../icons';
 import { MenuLineItem } from '../MenuLineItem';
 import {
   removeCellNumericFormat,
@@ -27,19 +26,19 @@ export const NumberFormatMenu = () => {
       )}
     >
       <MenuItem onClick={() => removeCellNumericFormat()}>
-        <MenuLineItem primary="Automatic" secondary={<code>999.99</code>} Icon={Icon123} />
+        <MenuLineItem primary="Automatic" secondary={<code className="text-xs">999.99</code>} />
       </MenuItem>
       <MenuItem onClick={() => textFormatSetCurrency()}>
-        <MenuLineItem primary="Currency" secondary={<code>$9,999.99</code>} Icon={AttachMoney} />
+        <MenuLineItem primary="Currency" secondary={<code className="text-xs">$9,999.99</code>} />
       </MenuItem>
       <MenuItem onClick={() => textFormatSetPercentage()}>
-        <MenuLineItem primary="Percent" secondary={<code>99.99%</code>} Icon={Percent} />
+        <MenuLineItem primary="Percent" secondary={<code className="text-xs">99.99%</code>} />
       </MenuItem>
       <MenuItem onClick={() => textFormatSetExponential()}>
-        <MenuLineItem primary="Scientific" secondary={<code>6.02E+23</code>} Icon={Functions} />
+        <MenuLineItem primary="Scientific" secondary={<code className="text-xs">6.02E+23</code>} />
       </MenuItem>
       <MenuItem onClick={() => toggleCommas()}>
-        <MenuLineItem primary="Toggle Commas" secondary={<code>9,999.99</code>} Icon={ModeEditOutline} />
+        <MenuLineItem primary="Toggle commas" secondary={<code className="text-xs">9,999.99</code>} />
       </MenuItem>
 
       <MenuDivider />
@@ -49,14 +48,14 @@ export const NumberFormatMenu = () => {
           textFormatIncreaseDecimalPlaces();
         }}
       >
-        <MenuLineItem primary="Increase decimals" Icon={DecimalIncrease} />
+        <MenuLineItem primary="Increase decimals" secondary={<code className="text-xs">.0000</code>} />
       </MenuItem>
       <MenuItem
         onClick={() => {
           textFormatDecreaseDecimalPlaces();
         }}
       >
-        <MenuLineItem primary="Decrease decimals" Icon={DecimalDecrease} />
+        <MenuLineItem primary="Decrease decimals" secondary={<code className="text-xs">.0</code>} />
       </MenuItem>
     </Menu>
   );


### PR DESCRIPTION
IMO we have too many icons. It's diluting the value/efficacy of the ones we do have. I think we should use them a lot more sparingly. My impulse is to remove a bunch, and then we can always add them back where we can justify their value.

The new command palette 

![CleanShot 2023-11-16 at 16 31 28@2x](https://github.com/quadratichq/quadratic/assets/1316441/ca38b7f7-a891-4d97-8aae-cb97a42c3952)

which is a lot more akin to Figma's: graphical elements are only used for 1) toggles, to indicate the on/off state of an item, or 2) external links, indicating these items will take you out of the app.

(Figma's UI)

![CleanShot 2023-11-16 at 16 28 28@2x](https://github.com/quadratichq/quadratic/assets/1316441/3e40d95f-7c24-4474-8a36-a4a2c1feabd8)

I also removed them from dropdown menus

![CleanShot 2023-11-16 at 20 34 34@2x](https://github.com/quadratichq/quadratic/assets/1316441/b4ee1315-2966-4090-a5c6-0f598a2dc43d)

![CleanShot 2023-11-16 at 20 35 44@2x](https://github.com/quadratichq/quadratic/assets/1316441/488f3177-401c-4b02-a709-baf94be7d61c)

For now, I think it's ok to keep them in the formatting menu.

## Todos

- [ ] Once #604 is done, remove the icons from the floating flyout menu and then merge this