### PR TITLE
cell sheet may not be defined if deleted

### DIFF
--- a/src/gridGL/cells/CellsSheet.ts
+++ b/src/gridGL/cells/CellsSheet.ts
@@ -371,12 +371,9 @@ export class CellsSheet extends Container {
   modified(modified: CellSheetsModified[]): void {
     for (const update of modified) {
       const cellsHash = this.getCellsHash(Number(update.x) * sheetHashWidth, Number(update.y) * sheetHashHeight, true);
-
-      // cellsHash should always exists since we createAsNeeded = true
-      if (!cellsHash) {
-        throw new Error('Expected cellsHash to be defined in modified of CellsSheet');
+      if (cellsHash) {
+        cellsHash.dirty = true;
       }
-      cellsHash.dirty = true;
     }
   }
 }


### PR DESCRIPTION
Removed the exception in cellSheet.ts as we do expect cellsHash to be undefined if all the data from that has was deleted.