### PR TITLE
fix: duplicate file

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -68,7 +68,7 @@ export const duplicateFile = {
   label: 'Duplicate',
   isAvailable: isViewerOrAbove,
   run({ name, submit }: { name: string; submit: SubmitFunction }) {
-    let data: CreateActionRequest = {
+    const data: CreateActionRequest = {
       name: name + ' (Copy)',
       contents: grid.export(),
       version: grid.getVersion(),

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,6 +6,7 @@ import { EditorInteractionState } from './atoms/editorInteractionStateAtom';
 import { GlobalSnackbar } from './components/GlobalSnackbarProvider';
 import { ROUTES } from './constants/routes';
 import { DOCUMENTATION_URL } from './constants/urls';
+import { CreateActionRequest } from './dashboard/FilesCreateRoute';
 import { grid } from './grid/controller/Grid';
 import { downloadFileInBrowser } from './helpers/downloadFileInBrowser';
 import { FileContextType } from './ui/components/FileProvider';
@@ -67,11 +68,13 @@ export const duplicateFile = {
   label: 'Duplicate',
   isAvailable: isViewerOrAbove,
   run({ name, submit }: { name: string; submit: SubmitFunction }) {
-    let formData = new FormData();
-    formData.append('name', name + ' (Copy)');
-    formData.append('contents', grid.export());
-    formData.append('version', grid.getVersion());
-    submit(formData, { method: 'POST', action: ROUTES.CREATE_FILE });
+    let data: CreateActionRequest = {
+      name: name + ' (Copy)',
+      contents: grid.export(),
+      version: grid.getVersion(),
+    };
+
+    submit(data, { method: 'POST', action: ROUTES.CREATE_FILE, encType: 'application/json' });
   },
 };
 

--- a/src/ui/menus/CommandPalette/ListItems/File.tsx
+++ b/src/ui/menus/CommandPalette/ListItems/File.tsx
@@ -1,8 +1,7 @@
 import { DeleteOutline, FileCopyOutlined, FileDownloadOutlined, InsertDriveFileOutlined } from '@mui/icons-material';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSubmit } from 'react-router-dom';
 import { createNewFile, deleteFile, downloadFile, duplicateFile } from '../../../../actions';
 import { useGlobalSnackbar } from '../../../../components/GlobalSnackbarProvider';
-import { ROUTES } from '../../../../constants/routes';
 import { useFileContext } from '../../../components/FileProvider';
 import { CommandPaletteListItem, CommandPaletteListItemSharedProps } from '../CommandPaletteListItem';
 
@@ -20,8 +19,11 @@ const ListItems = [
     label: 'File: ' + duplicateFile.label,
     isAvailable: duplicateFile.isAvailable,
     Component: (props: CommandPaletteListItemSharedProps) => {
-      const navigate = useNavigate();
-      const action = () => navigate(ROUTES.CREATE_FILE);
+      const submit = useSubmit();
+      const { name } = useFileContext();
+      const action = () => {
+        duplicateFile.run({ name, submit });
+      };
       return <CommandPaletteListItem {...props} icon={<FileCopyOutlined />} action={action} />;
     },
   },


### PR DESCRIPTION
Fixes bug where files were not duplicating from within the app

Also fixes bug where duplicating from within the command palette wasn't working.

### To test

Try duplicating a file from all the places where you can do it:

- Command palette -> Duplicate file
- Quadratic menu -> File -> Duplicate
- File name dropdown -> Duplicate
- Shared file overlay -> Duplicate