### PR TITLE
feat: better file errors

### DIFF
--- a/src/dashboard/FileRoute.tsx
+++ b/src/dashboard/FileRoute.tsx
@@ -37,7 +37,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs): Promise<F
 
   // Fetch the file
   const data = await apiClient.getFile(uuid).catch((e) => {
-    console.error(e);
+    console.error(e, e.message, e.status, e.method);
     return undefined;
   });
   if (!data) {


### PR DESCRIPTION
When you navigate to a file and it fails to load, today there's really only one generic message: a 404.

But it's not always a file not found error. Sometimes there are other errors. Here are some examples:

- Forbidden: the file exists but the user doesn't have the right to access it (do we want to actually want to communicate this to the user? is it a security/privacy concern? e.g. "you found a file that does in fact exist, but you can't access it")
- Broken file: the file exists but it couldn't be loaded into the app (e.g. it was returned from the server but the app failed to load it)
- Other...?