### PR TITLE
feat: indicate error state in console badge indicator

### DIFF
--- a/src/ui/menus/CodeEditor/Console.tsx
+++ b/src/ui/menus/CodeEditor/Console.tsx
@@ -46,7 +46,11 @@ export function Console({ consoleOutput, editorMode, editorContent, evaluationRe
             label="Console"
             id="console-tab-0"
             aria-controls="console-tabpanel-0"
-            icon={hasOutput ? <Circle sx={{ fontSize: 8 }}></Circle> : undefined}
+            icon={
+              hasOutput ? (
+                <Circle sx={{ fontSize: 8 }} color={consoleOutput?.stdErr ? 'error' : 'inherit'} />
+              ) : undefined
+            }
             iconPosition="end"
           ></Tab>
           {editorMode === 'PYTHON' && isViewerOrAbove(permission) && (


### PR DESCRIPTION
Was using the app myself — toggling between writing code and looking at the output and asking the AI for help — what would make the indicator next to the "Console" tab even more helpful would be to indicate whether what's being shown in the console is standard output or an error.

This feature turns the indicator red if it's an error.

As an example, I'm writing code and something is wrong. So i go to the AI and ask for help. It tells me how to fix it, I change the code and re-run the example. I can't tell whether it fixed it unless I go back to the "Console" tag and see if there's an error.

With this fix, I can know without switching away from the AI tab, which makes collaborating with the AI assistant much more helpful as you can write code and know when you create or fix errors.

https://github.com/quadratichq/quadratic/assets/1316441/6e60dc79-c1e2-4731-8552-c3562d302b12

Granted, you'll see the output with an error, but sometimes I don't have the active cell open on the grid so I just want to know if it completed or not
