### PR TITLE
Code Editor - unsaved indicator

### DIFF
--- a/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import mixpanel from 'mixpanel-browser';
+import monaco from 'monaco-editor';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { isEditorOrAbove } from '../../../actions';
@@ -18,6 +19,7 @@ export const CodeEditor = () => {
   const [editorInteractionState, setEditorInteractionState] = useRecoilState(editorInteractionStateAtom);
   const { showCodeEditor, mode: editorMode } = editorInteractionState;
   const isRunningComputation = useRef(false);
+  const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor>();
 
   const cellLocation = useMemo(() => {
     return {
@@ -100,6 +102,10 @@ export const CodeEditor = () => {
     },
     [codeString, editorContent, setEditorInteractionState]
   );
+
+  const unsaved = useMemo(() => {
+    return editorContent !== codeString;
+  }, [codeString, editorContent]);
 
   const saveAndRunCell = async () => {
     if (isRunningComputation.current) return;
@@ -187,6 +193,7 @@ export const CodeEditor = () => {
         <SaveChangesAlert
           onCancel={() => {
             setShowSaveChangesAlert(!showSaveChangesAlert);
+            editor?.focus();
           }}
           onSave={() => {
             saveAndRunCell();
@@ -201,12 +208,12 @@ export const CodeEditor = () => {
       <ResizeControl setState={setEditorWidth} position="LEFT" />
       <CodeEditorHeader
         cellLocation={cellLocation}
-        unsaved={false}
+        unsaved={unsaved}
         isRunningComputation={isRunningComputation.current}
         saveAndRunCell={saveAndRunCell}
         closeEditor={() => closeEditor(false)}
       />
-      <CodeEditorBody editorContent={editorContent} setEditorContent={setEditorContent} />
+      <CodeEditorBody editorContent={editorContent} setEditorContent={setEditorContent} setEditor={setEditor} />
       <ResizeControl setState={setConsoleHeight} position="TOP" />
 
       {/* Console Wrapper */}

--- a/src/ui/menus/CodeEditor/CodeEditorBody.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditorBody.tsx
@@ -1,6 +1,6 @@
 import Editor, { Monaco } from '@monaco-editor/react';
 import monaco from 'monaco-editor';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { isEditorOrAbove } from '../../../actions';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
@@ -17,10 +17,11 @@ import { useEditorOnSelectionChange } from './useEditorOnSelectionChange';
 interface Props {
   editorContent: string | undefined;
   setEditorContent: (value: string | undefined) => void;
+  setEditor: (editor: monaco.editor.IStandaloneCodeEditor) => void;
 }
 
-export const CodeEditorBody = (props: Props) => {
-  const { editorContent, setEditorContent } = props;
+export const CodeEditorBody = forwardRef((props: Props, ref) => {
+  const { editorContent, setEditorContent, setEditor } = props;
 
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
   const readOnly = !isEditorOrAbove(editorInteractionState.permission);
@@ -53,6 +54,8 @@ export const CodeEditorBody = (props: Props) => {
 
       monaco.editor.defineTheme('quadratic', QuadraticEditorTheme);
       monaco.editor.setTheme('quadratic');
+
+      setEditor(editor);
 
       if (didMount) return;
       // Only register language once
@@ -108,4 +111,4 @@ export const CodeEditorBody = (props: Props) => {
       )}
     </div>
   );
-};
+});

--- a/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/src/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -74,7 +74,7 @@ export const CodeEditorHeader = (props: Props) => {
               <FiberManualRecord
                 fontSize="small"
                 color="warning"
-                sx={{ fontSize: '.75rem', position: 'relative', top: '2px', left: '6px' }}
+                sx={{ fontSize: '.75rem', position: 'relative', top: '-1px', left: '6px' }}
               />
             </TooltipHint>
           )}


### PR DESCRIPTION
- [x] added back unsaved indicator for Code Editor
- [x] cancelling save dialog in Code Editor moves focus back to the Code Editor
- [x] fixed location of unsaved indicator (it was too low) 