### PR TITLE
feat: improve bottom bar stats functionality

### DIFF
--- a/src/ui/menus/BottomBar/SelectionSummary.tsx
+++ b/src/ui/menus/BottomBar/SelectionSummary.tsx
@@ -2,6 +2,7 @@ import { useMediaQuery } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { sheets } from '../../../grid/controller/Sheets';
 // import { getColumnA1Notation, getRowA1Notation } from '../../../gridGL/UI/gridHeadings/getA1Notation';
+import { TooltipHint } from '@/ui/components/TooltipHint';
 import { grid } from '../../../grid/controller/Grid';
 import BottomBarItem from './BottomBarItem';
 
@@ -12,6 +13,7 @@ export const SelectionSummary = () => {
   const [count, setCount] = useState<string | undefined>('');
   const [sum, setSum] = useState<string | undefined>('');
   const [avg, setAvg] = useState<string | undefined>('');
+  const [copied, setCopied] = useState(false);
 
   const runCalculationOnActiveSelection = () => {
     let result = grid.summarizeSelection();
@@ -19,7 +21,7 @@ export const SelectionSummary = () => {
     if (result) {
       setCount(result.count.toString());
       setSum(result.sum !== undefined ? result.sum.toString() : undefined);
-      setAvg(result.average !== undefined ? result.average.toString() : undefined);
+      setAvg(result.average !== undefined ? result.average.toFixed(9).toString() : undefined);
     } else {
       setCount(undefined);
       setSum(undefined);
@@ -40,12 +42,33 @@ export const SelectionSummary = () => {
     cursor.terminalPosition.y,
   ]);
 
+  const handleOnClick = (valueToCopy: string) => {
+    navigator.clipboard.writeText(valueToCopy).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  const tooltipTitle = copied ? 'Copied!' : 'Copy to clipboard';
+
   if (isBigEnoughForActiveSelectionStats && cursor.multiCursor)
     return (
       <>
-        {sum && <BottomBarItem>Sum: {sum}</BottomBarItem>}
-        {avg && <BottomBarItem>Avg: {avg}</BottomBarItem>}
-        {count && <BottomBarItem>Count: {count}</BottomBarItem>}
+        {sum && (
+          <TooltipHint title={tooltipTitle}>
+            <BottomBarItem onClick={() => handleOnClick(sum)}>Sum: {sum}</BottomBarItem>
+          </TooltipHint>
+        )}
+        {avg && (
+          <TooltipHint title={tooltipTitle}>
+            <BottomBarItem onClick={() => handleOnClick(avg)}>Avg: {avg}</BottomBarItem>
+          </TooltipHint>
+        )}
+        {count && (
+          <TooltipHint title={tooltipTitle}>
+            <BottomBarItem onClick={() => handleOnClick(count)}>Count: {count}</BottomBarItem>
+          </TooltipHint>
+        )}
       </>
     );
   else return null;


### PR DESCRIPTION
The current implementation of the bottom bar outputs a number that is _really_ big.

![CleanShot 2023-11-21 at 14 00 58@2x](https://github.com/quadratichq/quadratic/assets/1316441/1f409530-09a5-4c30-939e-e929a9eada5f)

Excel caps this number at 9 digits beyond the decimal

![CleanShot 2023-11-21 at 14 01 25@2x](https://github.com/quadratichq/quadratic/assets/1316441/422a2476-e221-4050-9e9c-742360214554)

So we do the same thing:

![CleanShot 2023-11-21 at 14 01 08@2x](https://github.com/quadratichq/quadratic/assets/1316441/564e1f68-7010-4dc1-bc0b-834dc960cc9b)

Also: excel provides the ability for you to click and copy the values in the bottom bar. This allows you to do the same thing in Quadratic.

![CleanShot 2023-11-21 at 14 08 22](https://github.com/quadratichq/quadratic/assets/1316441/71f4b857-0e5d-4fe4-8864-69257b3b19c0)
