### PR TITLE
Improvements to npm scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Run Clippy
         run: |
-          cd quadratic-client
           npm run lint:clippy
 
       - name: Install wasm-pack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ In order to run the front-end and/or the server locally, you must have all the e
 3. Configure `.env.local` values
 4. (a) `npm start` to run in browser or `npm run dev` to run with Electron; or (b) `npm run watch:front-end` to run in browser with automatic wasm rebuilding
 
+#### Note:
+To rebuild the rust types after `npm start`, you need to either manually call `npm run build:wasm:types`, or restart the `npm start" script.
+
 ### Run server locally
 
 1. `cd quadratic-api`

--- a/package.json
+++ b/package.json
@@ -9,19 +9,31 @@
   "repository": "https://github.com/quadratichq/quadratic.git",
   "private": true,
   "scripts": {
-    "start": "npm run watch:fast:front-end",
-    "watch:fast:front-end": "concurrently --hide=3 -n=react,rust,rust-types \"npm:watch:javascript\" \"npm:watch:wasm:fast:javascript\" \"npm:watch:wasm:types\" \"npm run api:start\"",
-    "watch:front-end": "concurrently --hide=3 -n=react,rust,rust-types \"npm:watch:javascript\" \"npm:watch:wasm:javascript\" \"npm:watch:wasm:types\" \"npm run api:start\"",
-    "watch:front-end-back-end": "concurrently -n=react,rust,rust-types,api \"npm:watch:javascript\" \"npm:watch:wasm:javascript\" \"npm:watch:wasm:types\" \"npm run api:start\"",
+    "start": "npm run watch:front-end",
+    "perf": "npm run watch:perf:front-end",
+
     "watch:javascript": "cd quadratic-client && npm run watch:javascript",
-    "watch:wasm:javascript": "cd quadratic-core && cargo watch -s 'wasm-pack build --dev --target web --out-dir ../quadratic-client/src/quadratic-core --weak-refs'",
-    "watch:wasm:fast:javascript": "cd quadratic-core && cargo watch -s 'wasm-pack build --target web --out-dir ../quadratic-client/src/quadratic-core --dev --weak-refs'",
-    "watch:wasm:types": "cd quadratic-core && cargo watch -s 'cargo run --bin export_types'",
-    "api:start": "cd quadratic-api && npm start",
+    "watch:perf:front-end": "npm run build:wasm:types && concurrently --hide=2 -n=react,rust,rust-types \"npm:watch:javascript\" \"npm:watch:wasm:perf:javascript\" \"npm run api:start\"",
+    "watch:front-end": "npm run build:wasm:types && concurrently --hide=2 -n=react,rust,rust-types \"npm:watch:javascript\" \"npm:watch:wasm:javascript\" \"npm run api:start\"",
+    "watch:front-end-back-end": "npm run build:wasm:types && concurrently -n=react,rust,rust-types,api \"npm:watch:javascript\" \"npm:watch:wasm:javascript\" \"npm run api:start\"",
     "lint:client": "cd quadratic-client && npm run lint:ts && npm run lint:eslint && lint:prettier && lint:clippy",
+
+    "api:start": "cd quadratic-api && npm start",
+
+    "build:wasm:types": "cd quadratic-core && cargo run --bin export_types",
+    "watch:wasm:javascript": "cd quadratic-core && cargo watch -s 'wasm-pack build --dev --target web --out-dir ../quadratic-client/src/quadratic-core --weak-refs'",
+    "watch:wasm:perf:javascript": "cd quadratic-core && cargo watch -s 'wasm-pack build --target web --out-dir ../quadratic-client/src/quadratic-core --weak-refs'",
+    "watch:wasm:types": "cd quadratic-core && cargo watch -s 'cargo run --bin export_types'",
+
     "coverage:wasm:gen": "cd quadratic-core && cd quadratic-core && CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='coverage/cargo-test-%p-%m.profraw' cargo test",
     "coverage:wasm:html": "cd quadratic-core && cd quadratic-core && grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore 'src/wasm_bindings/*' --ignore 'src/bin/*' --ignore '../*' --ignore '/*' -o coverage/html",
-    "coverage:wasm:view": "open quadratic-core/coverage/html/index.html"
+    "coverage:wasm:view": "open quadratic-core/coverage/html/index.html",
+
+    "test:wasm": "cd quadratic-core && cargo test",
+    "watch:test:wasm": "cd quadratic-core && cargo watch -x test",
+
+    "benchmark:rust": "cd quadratic-core && cargo bench",
+    "lint:clippy": "cd .. && cd quadratic-core && cargo clippy --all-targets --all-features -- -D warnings"
   },
   "devDependencies": {
     "concurrently": "^6.5.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "watch:test:wasm": "cd quadratic-core && cargo watch -x test",
 
     "benchmark:rust": "cd quadratic-core && cargo bench",
-    "lint:clippy": "cd .. && cd quadratic-core && cargo clippy --all-targets --all-features -- -D warnings"
+    "lint:clippy": "cd quadratic-core && cargo clippy --all-targets --all-features -- -D warnings"
   },
   "devDependencies": {
     "concurrently": "^6.5.1"

--- a/quadratic-client/package.json
+++ b/quadratic-client/package.json
@@ -77,7 +77,6 @@
     "lint:eslint": "eslint --ext .ts,.tsx src",
     "lint:prettier": "prettier --check src",
     "lint:prettier:write": "prettier --write src",
-    "lint:clippy": "cd .. && cd quadratic-core && cargo clippy --all-targets --all-features -- -D warnings",
     "coverage:wasm:gen": "cd .. && cd quadratic-core && CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='coverage/cargo-test-%p-%m.profraw' cargo test",
     "coverage:wasm:html": "cd .. && cd quadratic-core && grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore 'src/wasm_bindings/*' --ignore 'src/bin/*' --ignore '../*' --ignore '/*' -o coverage/html",
     "coverage:wasm:view": "open quadratic-core/coverage/html/index.html"


### PR DESCRIPTION
note: this removes `npm run watch:wasm:types` from `npm start` to avoid double rust compiles on rust changes. `npm run build:wasm:types` is run only once when the script starts. To rebuild the rust types, you need to manually call `npm run build:wasm:types`, or restart `npm start`