### PR TITLE
/support URL changed to /contact

### DIFF
--- a/quadratic-client/src/constants/urls.ts
+++ b/quadratic-client/src/constants/urls.ts
@@ -5,4 +5,4 @@ export const DOCUMENTATION_FILES_URL = `${DOCUMENTATION_URL}/files`;
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';
 export const DISCORD = 'https://discord.gg/quadratic';
 export const TWITTER = 'https://twitter.com/quadratichq';
-export const CONTACT_URL = 'https://quadratichq.com/support';
+export const CONTACT_URL = 'https://quadratichq.com/contact';


### PR DESCRIPTION
looks like we changed the support URL to /contact