### PR TITLE
feat: make embeds read-only

### DIFF
--- a/quadratic-client/src/dashboard/FileRoute.tsx
+++ b/quadratic-client/src/dashboard/FileRoute.tsx
@@ -68,7 +68,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs): Promise<F
 
   return {
     name: data.file.name,
-    permission: data.permission,
+    permission: isEmbed ? 'ANONYMOUS' : data.permission,
     sharing,
   };
 };

--- a/quadratic-client/src/ui/menus/TopBar/TopBar.tsx
+++ b/quadratic-client/src/ui/menus/TopBar/TopBar.tsx
@@ -88,7 +88,7 @@ export const TopBar = () => {
         {isDesktop && (
           <>
             <TopBarCodeOutlinesSwitch />
-            <TopBarUsers />
+            {!isEmbed && <TopBarUsers />}
             {!isEmbed && <TopBarShareButton />}
           </>
         )}


### PR DESCRIPTION
Make the embed experience be like the user is anonymous, regardless of whether they are logged in or not.

Before (user avatar is visible, file operations are visible):

![CleanShot 2023-12-12 at 16 54 12@2x](https://github.com/quadratichq/quadratic/assets/1316441/ddaaefe3-6f34-4ebf-8dd3-d2c790ec82d7)


After (user avatars are gone, file operations are hidden):

![CleanShot 2023-12-12 at 16 55 06@2x](https://github.com/quadratichq/quadratic/assets/1316441/e89dff28-771c-4902-b19f-d3b91213778c)

## To Test

You won't be able to see this on deploy previews since they are on the vercel domain. You'd have to pull this down and test locally — or just merge and see that it works hehe
