### PR TITLE
Mp transaction queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
           grcov $(find . -name "grcov-*.profraw" -print) \
             --branch \
             --ignore-not-existing \
-            --binary-path ./quadratic-core/target/debug/ \
+            --binary-path ./target/debug/ \
             -s . \
             -t lcov \
             --ignore "/*" \
-            --ignore "./quadratic-core/src/wasm_bindings/*" \
-            --ignore "./quadratic-core/src/bin/*" \
+            --ignore "./src/wasm_bindings/*" \
+            --ignore "./src/bin/*" \
             -o lcov.info
 
       - name: Upload coverage reports to Codecov
@@ -88,12 +88,12 @@ jobs:
           grcov $(find . -name "grcov-*.profraw" -print) \
             --branch \
             --ignore-not-existing \
-            --binary-path ./quadratic-multiplayer/target/debug/ \
+            --binary-path ./target/debug/ \
             -s . \
             -t lcov \
             --ignore "/*" \
-            --ignore "./quadratic-multiplayer/src/wasm_bindings/*" \
-            --ignore "./quadratic-multiplayer/src/bin/*" \
+            --ignore "./src/wasm_bindings/*" \
+            --ignore "./src/bin/*" \
             -o lcov.info
 
       - name: Upload coverage reports to Codecov quadratic-multiplayer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install grcov
         run: if ! which grcov; then cargo install grcov; fi
 
+      - name: Install llvm-tools-preview
+        run: if ! which llvm-tools-preview; then rustup component add llvm-tools-preview; fi
+
       - name: Install pkg-config
         if: github.runner.isHosted == true
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +444,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -457,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -564,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dummy"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +673,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -1112,6 +1130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1275,33 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a978c8292954bcb9347a4e28772c0a0621166a1598fc1be28ac0076a4bb810e"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2765371d0978ba4ace4ebef047baa62fc068b431e468444b5610dd441c639b"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.70",
+ "quote 1.0.33",
+ "syn 2.0.40",
 ]
 
 [[package]]
@@ -1515,6 +1569,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+dependencies = [
+ "anstyle",
+ "itertools 0.11.0",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1683,7 @@ dependencies = [
  "getrandom",
  "htmlescape",
  "indexmap 2.1.0",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "lexicon_fractional_index",
@@ -1641,6 +1722,7 @@ dependencies = [
  "futures-util",
  "headers",
  "jsonwebtoken",
+ "mockall",
  "quadratic-core",
  "reqwest",
  "rust-shared",
@@ -2213,6 +2295,12 @@ checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/quadratic-client/src/multiplayer/multiplayer.ts
+++ b/quadratic-client/src/multiplayer/multiplayer.ts
@@ -15,7 +15,9 @@ import {
   MultiplayerUser,
   ReceiveMessages,
   ReceiveRoom,
+  ReceiveTransactions,
   SendEnterRoom,
+  SendGetTransactions
 } from './multiplayerTypes';
 
 const UPDATE_TIME = 1000 / 30;
@@ -264,6 +266,16 @@ export class Multiplayer {
     this.websocket!.send(JSON.stringify(message));
   }
 
+  sendGetTransactions(min_sequence_num: number) {
+    const message: SendGetTransactions = {
+      type: 'GetTransactions',
+      session_id: this.sessionId,
+      file_id: this.room!,
+      min_sequence_num,
+    };
+    this.websocket!.send(JSON.stringify(message));
+  }
+
   //#endregion
 
   //#region receive messages
@@ -403,15 +415,22 @@ export class Multiplayer {
     }
   }
 
+  private receiveTransactions(data: ReceiveTransactions) {
+    console.log(data.transactions);
+  }
+
   receiveMessage = (e: { data: string }) => {
     const data = JSON.parse(e.data) as ReceiveMessages;
+    console.log(`[Multiplayer] Received receiveMessage ${data.type}`);
     const { type } = data;
     if (type === 'UsersInRoom') {
       this.receiveUsersInRoom(data);
     } else if (type === 'UserUpdate') {
       this.receiveUserUpdate(data);
     } else if (type === 'Transaction') {
-      this.receiveTransaction(data);
+    this.receiveTransaction(data);
+    } else if (type === 'Transactions') {
+      this.receiveTransactions(data);
     } else if (type !== 'Empty') {
       console.warn(`Unknown message type: ${type}`);
     }

--- a/quadratic-client/src/multiplayer/multiplayer.ts
+++ b/quadratic-client/src/multiplayer/multiplayer.ts
@@ -252,8 +252,11 @@ export class Multiplayer {
 
   async sendTransaction(operations: string) {
     await this.init();
+    // TODO(ddimaria): this ID should be stored somewhere
+    let id = uuid(); 
     const message: MessageTransaction = {
       type: 'Transaction',
+      id,
       session_id: this.sessionId,
       file_id: this.room!,
       operations,

--- a/quadratic-client/src/multiplayer/multiplayerTypes.ts
+++ b/quadratic-client/src/multiplayer/multiplayerTypes.ts
@@ -64,6 +64,13 @@ export interface MessageTransaction {
   operations: string;
 }
 
+export interface SendGetTransactions {
+  type: 'GetTransactions';
+  session_id: string;
+  file_id: string;
+  min_sequence_num: number;
+}
+
 export interface Heartbeat {
   type: 'Heartbeat';
   session_id: string;

--- a/quadratic-client/src/multiplayer/multiplayerTypes.ts
+++ b/quadratic-client/src/multiplayer/multiplayerTypes.ts
@@ -58,6 +58,7 @@ export interface SendEnterRoom extends MultiplayerUserServer {
 
 export interface MessageTransaction {
   type: 'Transaction';
+  id: string;
   session_id: string;
   file_id: string;
   operations: string;

--- a/quadratic-client/src/multiplayer/multiplayerTypes.ts
+++ b/quadratic-client/src/multiplayer/multiplayerTypes.ts
@@ -56,6 +56,13 @@ export interface SendEnterRoom extends MultiplayerUserServer {
   type: 'EnterRoom';
 }
 
+export interface Transaction {
+  id: string;
+  file_id: string;
+  sequence_num: number;
+  operations: string[];
+}
+
 export interface MessageTransaction {
   type: 'Transaction';
   id: string;
@@ -71,6 +78,11 @@ export interface SendGetTransactions {
   min_sequence_num: number;
 }
 
+export interface ReceiveTransactions {
+  type: 'Transactions';
+  transactions: Transaction[];
+}
+
 export interface Heartbeat {
   type: 'Heartbeat';
   session_id: string;
@@ -81,4 +93,4 @@ export interface ReceiveEmpty {
   type: 'Empty';
 }
 
-export type ReceiveMessages = ReceiveRoom | MessageUserUpdate | MessageTransaction | ReceiveEmpty;
+export type ReceiveMessages = ReceiveRoom | MessageUserUpdate | MessageTransaction | ReceiveEmpty | ReceiveTransactions;

--- a/quadratic-multiplayer/Cargo.toml
+++ b/quadratic-multiplayer/Cargo.toml
@@ -30,3 +30,4 @@ uuid = { version = "1.6.1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 fake = { version = "2.9.1", features = ["derive"] }
+mockall = "0.12.0"

--- a/quadratic-multiplayer/package.json
+++ b/quadratic-multiplayer/package.json
@@ -13,7 +13,7 @@
     "lint": "cargo clippy --all-targets --all-features -- -D warnings",
     "coverage": "npm run coverage:gen && npm run coverage:html && npm run coverage:view",
     "coverage:gen": "CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='coverage/cargo-test-%p-%m.profraw' cargo test",
-    "coverage:html": "grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore 'src/main.rs' -o coverage/html",
+    "coverage:html": "grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore '/*' -o coverage/html",
     "coverage:view": "open coverage/html/index.html"
   }
 }

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -11,6 +11,7 @@ use crate::{
 /// In a separate thread:
 ///   * Broadcast sequence number to all users in the room
 ///   * Check for stale users in rooms and remove them.
+#[tracing::instrument]
 pub(crate) async fn work(state: Arc<State>, heartbeat_check_s: i64, heartbeat_timeout_s: i64) {
     let state = Arc::clone(&state);
 
@@ -66,6 +67,7 @@ async fn broadcast_sequence_num(state: Arc<State>, file_id: Uuid) -> Result<Join
 }
 
 // remove stale users in the room
+#[tracing::instrument]
 async fn remove_stale_users_in_room(
     state: Arc<State>,
     file_id: &Uuid,

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -19,8 +19,6 @@ pub(crate) async fn work(state: Arc<State>, heartbeat_check_s: i64, heartbeat_ti
         let mut interval = time::interval(Duration::from_millis(heartbeat_check_s as u64 * 1000));
 
         loop {
-            // let rooms = state.rooms.lock().await.clone();
-
             for (file_id, room) in state.rooms.lock().await.iter() {
                 // broadcast sequence number to all users in the room
                 if let Err(error) =

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -1,0 +1,67 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::time;
+use uuid::Uuid;
+
+use crate::{
+    message::{broadcast, response::MessageResponse},
+    state::State,
+};
+
+/// In a separate thread:
+///   * Broadcast sequence number to all users in the room
+///   * Check for stale users in rooms and remove them.
+pub(crate) async fn work(state: Arc<State>, heartbeat_check_s: i64, heartbeat_timeout_s: i64) {
+    let state = Arc::clone(&state);
+
+    tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_millis(heartbeat_check_s as u64 * 1000));
+
+        loop {
+            let rooms = state.rooms.lock().await.clone();
+
+            for (file_id, room) in rooms.iter() {
+                // broadcast sequence number to all users in the room
+                let sequence_num = state
+                    .transaction_queue
+                    .lock()
+                    .await
+                    .get_sequence_num(file_id.to_owned());
+
+                if let Ok(sequence_num) = sequence_num {
+                    broadcast(
+                        Uuid::new_v4(),
+                        file_id.to_owned(),
+                        Arc::clone(&state),
+                        MessageResponse::CurrentTransaction { sequence_num },
+                    );
+                }
+
+                // remove stale users in the room
+                match state
+                    .remove_stale_users_in_room(file_id.to_owned(), heartbeat_timeout_s)
+                    .await
+                {
+                    Ok((num_removed, num_remaining)) => {
+                        tracing::info!("Checking heartbeats in room {file_id} ({num_remaining} remaining in room)");
+
+                        if num_removed > 0 {
+                            broadcast(
+                                // TODO(ddimaria): use a real session_id here
+                                Uuid::new_v4(),
+                                file_id.to_owned(),
+                                Arc::clone(&state),
+                                MessageResponse::from(room.to_owned()),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Error removing stale users from room {file_id}: {:?}", e);
+                    }
+                }
+            }
+
+            interval.tick().await;
+        }
+    });
+}

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -11,7 +11,7 @@ use crate::{
 /// In a separate thread:
 ///   * Broadcast sequence number to all users in the room
 ///   * Check for stale users in rooms and remove them.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 pub(crate) async fn start(state: Arc<State>, heartbeat_check_s: i64, heartbeat_timeout_s: i64) {
     let state = Arc::clone(&state);
 
@@ -65,7 +65,7 @@ async fn broadcast_sequence_num(state: Arc<State>, file_id: Uuid) -> Result<Join
 }
 
 // remove stale users in the room
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 async fn remove_stale_users_in_room(
     state: Arc<State>,
     file_id: &Uuid,

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -134,6 +134,7 @@ mod tests {
             .await
             .unwrap();
 
+        // user was removed from the room and the room was closed
         let room = state.get_room(&file_id).await;
         assert!(room.is_err());
     }

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -57,7 +57,7 @@ async fn broadcast_sequence_num(state: Arc<State>, file_id: Uuid) -> Result<Join
         .get_sequence_num(file_id.to_owned())?;
 
     Ok(broadcast(
-        Uuid::new_v4(),
+        vec![],
         file_id.to_owned(),
         Arc::clone(&state),
         MessageResponse::CurrentTransaction { sequence_num },
@@ -80,8 +80,7 @@ async fn remove_stale_users_in_room(
 
     if num_removed > 0 {
         return Ok(broadcast(
-            // TODO(ddimaria): use a real session_id here
-            Uuid::new_v4(),
+            vec![],
             file_id.to_owned(),
             Arc::clone(&state),
             MessageResponse::from(room.to_owned()),

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -17,9 +17,10 @@ pub(crate) async fn start(state: Arc<State>, heartbeat_check_s: i64, heartbeat_t
 
     tokio::spawn(async move {
         let mut interval = time::interval(Duration::from_millis(heartbeat_check_s as u64 * 1000));
+        let rooms = state.rooms.lock().await.clone();
 
         loop {
-            for (file_id, room) in state.rooms.lock().await.iter() {
+            for (file_id, room) in rooms.iter() {
                 // broadcast sequence number to all users in the room
                 if let Err(error) =
                     broadcast_sequence_num(Arc::clone(&state), file_id.to_owned()).await

--- a/quadratic-multiplayer/src/background_worker.rs
+++ b/quadratic-multiplayer/src/background_worker.rs
@@ -12,7 +12,7 @@ use crate::{
 ///   * Broadcast sequence number to all users in the room
 ///   * Check for stale users in rooms and remove them.
 #[tracing::instrument]
-pub(crate) async fn work(state: Arc<State>, heartbeat_check_s: i64, heartbeat_timeout_s: i64) {
+pub(crate) async fn start(state: Arc<State>, heartbeat_check_s: i64, heartbeat_timeout_s: i64) {
     let state = Arc::clone(&state);
 
     tokio::spawn(async move {

--- a/quadratic-multiplayer/src/file.rs
+++ b/quadratic-multiplayer/src/file.rs
@@ -4,11 +4,13 @@ use quadratic_core::{
     grid::{file::import, Grid},
 };
 
-pub(crate) fn load_file(file: &str) -> Result<Grid> {
+/// Load a .grid file
+pub(crate) fn _load_file(file: &str) -> Result<Grid> {
     import(file)
 }
 
-pub(crate) fn apply_string_operations(
+/// Apply a stringified vec of operations to the grid
+pub(crate) fn _apply_string_operations(
     grid: &mut GridController,
     operations: String,
 ) -> Result<TransactionSummary> {
@@ -16,10 +18,11 @@ pub(crate) fn apply_string_operations(
 
     let operations: Vec<Operation> = serde_json::from_str(&operations)?;
 
-    apply_operations(grid, operations)
+    _apply_operations(grid, operations)
 }
 
-pub(crate) fn apply_operations(
+/// Apply a vec of operations to the grid
+pub(crate) fn _apply_operations(
     grid: &mut GridController,
     operations: Vec<Operation>,
 ) -> Result<TransactionSummary> {
@@ -35,7 +38,8 @@ mod tests {
 
     #[test]
     fn loads_a_file() {
-        let file = load_file(include_str!("../../rust-shared/data/grid/v1_4_simple.grid")).unwrap();
+        let file =
+            _load_file(include_str!("../../rust-shared/data/grid/v1_4_simple.grid")).unwrap();
 
         let mut grid = GridController::from_grid(file);
         let sheet_id = grid.sheet_ids().first().unwrap().to_owned();
@@ -45,7 +49,7 @@ mod tests {
         let values = Array::from(value);
         let operation = Operation::SetCellValues { region, values };
 
-        let _ = apply_operations(&mut grid, vec![operation]);
+        let _ = _apply_operations(&mut grid, vec![operation]);
 
         assert_cell_value(&grid, sheet_id, 0, 0, "hello");
     }

--- a/quadratic-multiplayer/src/file.rs
+++ b/quadratic-multiplayer/src/file.rs
@@ -14,8 +14,6 @@ pub(crate) fn _apply_string_operations(
     grid: &mut GridController,
     operations: String,
 ) -> Result<TransactionSummary> {
-    tracing::info!("Applying operations: {}", operations);
-
     let operations: Vec<Operation> = serde_json::from_str(&operations)?;
 
     _apply_operations(grid, operations)

--- a/quadratic-multiplayer/src/main.rs
+++ b/quadratic-multiplayer/src/main.rs
@@ -4,6 +4,7 @@
 //! tracking for a shared file.
 
 mod auth;
+mod background_worker;
 mod config;
 mod file;
 mod message;

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -67,18 +67,10 @@ pub(crate) async fn handle_message(
 
             // only broadcast if the user is new to the room
             if is_new {
-                let session_id = user.session_id;
                 let room = state.get_room(&file_id).await?;
                 let response = MessageResponse::from(room.to_owned());
 
                 broadcast(vec![], file_id, Arc::clone(&state), response);
-
-                tracing::info!(
-                    "User {} joined room {} with session {}",
-                    user.user_id,
-                    file_id,
-                    session_id
-                );
             }
 
             Ok(None)

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -5,11 +5,10 @@
 //! socket information is stored in the global state, we can broadcast
 //! to all users in a room.
 
-use std::sync::Arc;
-
 use anyhow::Result;
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::stream::SplitSink;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -124,7 +124,8 @@ pub(crate) async fn handle_message(
                 sequence_num,
             };
 
-            broadcast(vec![session_id], file_id, Arc::clone(&state), response);
+            // the user who sent the transaction should receive the transaction response
+            broadcast(vec![], file_id, Arc::clone(&state), response);
 
             Ok(None)
         }

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -100,6 +100,7 @@ pub(crate) async fn handle_message(
 
         // User sends transactions
         MessageRequest::Transaction {
+            id,
             session_id,
             file_id,
             operations,
@@ -112,10 +113,11 @@ pub(crate) async fn handle_message(
                 .transaction_queue
                 .lock()
                 .await
-                .push(file_id, serde_json::from_str(&operations)?)
+                .push(id, file_id, serde_json::from_str(&operations)?)
                 .await;
 
             let response = MessageResponse::Transaction {
+                id,
                 file_id,
                 operations,
                 sequence,
@@ -320,11 +322,13 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_transaction() {
         let state = Arc::new(State::new());
+        let id = Uuid::new_v4();
         let connection_id = Uuid::new_v4();
         let file_id = Uuid::new_v4();
         let user_1 = add_new_user_to_room(file_id, state.clone(), connection_id).await;
         let _user_2 = add_new_user_to_room(file_id, state.clone(), connection_id).await;
         let message = MessageResponse::Transaction {
+            id,
             file_id,
             operations: "test".to_string(),
             sequence: 1,

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -17,7 +17,7 @@ use crate::state::user::UserState;
 use crate::state::{user::User, State};
 
 /// Handle incoming messages.  All requests and responses are strictly typed.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 pub(crate) async fn handle_message(
     request: MessageRequest,
     state: Arc<State>,

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -71,7 +71,7 @@ pub(crate) async fn handle_message(
                 let room = state.get_room(&file_id).await?;
                 let response = MessageResponse::from(room.to_owned());
 
-                broadcast(Uuid::new_v4(), file_id, Arc::clone(&state), response);
+                broadcast(vec![], file_id, Arc::clone(&state), response);
 
                 tracing::info!(
                     "User {} joined room {} with session {}",
@@ -94,7 +94,7 @@ pub(crate) async fn handle_message(
 
             if is_not_empty {
                 let response = MessageResponse::from(room.to_owned());
-                broadcast(session_id, file_id, Arc::clone(&state), response);
+                broadcast(vec![session_id], file_id, Arc::clone(&state), response);
             }
 
             Ok(None)
@@ -124,7 +124,7 @@ pub(crate) async fn handle_message(
                 sequence_num,
             };
 
-            broadcast(session_id, file_id, Arc::clone(&state), response);
+            broadcast(vec![session_id], file_id, Arc::clone(&state), response);
 
             Ok(None)
         }
@@ -168,7 +168,7 @@ pub(crate) async fn handle_message(
                 update,
             };
 
-            broadcast(session_id, file_id, Arc::clone(&state), response);
+            broadcast(vec![session_id], file_id, Arc::clone(&state), response);
 
             Ok(None)
         }
@@ -217,7 +217,7 @@ pub(crate) mod tests {
                 viewport: None,
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -240,7 +240,7 @@ pub(crate) mod tests {
                 viewport: None,
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -263,7 +263,7 @@ pub(crate) mod tests {
                 viewport: None,
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -286,7 +286,7 @@ pub(crate) mod tests {
                 viewport: None,
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -314,7 +314,7 @@ pub(crate) mod tests {
                 viewport: None,
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -337,7 +337,7 @@ pub(crate) mod tests {
                 viewport: Some("viewport".to_string()),
             },
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 
@@ -354,7 +354,7 @@ pub(crate) mod tests {
             operations: "test".to_string(),
             sequence_num: 1,
         };
-        broadcast(user_1.session_id, file_id, state, message)
+        broadcast(vec![user_1.session_id], file_id, state, message)
             .await
             .unwrap();
 

--- a/quadratic-multiplayer/src/message/handle.rs
+++ b/quadratic-multiplayer/src/message/handle.rs
@@ -18,6 +18,7 @@ use crate::state::user::UserState;
 use crate::state::{user::User, State};
 
 /// Handle incoming messages.  All requests and responses are strictly typed.
+#[tracing::instrument]
 pub(crate) async fn handle_message(
     request: MessageRequest,
     state: Arc<State>,

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -27,7 +27,7 @@ pub(crate) fn broadcast(
                 .await?
                 .users
                 .iter()
-                .filter(|(_, user)| session_id != user.session_id)
+                .filter(|(_, user)| !exclude.contains(&user.session_id))
             {
                 if let Some(sender) = &user.socket {
                     sender

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -15,7 +15,7 @@ pub mod response;
 /// All messages are sent in a separate thread.
 #[tracing::instrument]
 pub(crate) fn broadcast(
-    session_id: Uuid,
+    exclude: Vec<Uuid>,
     file_id: Uuid,
     state: Arc<State>,
     message: MessageResponse,

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -13,7 +13,7 @@ pub mod response;
 
 /// Broadcast a message to all users in a room except the sender.
 /// All messages are sent in a separate thread.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 pub(crate) fn broadcast(
     exclude: Vec<Uuid>,
     file_id: Uuid,

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -20,6 +20,7 @@ pub(crate) fn broadcast(
     state: Arc<State>,
     message: MessageResponse,
 ) -> JoinHandle<()> {
+    // println!("message: {:?}", message);
     tokio::spawn(async move {
         let result = async {
             for (_, user) in state

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -13,6 +13,7 @@ pub mod response;
 
 /// Broadcast a message to all users in a room except the sender.
 /// All messages are sent in a separate thread.
+#[tracing::instrument]
 pub(crate) fn broadcast(
     session_id: Uuid,
     file_id: Uuid,

--- a/quadratic-multiplayer/src/message/mod.rs
+++ b/quadratic-multiplayer/src/message/mod.rs
@@ -28,7 +28,6 @@ pub(crate) fn broadcast(
                 .iter()
                 .filter(|(_, user)| session_id != user.session_id)
             {
-                println!("broadcasting to user: {:?}", user);
                 if let Some(sender) = &user.socket {
                     sender
                         .lock()
@@ -40,6 +39,7 @@ pub(crate) fn broadcast(
 
             Ok::<_, anyhow::Error>(())
         };
+
         if let Err(e) = result.await {
             tracing::warn!("Error broadcasting message: {:?}", e.to_string());
         }

--- a/quadratic-multiplayer/src/message/request.rs
+++ b/quadratic-multiplayer/src/message/request.rs
@@ -34,6 +34,7 @@ pub(crate) enum MessageRequest {
         update: UserStateUpdate,
     },
     Transaction {
+        id: Uuid,
         session_id: Uuid,
         file_id: Uuid,
 

--- a/quadratic-multiplayer/src/message/request.rs
+++ b/quadratic-multiplayer/src/message/request.rs
@@ -41,6 +41,11 @@ pub(crate) enum MessageRequest {
         // todo: this is a stringified Vec<Operation>. Eventually, Operation should be a shared type.
         operations: String,
     },
+    GetTransactions {
+        file_id: Uuid,
+        session_id: Uuid,
+        min_sequence_num: u64,
+    },
     Heartbeat {
         session_id: Uuid,
         file_id: Uuid,

--- a/quadratic-multiplayer/src/message/response.rs
+++ b/quadratic-multiplayer/src/message/response.rs
@@ -16,6 +16,7 @@ pub(crate) enum MessageResponse {
         users: Vec<User>,
     },
     Transaction {
+        id: Uuid,
         file_id: Uuid,
         // todo: this is a stringified Vec<Operation>. Eventually, Operation should be a shared type.
         operations: String,

--- a/quadratic-multiplayer/src/message/response.rs
+++ b/quadratic-multiplayer/src/message/response.rs
@@ -5,6 +5,7 @@
 use serde::Serialize;
 use uuid::Uuid;
 
+use crate::state::transaction_queue::Transaction;
 use crate::state::user::UserStateUpdate;
 use crate::state::{room::Room, user::User};
 
@@ -15,17 +16,23 @@ pub(crate) enum MessageResponse {
     UsersInRoom {
         users: Vec<User>,
     },
+    UserUpdate {
+        session_id: Uuid,
+        file_id: Uuid,
+        update: UserStateUpdate,
+    },
     Transaction {
         id: Uuid,
         file_id: Uuid,
         // todo: this is a stringified Vec<Operation>. Eventually, Operation should be a shared type.
         operations: String,
-        sequence: u64,
+        sequence_num: u64,
     },
-    UserUpdate {
-        session_id: Uuid,
-        file_id: Uuid,
-        update: UserStateUpdate,
+    Transactions {
+        transactions: Vec<Transaction>,
+    },
+    CurrentTransaction {
+        sequence_num: u64,
     },
 }
 

--- a/quadratic-multiplayer/src/message/response.rs
+++ b/quadratic-multiplayer/src/message/response.rs
@@ -19,6 +19,7 @@ pub(crate) enum MessageResponse {
         file_id: Uuid,
         // todo: this is a stringified Vec<Operation>. Eventually, Operation should be a shared type.
         operations: String,
+        sequence: u64,
     },
     UserUpdate {
         session_id: Uuid,

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -85,7 +85,7 @@ pub(crate) async fn serve() -> Result<()> {
         tracing::warn!("JWT authentication is disabled");
     }
 
-    background_worker::work(Arc::clone(&state), heartbeat_check_s, heartbeat_timeout_s).await;
+    background_worker::start(Arc::clone(&state), heartbeat_check_s, heartbeat_timeout_s).await;
 
     axum::serve(
         listener,

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -432,12 +432,15 @@ pub(crate) mod tests {
         let new_user = new_user();
         let session_id = new_user.session_id;
         let operations = serde_json::to_string::<Vec<Operation>>(&vec![]).unwrap();
+        let id = Uuid::new_v4();
         let request = MessageRequest::Transaction {
+            id,
             session_id,
             file_id,
             operations: operations.clone(),
         };
         let expected = MessageResponse::Transaction {
+            id,
             file_id,
             operations: operations.clone(),
             sequence: 1,

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -261,6 +261,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::state::user::{CellEdit, User, UserStateUpdate};
     use crate::test_util::{integration_test_send_and_receive, integration_test_setup, new_user};
+    use quadratic_core::controller::operation::Operation;
     use tokio::net::TcpStream;
     use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
     use uuid::Uuid;
@@ -430,14 +431,16 @@ pub(crate) mod tests {
         let (socket, _, _, file_id, _) = setup().await;
         let new_user = new_user();
         let session_id = new_user.session_id;
+        let operations = serde_json::to_string::<Vec<Operation>>(&vec![]).unwrap();
         let request = MessageRequest::Transaction {
             session_id,
             file_id,
-            operations: "test".to_string(),
+            operations: operations.clone(),
         };
         let expected = MessageResponse::Transaction {
             file_id,
-            operations: "test".to_string(),
+            operations: operations.clone(),
+            sequence: 1,
         };
 
         let response = integration_test_send_and_receive(socket, request, true).await;

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -51,7 +51,7 @@ pub(crate) fn app(state: Arc<State>) -> Router {
 }
 
 /// Start the websocket server.  This is the entrypoint for the application.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 pub(crate) async fn serve() -> Result<()> {
     let Config {
         host,
@@ -97,7 +97,7 @@ pub(crate) async fn serve() -> Result<()> {
 }
 
 // Handle the websocket upgrade from http.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 async fn ws_handler(
     ws: WebSocketUpgrade,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
@@ -141,7 +141,7 @@ async fn ws_handler(
 }
 
 // After websocket is established, delegate incoming messages as they arrive.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 async fn handle_socket(socket: WebSocket, state: Arc<State>, addr: String, connection_id: Uuid) {
     let (sender, mut receiver) = socket.split();
     let sender = Arc::new(Mutex::new(sender));
@@ -179,7 +179,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<State>, addr: String, conne
 }
 
 /// Based on the incoming message type, perform some action and return a response.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 async fn process_message(
     msg: Message,
     sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -51,6 +51,7 @@ pub(crate) fn app(state: Arc<State>) -> Router {
 }
 
 /// Start the websocket server.  This is the entrypoint for the application.
+#[tracing::instrument]
 pub(crate) async fn serve() -> Result<()> {
     let Config {
         host,
@@ -96,6 +97,7 @@ pub(crate) async fn serve() -> Result<()> {
 }
 
 // Handle the websocket upgrade from http.
+#[tracing::instrument]
 async fn ws_handler(
     ws: WebSocketUpgrade,
     user_agent: Option<TypedHeader<headers::UserAgent>>,
@@ -139,6 +141,7 @@ async fn ws_handler(
 }
 
 // After websocket is established, delegate incoming messages as they arrive.
+#[tracing::instrument]
 async fn handle_socket(socket: WebSocket, state: Arc<State>, addr: String, connection_id: Uuid) {
     let (sender, mut receiver) = socket.split();
     let sender = Arc::new(Mutex::new(sender));
@@ -176,6 +179,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<State>, addr: String, conne
 }
 
 /// Based on the incoming message type, perform some action and return a response.
+#[tracing::instrument]
 async fn process_message(
     msg: Message,
     sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,

--- a/quadratic-multiplayer/src/server.rs
+++ b/quadratic-multiplayer/src/server.rs
@@ -169,7 +169,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<State>, addr: String, conne
                 tracing::info!("Broadcasting room {file_id} after removing stale users");
 
                 let message = MessageResponse::from(room.to_owned());
-                broadcast(Uuid::new_v4(), file_id, Arc::clone(&state), message);
+                broadcast(vec![], file_id, Arc::clone(&state), message);
             }
         }
     }

--- a/quadratic-multiplayer/src/state/connection.rs
+++ b/quadratic-multiplayer/src/state/connection.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use crate::state::State;
 
 impl State {
+    /// Retrieve the session_id from connections
     pub(crate) async fn get_session_id(&self, connection_id: Uuid) -> Result<Uuid> {
         let session_id = self
             .connections

--- a/quadratic-multiplayer/src/state/connection.rs
+++ b/quadratic-multiplayer/src/state/connection.rs
@@ -21,7 +21,7 @@ impl State {
     }
 
     /// Removes a connection from the state.  If the connection is in a room, leave the room.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn clear_connections(&self, connection_id: Uuid) -> Result<Vec<Uuid>> {
         let mut affected_rooms = vec![];
         let rooms = self.rooms.lock().await.clone();

--- a/quadratic-multiplayer/src/state/connection.rs
+++ b/quadratic-multiplayer/src/state/connection.rs
@@ -21,6 +21,7 @@ impl State {
     }
 
     /// Removes a connection from the state.  If the connection is in a room, leave the room.
+    #[tracing::instrument]
     pub(crate) async fn clear_connections(&self, connection_id: Uuid) -> Result<Vec<Uuid>> {
         let mut affected_rooms = vec![];
         let rooms = self.rooms.lock().await.clone();

--- a/quadratic-multiplayer/src/state/mod.rs
+++ b/quadratic-multiplayer/src/state/mod.rs
@@ -33,7 +33,7 @@ pub(crate) struct Settings {
 
 impl State {
     pub(crate) fn new() -> Self {
-        // TODO(ddimaria): seed transaction_queue with the sequence from the database for each file
+        // TODO(ddimaria): seed transaction_queue with the sequence_num from the database for each file
         State {
             rooms: Mutex::new(HashMap::new()),
             connections: Mutex::new(HashMap::new()),

--- a/quadratic-multiplayer/src/state/mod.rs
+++ b/quadratic-multiplayer/src/state/mod.rs
@@ -34,12 +34,10 @@ pub(crate) struct Settings {
 impl State {
     pub(crate) fn new() -> Self {
         // TODO(ddimaria): seed transaction_queue with the sequence from the database for each file
-        let sequence = 0;
-
         State {
             rooms: Mutex::new(HashMap::new()),
             connections: Mutex::new(HashMap::new()),
-            transaction_queue: Mutex::new(TransactionQueue::new(sequence)),
+            transaction_queue: Mutex::new(TransactionQueue::new()),
             settings: Settings::default(),
         }
     }

--- a/quadratic-multiplayer/src/state/mod.rs
+++ b/quadratic-multiplayer/src/state/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod connection;
 pub mod room;
+pub mod transaction_queue;
 pub mod user;
 
 use jsonwebtoken::jwk::JwkSet;
@@ -14,10 +15,13 @@ use uuid::Uuid;
 
 use crate::state::room::Room;
 
+use self::transaction_queue::TransactionQueue;
+
 #[derive(Debug)]
 pub(crate) struct State {
     pub(crate) rooms: Mutex<HashMap<Uuid, Room>>,
     pub(crate) connections: Mutex<HashMap<Uuid, Uuid>>,
+    pub(crate) transaction_queue: Mutex<TransactionQueue>,
     pub(crate) settings: Settings,
 }
 
@@ -29,9 +33,13 @@ pub(crate) struct Settings {
 
 impl State {
     pub(crate) fn new() -> Self {
+        // TODO(ddimaria): seed transaction_queue with the sequence from the database for each file
+        let sequence = 0;
+
         State {
             rooms: Mutex::new(HashMap::new()),
             connections: Mutex::new(HashMap::new()),
+            transaction_queue: Mutex::new(TransactionQueue::new(sequence)),
             settings: Settings::default(),
         }
     }

--- a/quadratic-multiplayer/src/state/room.rs
+++ b/quadratic-multiplayer/src/state/room.rs
@@ -38,6 +38,7 @@ impl State {
     /// Add a user to a room.  If the room doesn't exist, it is created.  Users
     /// are only added to a room once (HashMap).  Returns true if the user was
     /// newly added.
+    #[tracing::instrument]
     pub(crate) async fn enter_room(&self, file_id: Uuid, user: &User, connection_id: Uuid) -> bool {
         let is_new = get_or_create_room!(self, file_id)
             .users
@@ -56,6 +57,7 @@ impl State {
 
     /// Removes a user from a room. If the room is empty, it deletes the room.
     /// Returns true if the room still exists after the user leaves.
+    #[tracing::instrument]
     pub(crate) async fn leave_room(&self, file_id: Uuid, session_id: &Uuid) -> Result<bool> {
         get_mut_room!(self, file_id)?.users.remove(session_id);
         let num_in_room = get_room!(self, file_id)?.users.len();

--- a/quadratic-multiplayer/src/state/room.rs
+++ b/quadratic-multiplayer/src/state/room.rs
@@ -38,7 +38,7 @@ impl State {
     /// Add a user to a room.  If the room doesn't exist, it is created.  Users
     /// are only added to a room once (HashMap).  Returns true if the user was
     /// newly added.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn enter_room(&self, file_id: Uuid, user: &User, connection_id: Uuid) -> bool {
         let is_new = get_or_create_room!(self, file_id)
             .users
@@ -57,7 +57,7 @@ impl State {
 
     /// Removes a user from a room. If the room is empty, it deletes the room.
     /// Returns true if the room still exists after the user leaves.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn leave_room(&self, file_id: Uuid, session_id: &Uuid) -> Result<bool> {
         get_mut_room!(self, file_id)?.users.remove(session_id);
         let num_in_room = get_room!(self, file_id)?.users.len();

--- a/quadratic-multiplayer/src/state/transaction_queue.rs
+++ b/quadratic-multiplayer/src/state/transaction_queue.rs
@@ -1,35 +1,123 @@
-use std::collections::VecDeque;
-
+use anyhow::{anyhow, Result};
 use quadratic_core::controller::operation::Operation;
+use std::collections::{HashMap, VecDeque};
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Transaction {
     pub(crate) file_id: Uuid,
     pub(crate) operations: Vec<Operation>,
     pub(crate) sequence: u64,
 }
 
-#[derive(Debug)]
-pub(crate) struct TransactionQueue {
-    pub(crate) queue: VecDeque<Transaction>,
-    pub(crate) sequence: u64,
-}
-
-impl TransactionQueue {
-    pub(crate) fn new(sequence: u64) -> Self {
-        TransactionQueue {
-            queue: VecDeque::new(),
+impl Transaction {
+    pub(crate) fn new(file_id: Uuid, operations: Vec<Operation>, sequence: u64) -> Self {
+        Transaction {
+            file_id,
+            operations,
             sequence,
         }
     }
+}
 
-    pub(crate) fn push(&mut self, transaction: Transaction) {
-        self.sequence = transaction.sequence;
+#[derive(Debug, Default)]
+pub(crate) struct TransactionQueue {
+    pub(crate) queue: VecDeque<Transaction>,
+    pub(crate) file_sequence: Mutex<HashMap<Uuid, u64>>,
+}
+
+impl TransactionQueue {
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    pub(crate) async fn push(&mut self, file_id: Uuid, operations: Vec<Operation>) -> u64 {
+        let sequence = self.increment_sequence(file_id).await;
+        let transaction = Transaction::new(file_id, operations, sequence);
         self.queue.push_back(transaction);
+        sequence
     }
 
     pub(crate) fn pop(&mut self) -> Option<Transaction> {
         self.queue.pop_front()
+    }
+
+    /// Increment the sequence number for this file and return the new sequence number.
+    pub(crate) async fn increment_sequence(&mut self, file_id: Uuid) -> u64 {
+        self.file_sequence
+            .lock()
+            .await
+            .entry(file_id)
+            .and_modify(|sequence| *sequence += 1)
+            .or_insert(1)
+            .to_owned()
+    }
+
+    pub(crate) async fn get_sequence(&mut self, file_id: Uuid) -> Result<u64> {
+        self.file_sequence
+            .lock()
+            .await
+            .get(&file_id)
+            .copied()
+            .ok_or_else(|| anyhow!("file_id {file_id} not found in file_sequence"))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use quadratic_core::grid::{Sheet, SheetId};
+
+    use crate::{
+        state::State,
+        test_util::{assert_anyhow_error, grid_setup, new_user, operation},
+    };
+
+    fn setup() -> (State, Uuid) {
+        let state = State::new();
+        let file_id = Uuid::new_v4();
+
+        (state, file_id)
+    }
+
+    use super::*;
+    #[tokio::test]
+    async fn transaction_queue() {
+        let (state, file_id) = setup();
+        let mut grid = grid_setup();
+        let operations_1 = operation(&mut grid, 0, 0, "1");
+        let operations_2 = operation(&mut grid, 1, 0, "2");
+
+        state
+            .transaction_queue
+            .lock()
+            .await
+            .push(file_id, vec![operations_1.clone()])
+            .await;
+
+        let mut transaction_queue = state.transaction_queue.lock().await;
+        assert_eq!(transaction_queue.queue.len(), 1);
+        assert_eq!(transaction_queue.get_sequence(file_id).await.unwrap(), 1);
+        assert_eq!(
+            transaction_queue.queue[0].operations,
+            vec![operations_1.clone()]
+        );
+        assert_eq!(transaction_queue.queue[0].sequence, 1);
+
+        std::mem::drop(transaction_queue);
+
+        state
+            .transaction_queue
+            .lock()
+            .await
+            .push(file_id, vec![operations_2.clone()])
+            .await;
+
+        let mut transaction_queue = state.transaction_queue.lock().await;
+        assert_eq!(transaction_queue.queue.len(), 2);
+        assert_eq!(transaction_queue.get_sequence(file_id).await.unwrap(), 2);
+        assert_eq!(transaction_queue.queue[0].operations, vec![operations_1]);
+        assert_eq!(transaction_queue.queue[1].operations, vec![operations_2]);
+        assert_eq!(transaction_queue.queue[0].sequence, 1);
+        assert_eq!(transaction_queue.queue[1].sequence, 2);
     }
 }

--- a/quadratic-multiplayer/src/state/transaction_queue.rs
+++ b/quadratic-multiplayer/src/state/transaction_queue.rs
@@ -1,0 +1,35 @@
+use std::collections::VecDeque;
+
+use quadratic_core::controller::operation::Operation;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(crate) struct Transaction {
+    pub(crate) file_id: Uuid,
+    pub(crate) operations: Vec<Operation>,
+    pub(crate) sequence: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct TransactionQueue {
+    pub(crate) queue: VecDeque<Transaction>,
+    pub(crate) sequence: u64,
+}
+
+impl TransactionQueue {
+    pub(crate) fn new(sequence: u64) -> Self {
+        TransactionQueue {
+            queue: VecDeque::new(),
+            sequence,
+        }
+    }
+
+    pub(crate) fn push(&mut self, transaction: Transaction) {
+        self.sequence = transaction.sequence;
+        self.queue.push_back(transaction);
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<Transaction> {
+        self.queue.pop_front()
+    }
+}

--- a/quadratic-multiplayer/src/state/user.rs
+++ b/quadratic-multiplayer/src/state/user.rs
@@ -83,6 +83,7 @@ impl State {
     }
 
     /// Remove stale users in a room.  Returns the number of users removed in the room, and the number left.
+    #[tracing::instrument]
     pub(crate) async fn remove_stale_users_in_room(
         &self,
         file_id: Uuid,
@@ -115,6 +116,7 @@ impl State {
     }
 
     /// Updates a user's heartbeat in a room
+    #[tracing::instrument]
     pub(crate) async fn update_user_heartbeat(
         &self,
         file_id: Uuid,

--- a/quadratic-multiplayer/src/state/user.rs
+++ b/quadratic-multiplayer/src/state/user.rs
@@ -163,6 +163,7 @@ impl State {
                 if let Some(viewport) = user_state.viewport.to_owned() {
                     user.state.viewport = viewport;
                 }
+
                 user.last_heartbeat = Utc::now();
             });
 

--- a/quadratic-multiplayer/src/state/user.rs
+++ b/quadratic-multiplayer/src/state/user.rs
@@ -83,7 +83,7 @@ impl State {
     }
 
     /// Remove stale users in a room.  Returns the number of users removed in the room, and the number left.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn remove_stale_users_in_room(
         &self,
         file_id: Uuid,
@@ -116,7 +116,7 @@ impl State {
     }
 
     /// Updates a user's heartbeat in a room
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn update_user_heartbeat(
         &self,
         file_id: Uuid,

--- a/quadratic-multiplayer/src/test_util.rs
+++ b/quadratic-multiplayer/src/test_util.rs
@@ -70,9 +70,7 @@ pub(crate) async fn add_new_user_to_room(
 }
 
 pub(crate) fn grid_setup() -> GridController {
-    let grid = GridController::new();
-
-    grid
+    GridController::new()
 }
 
 pub(crate) fn operation(grid: &mut GridController, x: i64, y: i64, value: &str) -> Operation {

--- a/quadratic-multiplayer/src/test_util.rs
+++ b/quadratic-multiplayer/src/test_util.rs
@@ -6,8 +6,6 @@ use futures::stream::StreamExt;
 use futures_util::SinkExt;
 use quadratic_core::controller::operation::Operation;
 use quadratic_core::controller::GridController;
-use quadratic_core::grid::SheetId;
-use quadratic_core::test_util::assert_cell_value;
 use quadratic_core::{Array, CellValue, Rect};
 use std::sync::Arc;
 use std::{


### PR DESCRIPTION
- [x] Build out basic transaction queue
- [x] Add to the transaction queue for each transaction in ANY room
- [x] Accept UUIDs for incoming Transaction messages
- [x] Broadcast UUIDs for all outgoing Transaction responses
- [x] Broadcast current sequence number to all users in the room
- [x] Allow the client to retrieve missing transactions