### PR TITLE
Improve CodeEditor warning dialog

### DIFF
--- a/quadratic-client/src/atoms/editorInteractionStateAtom.ts
+++ b/quadratic-client/src/atoms/editorInteractionStateAtom.ts
@@ -14,6 +14,7 @@ export interface EditorInteractionState {
   selectedCell: Coordinate;
   selectedCellSheet: string;
   mode: CellType;
+  editorEscapePressed?: boolean;
   waitingForEditorClose?: {
     selectedCell: Coordinate;
     selectedCellSheet: string;

--- a/quadratic-client/src/atoms/editorInteractionStateAtom.ts
+++ b/quadratic-client/src/atoms/editorInteractionStateAtom.ts
@@ -14,6 +14,7 @@ export interface EditorInteractionState {
   selectedCell: Coordinate;
   selectedCellSheet: string;
   mode: CellType;
+  waitingForEditorClose?: { selectedCell: Coordinate; selectedCellSheet: string; mode: CellType };
 }
 
 export const editorInteractionStateDefault: EditorInteractionState = {

--- a/quadratic-client/src/atoms/editorInteractionStateAtom.ts
+++ b/quadratic-client/src/atoms/editorInteractionStateAtom.ts
@@ -14,7 +14,12 @@ export interface EditorInteractionState {
   selectedCell: Coordinate;
   selectedCellSheet: string;
   mode: CellType;
-  waitingForEditorClose?: { selectedCell: Coordinate; selectedCellSheet: string; mode: CellType };
+  waitingForEditorClose?: {
+    selectedCell: Coordinate;
+    selectedCellSheet: string;
+    mode: CellType;
+    showCellTypeMenu: boolean;
+  };
 }
 
 export const editorInteractionStateDefault: EditorInteractionState = {

--- a/quadratic-client/src/gridGL/interaction/CellInput.tsx
+++ b/quadratic-client/src/gridGL/interaction/CellInput.tsx
@@ -259,12 +259,15 @@ export const CellInput = (props: CellInputProps) => {
           // Open cell type menu, close editor.
           setEditorInteractionState({
             ...editorInteractionState,
-            showCellTypeMenu: true,
-            showCodeEditor: false,
-            selectedCell: { x: cellLocation.x, y: cellLocation.y },
-            selectedCellSheet: sheets.sheet.id,
-            mode: 'PYTHON',
+            showCodeEditor: true,
+            waitingForEditorClose: {
+              selectedCell: { x: cellLocation.x, y: cellLocation.y },
+              selectedCellSheet: sheets.sheet.id,
+              mode: 'PYTHON',
+              showCellTypeMenu: true,
+            },
           });
+          pixiAppSettings.changeInput(false);
           event.stopPropagation();
         } else if (event.key === 'Tab') {
           if (event.shiftKey) closeInput({ x: -1, y: 0 });

--- a/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
+++ b/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
@@ -121,7 +121,7 @@ export function keyboardCell(options: {
         const mode = cell.language === 'Python' ? 'PYTHON' : cell.language === 'Formula' ? 'FORMULA' : undefined;
         if (!mode) throw new Error(`Unhandled cell.language ${cell.language} in keyboardCell`);
 
-        // Open code editor, or move code editor if already open.
+        // Open code editor, or move change editor if already open.
         setEditorInteractionState({
           ...editorInteractionState,
           showCellTypeMenu: false,
@@ -133,8 +133,8 @@ export function keyboardCell(options: {
           },
         });
       }
-    } else {
-      // Open cell type menu, close editor.
+    } else if (editorInteractionState.showCodeEditor) {
+      // code editor is already open, so check it for save before closing
       setEditorInteractionState({
         ...editorInteractionState,
         waitingForEditorClose: {
@@ -143,6 +143,14 @@ export function keyboardCell(options: {
           selectedCellSheet: sheets.sheet.id,
           mode: 'PYTHON',
         },
+      });
+    } else {
+      // just open the code editor selection menu
+      setEditorInteractionState({
+        ...editorInteractionState,
+        showCellTypeMenu: true,
+        selectedCell: { x: x, y: y },
+        selectedCellSheet: sheets.sheet.id,
       });
     }
     event.preventDefault();

--- a/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
+++ b/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
@@ -121,17 +121,28 @@ export function keyboardCell(options: {
         const mode = cell.language === 'Python' ? 'PYTHON' : cell.language === 'Formula' ? 'FORMULA' : undefined;
         if (!mode) throw new Error(`Unhandled cell.language ${cell.language} in keyboardCell`);
 
-        // Open code editor, or move change editor if already open.
-        setEditorInteractionState({
-          ...editorInteractionState,
-          showCellTypeMenu: false,
-          waitingForEditorClose: {
+        if (editorInteractionState.showCodeEditor) {
+          // Open code editor, or move change editor if already open.
+          setEditorInteractionState({
+            ...editorInteractionState,
+            showCellTypeMenu: false,
+            waitingForEditorClose: {
+              selectedCell: { x: x, y: y },
+              selectedCellSheet: sheets.sheet.id,
+              mode,
+              showCellTypeMenu: false,
+            },
+          });
+        } else {
+          setEditorInteractionState({
+            ...editorInteractionState,
+            showCellTypeMenu: false,
             selectedCell: { x: x, y: y },
             selectedCellSheet: sheets.sheet.id,
             mode,
-            showCellTypeMenu: false,
-          },
-        });
+            showCodeEditor: true,
+          });
+        }
       }
     } else if (editorInteractionState.showCodeEditor) {
       // code editor is already open, so check it for save before closing

--- a/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
+++ b/quadratic-client/src/gridGL/interaction/keyboard/keyboardCell.ts
@@ -125,21 +125,24 @@ export function keyboardCell(options: {
         setEditorInteractionState({
           ...editorInteractionState,
           showCellTypeMenu: false,
-          showCodeEditor: true,
-          selectedCell: { x: x, y: y },
-          selectedCellSheet: sheets.sheet.id,
-          mode,
+          waitingForEditorClose: {
+            selectedCell: { x: x, y: y },
+            selectedCellSheet: sheets.sheet.id,
+            mode,
+            showCellTypeMenu: false,
+          },
         });
       }
     } else {
       // Open cell type menu, close editor.
       setEditorInteractionState({
         ...editorInteractionState,
-        showCellTypeMenu: true,
-        showCodeEditor: false,
-        selectedCell: { x: x, y: y },
-        selectedCellSheet: sheets.sheet.id,
-        mode: 'PYTHON',
+        waitingForEditorClose: {
+          showCellTypeMenu: true,
+          selectedCell: { x: x, y: y },
+          selectedCellSheet: sheets.sheet.id,
+          mode: 'PYTHON',
+        },
       });
     }
     event.preventDefault();

--- a/quadratic-client/src/gridGL/interaction/keyboard/keyboardViewport.ts
+++ b/quadratic-client/src/gridGL/interaction/keyboard/keyboardViewport.ts
@@ -39,6 +39,12 @@ export function keyboardViewport(options: {
     if (presentationMode) {
       setPresentationMode(false);
       return true;
+    } else if (editorInteractionState.showCodeEditor) {
+      setEditorInteractionState({
+        ...editorInteractionState,
+        editorEscapePressed: true,
+      });
+      return true;
     }
     return pointer.handleEscape();
   }

--- a/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
@@ -15,14 +15,28 @@ export function doubleClickCell(options: {
 
   if (!settings.setEditorInteractionState) return;
   if (mode) {
-    settings.setEditorInteractionState({
-      ...settings.editorInteractionState,
-      showCellTypeMenu: false,
-      showCodeEditor: true,
-      selectedCell: { x: column, y: row },
-      selectedCellSheet: sheets.sheet.id,
-      mode,
-    });
+    if (settings.editorInteractionState.showCodeEditor) {
+      settings.setEditorInteractionState({
+        ...settings.editorInteractionState,
+        showCellTypeMenu: false,
+        waitingForEditorClose: {
+          selectedCell: { x: column, y: row },
+          selectedCellSheet: sheets.sheet.id,
+          mode,
+        },
+      });
+    } else {
+      console.log('hi');
+      settings.setEditorInteractionState({
+        ...settings.editorInteractionState,
+        showCellTypeMenu: false,
+        showCodeEditor: true,
+        selectedCell: { x: column, y: row },
+        selectedCellSheet: sheets.sheet.id,
+        mode,
+        waitingForEditorClose: undefined,
+      });
+    }
   } else if (hasPermission) {
     settings.changeInput(true, cell);
   }

--- a/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
@@ -23,6 +23,7 @@ export function doubleClickCell(options: {
           selectedCell: { x: column, y: row },
           selectedCellSheet: sheets.sheet.id,
           mode,
+          showCellTypeMenu: !mode,
         },
       });
     } else {

--- a/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/gridGL/interaction/pointer/doubleClickCell.ts
@@ -18,6 +18,7 @@ export function doubleClickCell(options: {
     if (settings.editorInteractionState.showCodeEditor) {
       settings.setEditorInteractionState({
         ...settings.editorInteractionState,
+        editorEscapePressed: false,
         showCellTypeMenu: false,
         waitingForEditorClose: {
           selectedCell: { x: column, y: row },
@@ -27,7 +28,6 @@ export function doubleClickCell(options: {
         },
       });
     } else {
-      console.log('hi');
       settings.setEditorInteractionState({
         ...settings.editorInteractionState,
         showCellTypeMenu: false,
@@ -35,6 +35,7 @@ export function doubleClickCell(options: {
         selectedCell: { x: column, y: row },
         selectedCellSheet: sheets.sheet.id,
         mode,
+        editorEscapePressed: false,
         waitingForEditorClose: undefined,
       });
     }

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -116,13 +116,6 @@ export const CodeEditor = () => {
     updateCodeCell(true);
   }, [updateCodeCell]);
 
-  // handle when escape is pressed when escape does not have focus
-  useEffect(() => {
-    if (editorInteractionState.editorEscapePressed) {
-      setShowSaveChangesAlert(true);
-    }
-  }, [editorInteractionState.editorEscapePressed]);
-
   useEffect(() => {
     mixpanel.track('[CodeEditor].opened', { type: editorMode });
   }, [editorMode]);
@@ -143,6 +136,17 @@ export const CodeEditor = () => {
     },
     [setEditorInteractionState, unsaved]
   );
+
+  // handle when escape is pressed when escape does not have focus
+  useEffect(() => {
+    if (editorInteractionState.editorEscapePressed) {
+      if (unsaved) {
+        setShowSaveChangesAlert(true);
+      } else {
+        closeEditor(true);
+      }
+    }
+  }, [closeEditor, editorInteractionState.editorEscapePressed, unsaved]);
 
   const saveAndRunCell = async () => {
     if (pythonState !== 'idle') return;

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -258,6 +258,7 @@ export const CodeEditor = () => {
             setShowSaveChangesAlert(!showSaveChangesAlert);
             setEditorInteractionState((old) => ({
               ...old,
+              editorEscapePressed: false,
               waitingForEditorClose: undefined,
             }));
           }}

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -122,6 +122,7 @@ export const CodeEditor = () => {
       } else {
         setEditorInteractionState((oldState) => ({
           ...oldState,
+          editorEscapePressed: false,
           showCodeEditor: false,
         }));
         pixiApp.highlightedCells.clear();
@@ -195,6 +196,9 @@ export const CodeEditor = () => {
 
   const afterDialog = () => {
     setShowSaveChangesAlert(false);
+    if (editorInteractionState.editorEscapePressed) {
+      closeEditor(true);
+    }
     const waitingForEditorClose = editorInteractionState.waitingForEditorClose;
     if (waitingForEditorClose) {
       setEditorInteractionState((oldState) => ({

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -51,11 +51,16 @@ export const CodeEditor = () => {
     return editorContent !== codeString;
   }, [codeString, editorContent]);
 
+  // handle someone trying to open a different code editor
   useEffect(() => {
     if (editorInteractionState.waitingForEditorClose) {
+      // if unsaved then show save dialog and wait for that to complete
       if (unsaved) {
         setShowSaveChangesAlert(true);
-      } else {
+      }
+
+      // otherwise either open the new editor or show the cell type menu (if type is not selected)
+      else {
         const waitingForEditorClose = editorInteractionState.waitingForEditorClose;
         if (waitingForEditorClose) {
           setEditorInteractionState((oldState) => ({
@@ -63,7 +68,7 @@ export const CodeEditor = () => {
             selectedCell: waitingForEditorClose.selectedCell,
             selectedCellSheet: waitingForEditorClose.selectedCellSheet,
             mode: waitingForEditorClose.mode,
-            showCodeEditor: true,
+            showCodeEditor: !waitingForEditorClose.showCellTypeMenu,
             showCellTypeMenu: waitingForEditorClose.showCellTypeMenu,
             waitingForEditorClose: undefined,
           }));
@@ -110,6 +115,13 @@ export const CodeEditor = () => {
   useEffect(() => {
     updateCodeCell(true);
   }, [updateCodeCell]);
+
+  // handle when escape is pressed when escape does not have focus
+  useEffect(() => {
+    if (editorInteractionState.editorEscapePressed) {
+      setShowSaveChangesAlert(true);
+    }
+  }, [editorInteractionState.editorEscapePressed]);
 
   useEffect(() => {
     mixpanel.track('[CodeEditor].opened', { type: editorMode });

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -20,6 +20,7 @@ export const CodeEditor = () => {
   const [editorInteractionState, setEditorInteractionState] = useRecoilState(editorInteractionStateAtom);
   const { showCodeEditor, mode: editorMode } = editorInteractionState;
   const { pythonState } = useRecoilValue(pythonStateAtom);
+
   // update code cell
   const [codeString, setCodeString] = useState('');
   const [out, setOut] = useState<{ stdOut?: string; stdErr?: string } | undefined>(undefined);
@@ -95,7 +96,7 @@ export const CodeEditor = () => {
 
   const closeEditor = useCallback(
     (skipSaveCheck: boolean) => {
-      if (!skipSaveCheck && editorContent !== codeString) {
+      if (!skipSaveCheck && unsaved) {
         setShowSaveChangesAlert(true);
       } else {
         setEditorInteractionState((oldState) => ({
@@ -106,7 +107,7 @@ export const CodeEditor = () => {
         focusGrid();
       }
     },
-    [codeString, editorContent, setEditorInteractionState]
+    [setEditorInteractionState, unsaved]
   );
 
   const saveAndRunCell = async () => {

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -51,6 +51,25 @@ export const CodeEditor = () => {
     return editorContent !== codeString;
   }, [codeString, editorContent]);
 
+  useEffect(() => {
+    if (editorInteractionState.waitingForEditorClose) {
+      if (unsaved) {
+        setShowSaveChangesAlert(true);
+      } else {
+        const waitingForEditorClose = editorInteractionState.waitingForEditorClose;
+        if (waitingForEditorClose) {
+          setEditorInteractionState((oldState) => ({
+            ...oldState,
+            selectedCell: waitingForEditorClose.selectedCell,
+            selectedCellSheet: waitingForEditorClose.selectedCellSheet,
+            mode: waitingForEditorClose.mode,
+            waitingForEditorClose: undefined,
+          }));
+        }
+      }
+    }
+  }, [editorInteractionState.waitingForEditorClose, setEditorInteractionState, unsaved]);
+
   const updateCodeCell = useCallback(
     (updateEditorContent: boolean) => {
       const codeCell = grid.getCodeCell(
@@ -172,6 +191,22 @@ export const CodeEditor = () => {
     }
   };
 
+  const afterDialog = () => {
+    setShowSaveChangesAlert(false);
+    const waitingForEditorClose = editorInteractionState.waitingForEditorClose;
+    if (waitingForEditorClose) {
+      setEditorInteractionState((oldState) => ({
+        ...oldState,
+        selectedCell: waitingForEditorClose.selectedCell,
+        selectedCellSheet: waitingForEditorClose.selectedCellSheet,
+        mode: waitingForEditorClose.mode,
+        waitingForEditorClose: undefined,
+      }));
+    } else {
+      closeEditor(true);
+    }
+  };
+
   if (!showCodeEditor) {
     return null;
   }
@@ -200,10 +235,10 @@ export const CodeEditor = () => {
           }}
           onSave={() => {
             saveAndRunCell();
-            closeEditor(true);
+            afterDialog();
           }}
           onDiscard={() => {
-            closeEditor(true);
+            afterDialog();
           }}
         />
       )}

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -63,6 +63,8 @@ export const CodeEditor = () => {
             selectedCell: waitingForEditorClose.selectedCell,
             selectedCellSheet: waitingForEditorClose.selectedCellSheet,
             mode: waitingForEditorClose.mode,
+            showCodeEditor: true,
+            showCellTypeMenu: waitingForEditorClose.showCellTypeMenu,
             waitingForEditorClose: undefined,
           }));
         }
@@ -200,6 +202,8 @@ export const CodeEditor = () => {
         selectedCell: waitingForEditorClose.selectedCell,
         selectedCellSheet: waitingForEditorClose.selectedCellSheet,
         mode: waitingForEditorClose.mode,
+        showCodeEditor: !waitingForEditorClose.showCellTypeMenu,
+        showCellTypeMenu: waitingForEditorClose.showCellTypeMenu,
         waitingForEditorClose: undefined,
       }));
     } else {

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -240,6 +240,10 @@ export const CodeEditor = () => {
         <SaveChangesAlert
           onCancel={() => {
             setShowSaveChangesAlert(!showSaveChangesAlert);
+            setEditorInteractionState((old) => ({
+              ...old,
+              waitingForEditorClose: undefined,
+            }));
           }}
           onSave={() => {
             saveAndRunCell();

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditorBody.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditorBody.tsx
@@ -64,16 +64,20 @@ export const CodeEditorBody = (props: Props) => {
       monaco.languages.registerCompletionItemProvider('formula', { provideCompletionItems });
       monaco.languages.registerHoverProvider('formula', { provideHover });
 
-      editor.addCommand(
-        monaco.KeyCode.Escape,
+      setDidMount(true);
+    },
+    [didMount]
+  );
+
+  useEffect(() => {
+    if (editorRef.current && monacoRef.current && didMount) {
+      editorRef.current.addCommand(
+        monacoRef.current.KeyCode.Escape,
         () => closeEditor(false),
         '!findWidgetVisible && !inReferenceSearchEditor && !editorHasSelection && !suggestWidgetVisible'
       );
-
-      setDidMount(true);
-    },
-    [didMount, closeEditor]
-  );
+    }
+  }, [closeEditor, didMount]);
 
   useEffect(() => {
     return () => editorRef.current?.dispose();


### PR DESCRIPTION
- [x] fix bug with escape key not trigger CodeEditor save warning
- [x] add warning dialog when changing code cell to a different cell
  - [x] double click
  - [x] = from outside cell
  - [x] = within CellInput
- [x] add escape anywhere in app to close code editor

The testing matrix is rather large:

__Possible states__
1. Code Editor is open or closed
2. Code Editor has changes or not
3. Code Editor has focus or not

__Triggers__
- [x] Pressing escape (with states 2 and 3)
- [x] Pressing the close button on code editor (with states 2 and 3)
- [x] Double-clicking a code cell (with state 2)
- [x] Pressing equals or slash on a code cell (with state 2)
- [x] Pressing equals or slash on a non-code cell (with state 2)
- [x] Typing = as the first character while cell input is open (with state 2)

__Save Dialog choice__
Need to check all the triggers against the three results of the dialog: Save and Run, Discard, and Cancel. 
* Save and Run should save and run the cell and update it before performing the trigger
* Cancel should revert the original code cell's contents before performing the trigger
* Cancel should always leave the code cell the way it was with the unsaved change and cancel the triggering event 