### PR TITLE
feat: new user association

### DIFF
--- a/quadratic-api/src/auth0/profile.ts
+++ b/quadratic-api/src/auth0/profile.ts
@@ -26,6 +26,7 @@ export const getAuth0Users = async (auth0Ids: string[]) => {
 
 /**
  * Given a list of users from our system, we lookup their info in Auth0.
+ * If we don't find a user, we throw.
  *
  * Example in:
  *   [
@@ -33,7 +34,7 @@ export const getAuth0Users = async (auth0Ids: string[]) => {
  *   ]
  * Example out:
  *   {
- *     'google-oauth2|112233': {
+ *     10: {
  *       id: 10,
  *       auth0Id: 'google-oauth2|112233',
  *       email: 'john_doe@example.com',
@@ -66,7 +67,7 @@ export const getUsersFromAuth0 = async (users: { id: number; auth0Id: string }[]
     // If we're missing data we expect, log it to Sentry and skip this user
     if (!auth0User || auth0User.email === undefined) {
       Sentry.captureException({
-        message: 'Auth0 user returned without `user_id` or `email`',
+        message: 'Auth0 user returned without `email`',
         level: 'error',
         extra: {
           auth0User,
@@ -91,7 +92,7 @@ export const getUsersFromAuth0 = async (users: { id: number; auth0Id: string }[]
   return usersById;
 };
 
-export const getUsersByEmail = async (email: string) => {
+export const lookupUsersFromAuth0ByEmail = async (email: string) => {
   const auth0Users = await auth0.getUsersByEmail(email);
   return auth0Users;
 };

--- a/quadratic-api/src/auth0/profile.ts
+++ b/quadratic-api/src/auth0/profile.ts
@@ -17,13 +17,6 @@ const auth0 = new ManagementClient({
   scope: 'read:users',
 });
 
-export const getAuth0Users = async (auth0Ids: string[]) => {
-  const auth0Users = await auth0.getUsers({
-    q: `user_id:(${auth0Ids.join(' OR ')})`,
-  });
-  return auth0Users;
-};
-
 /**
  * Given a list of users from our system, we lookup their info in Auth0.
  * If we don't find a user, we throw.

--- a/quadratic-api/src/middleware/user.test.ts
+++ b/quadratic-api/src/middleware/user.test.ts
@@ -1,0 +1,159 @@
+import request from 'supertest';
+import { app } from '../app';
+import dbClient from '../dbClient';
+import { createFile } from '../tests/testDataGenerator';
+
+beforeEach(async () => {
+  // Create a user
+  const user1 = await dbClient.user.create({
+    data: {
+      auth0Id: 'user1',
+    },
+  });
+
+  // Create a file with an invite
+  await createFile({
+    data: {
+      name: 'Test File 1',
+      uuid: '00000000-0000-4000-8000-000000000001',
+      creatorUserId: user1.id,
+      ownerUserId: user1.id,
+      FileInvite: {
+        create: [
+          {
+            email: 'johnDoe@example.com',
+            role: 'EDITOR',
+          },
+        ],
+      },
+    },
+  });
+
+  // Create a team with an invite
+  await dbClient.team.create({
+    data: {
+      name: 'Test Team 1',
+      uuid: '00000000-0000-4000-8000-000000000002',
+      UserTeamRole: {
+        create: [
+          {
+            userId: user1.id,
+            role: 'OWNER',
+          },
+        ],
+      },
+      TeamInvite: {
+        create: [
+          {
+            email: 'johnDoe@example.com',
+            role: 'EDITOR',
+          },
+        ],
+      },
+    },
+  });
+});
+
+afterEach(async () => {
+  await dbClient.$transaction([
+    dbClient.fileInvite.deleteMany(),
+    dbClient.teamInvite.deleteMany(),
+    dbClient.userTeamRole.deleteMany(),
+    dbClient.userFileRole.deleteMany(),
+    dbClient.fileCheckpoint.deleteMany(),
+    dbClient.file.deleteMany(),
+    dbClient.user.deleteMany(),
+    dbClient.team.deleteMany(),
+  ]);
+});
+
+jest.mock('auth0', () => {
+  return {
+    ManagementClient: jest.fn().mockImplementation(() => {
+      return {
+        getUsers: jest.fn().mockImplementation(({ q }: { q: string }) => {
+          // example value for `q`: "user_id:(user1 OR user2)"
+          const auth0Users = [
+            {
+              user_id: 'firstTimeUser',
+              email: 'johnDoe@example.com',
+              name: 'Test User 1',
+            },
+            {
+              user_id: 'user1',
+              email: 'user1@example.com',
+            },
+          ];
+          return auth0Users.filter(({ user_id }) => q.includes(user_id));
+        }),
+      };
+    }),
+  };
+});
+
+describe('A user coming in to the system for the first time', () => {
+  describe('accessing _any_ endpoint', () => {
+    it('creates the user in the database', async () => {
+      const userBefore = await dbClient.user.findUnique({
+        where: {
+          auth0Id: 'firstTimeUser',
+        },
+      });
+      expect(userBefore).toBe(null);
+      await request(app)
+        .get('/v0/files')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ValidToken firstTimeUser`)
+        .expect(200);
+      const userAfter = await dbClient.user.findUnique({
+        where: {
+          auth0Id: 'firstTimeUser',
+        },
+      });
+      expect(userAfter).toHaveProperty('id');
+      expect(userAfter).toHaveProperty('auth0Id');
+    });
+  });
+  describe('accessing a team', () => {
+    it('deletes invites when they log in and gives them access', async () => {
+      const invitesBefore = await dbClient.teamInvite.findMany({
+        where: {
+          email: 'johnDoe@example.com',
+        },
+      });
+      expect(invitesBefore.length).toBe(1);
+      await request(app)
+        .get('/v0/teams/00000000-0000-4000-8000-000000000002')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ValidToken firstTimeUser`)
+        .expect(200);
+      const invitesAfter = await dbClient.teamInvite.findMany({
+        where: {
+          email: 'johnDoe@example.com',
+        },
+      });
+      expect(invitesAfter.length).toBe(0);
+    });
+  });
+  describe('accessing a file', () => {
+    it('deletes invites when they log in and gives them access', async () => {
+      const invitesBefore = await dbClient.fileInvite.findMany({
+        where: {
+          email: 'johnDoe@example.com',
+        },
+      });
+      expect(invitesBefore.length).toBe(1);
+      await request(app)
+        .get('/v0/files/00000000-0000-4000-8000-000000000001')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ValidToken firstTimeUser`)
+        .expect(200);
+      const invitesAfter = await dbClient.fileInvite.findMany({
+        where: {
+          email: 'johnDoe@example.com',
+        },
+      });
+      expect(invitesAfter.length).toBe(0);
+    });
+  });
+});

--- a/quadratic-api/src/middleware/user.ts
+++ b/quadratic-api/src/middleware/user.ts
@@ -1,20 +1,76 @@
 import { NextFunction, Request, Response } from 'express';
+import { getUsersFromAuth0 } from '../auth0/profile';
 import dbClient from '../dbClient';
 import { RequestWithAuth, RequestWithOptionalAuth, RequestWithUser } from '../types/Request';
 
 const getOrCreateUser = async (auth0Id: string) => {
-  // get user from db
-  const user = await dbClient.user.upsert({
+  // First try to get the user
+  const user = await dbClient.user.findUnique({
     where: {
       auth0Id,
     },
-    update: {},
-    create: {
+  });
+  if (user) {
+    return user;
+  }
+
+  // If they don't exist yet, create them
+  const newUser = await dbClient.user.create({
+    data: {
       auth0Id,
     },
   });
 
-  return user;
+  // And now we have some extra work to do if it's their first time logging in
+
+  // Lookup their email in auth0
+  const usersById = await getUsersFromAuth0([{ id: newUser.id, auth0Id: auth0Id }]);
+  const { email } = usersById[newUser.id];
+
+  // See if they've been invited to any teams and make them team members
+  const teamInvites = await dbClient.teamInvite.findMany({
+    where: {
+      email,
+    },
+  });
+  if (teamInvites.length) {
+    await dbClient.teamInvite.deleteMany({
+      where: {
+        email,
+      },
+    });
+    await dbClient.userTeamRole.createMany({
+      data: teamInvites.map(({ teamId, role }) => ({
+        teamId,
+        userId: newUser.id,
+        role,
+      })),
+    });
+  }
+
+  // Do the same as teams, but with files
+  const fileInvites = await dbClient.fileInvite.findMany({
+    where: {
+      email,
+    },
+  });
+  if (fileInvites.length) {
+    await dbClient.fileInvite.deleteMany({
+      where: {
+        email,
+      },
+    });
+    await dbClient.userFileRole.createMany({
+      data: fileInvites.map(({ fileId, role }) => ({
+        fileId,
+        userId: newUser.id,
+        role,
+      })),
+    });
+  }
+
+  // Return the user
+  return newUser;
 };
 
 export const userMiddleware = async (req: Request, res: Response, next: NextFunction) => {

--- a/quadratic-api/src/routes/v0/files.$uuid.invites.POST.ts
+++ b/quadratic-api/src/routes/v0/files.$uuid.invites.POST.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { ApiSchemas, ApiTypes, FilePermissionSchema } from 'quadratic-shared/typesAndSchemas';
 import { z } from 'zod';
-import { getUsersByEmail } from '../../auth0/profile';
+import { lookupUsersFromAuth0ByEmail } from '../../auth0/profile';
 import dbClient from '../../dbClient';
 import { getFile } from '../../middleware/getFile';
 import { userMiddleware } from '../../middleware/user';
@@ -45,7 +45,7 @@ async function handler(req: Request, res: Response) {
   }
 
   // Look up the invited user by email in Auth0 and then 1 of 3 things will happen:
-  const auth0Users = await getUsersByEmail(email);
+  const auth0Users = await lookupUsersFromAuth0ByEmail(email);
 
   // 1. Nobody with an account by that email, invite them!
   if (auth0Users.length === 0) {

--- a/quadratic-api/src/routes/v0/teams.$uuid.invites.POST.ts
+++ b/quadratic-api/src/routes/v0/teams.$uuid.invites.POST.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { ApiSchemas, ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import { z } from 'zod';
-import { getUsersByEmail } from '../../auth0/profile';
+import { lookupUsersFromAuth0ByEmail } from '../../auth0/profile';
 import dbClient from '../../dbClient';
 import { getTeam } from '../../middleware/getTeam';
 import { userMiddleware } from '../../middleware/user';
@@ -56,7 +56,7 @@ async function handler(req: Request, res: Response) {
   }
 
   // Look up the invited user by email in Auth0
-  const auth0Users = await getUsersByEmail(email);
+  const auth0Users = await lookupUsersFromAuth0ByEmail(email);
 
   // Nobody with an account by that email
   if (auth0Users.length === 0) {

--- a/quadratic-api/src/tests/testDataGenerator.ts
+++ b/quadratic-api/src/tests/testDataGenerator.ts
@@ -2,6 +2,21 @@ import { randomUUID } from 'crypto';
 import { UserTeamRole } from 'quadratic-shared/typesAndSchemas';
 import dbClient from '../dbClient';
 
+export async function createFile({ data }: { data: Parameters<typeof dbClient.file.create>[0]['data'] }) {
+  const dbFile = await dbClient.file.create({ data });
+  await dbClient.fileCheckpoint.create({
+    data: {
+      fileId: dbFile.id,
+      sequenceNumber: 0,
+      s3Bucket: 'string',
+      s3Key: 'string',
+      version: '1.4',
+    },
+  });
+
+  return dbFile;
+}
+
 export async function createTeam({
   teamArgs,
   userRoles,


### PR DESCRIPTION
When a new user comes in to the system:

- Create them in the User table of the database
- Find any outstanding invites that they have to a team or a file
- Make them members of the team or file
- Delete the old invites

Tested this locally by:

- Deleting my quadratichq.com user from my local database and then from auth0 (staging)
- Use my personal gmail.com to invite my quadartichq.com user to 1 file and 1 team
- Log in to the app using my quadrtichq.com user and see that immediately belong to 1 team and have 1 file in the "Share with me" tab
- Look in my local database and see that the old invites were removed and associations made to the team/file