### PR TITLE
feat: mixpanel events

### DIFF
--- a/quadratic-client/src/api/apiClient.ts
+++ b/quadratic-client/src/api/apiClient.ts
@@ -155,6 +155,7 @@ export const apiClient = {
         );
       },
       async update(uuid: string, body: ApiTypes['/v0/files/:uuid/sharing.PATCH.request']) {
+        mixpanel.track('[FileSharing].publicLinkAccess.update', { value: body.publicLinkAccess });
         return fetchFromApi(
           `/v0/files/${uuid}/sharing`,
           {
@@ -167,6 +168,7 @@ export const apiClient = {
     },
     invites: {
       async create(uuid: string, body: ApiTypes['/v0/files/:uuid/invites.POST.request']) {
+        mixpanel.track('[FileSharing].invite.create');
         return fetchFromApi(
           `/v0/files/${uuid}/invites`,
           {
@@ -177,6 +179,7 @@ export const apiClient = {
         );
       },
       async delete(uuid: string, inviteId: string) {
+        mixpanel.track('[FileSharing].invite.delete');
         return fetchFromApi(
           `/v0/files/${uuid}/invites/${inviteId}`,
           {
@@ -188,6 +191,7 @@ export const apiClient = {
     },
     users: {
       async update(uuid: string, userId: string, body: ApiTypes['/v0/files/:uuid/users/:userId.PATCH.request']) {
+        mixpanel.track('[FileSharing].users.updateRole');
         return fetchFromApi(
           `/v0/files/${uuid}/users/${userId}`,
           { method: 'PATCH', body: JSON.stringify(body) },
@@ -195,6 +199,7 @@ export const apiClient = {
         );
       },
       async delete(uuid: string, userId: string) {
+        mixpanel.track('[FileSharing].users.remove');
         return fetchFromApi(
           `/v0/files/${uuid}/users/${userId}`,
           { method: 'DELETE' },

--- a/quadratic-client/src/components/ShareDialog.tsx
+++ b/quadratic-client/src/components/ShareDialog.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/shadcn/ui/skeleton';
 import { isJsonObject } from '@/utils/isJsonObject';
 import { Avatar } from '@mui/material';
 import { EnvelopeClosedIcon, Link1Icon, LinkBreak1Icon } from '@radix-ui/react-icons';
+import mixpanel from 'mixpanel-browser';
 import {
   ApiTypes,
   PublicLinkAccess,
@@ -572,16 +573,13 @@ function ManageInvite({
   const { email, role, id } = invite;
   const inviteId = String(id);
   const disabled = !Boolean(onDelete);
+  const hasError = deleteFetcher.state === 'idle' && deleteFetcher.data && !deleteFetcher.data.ok;
+  const label = getRoleLabel(role);
 
   // If we're not idle, we're deleting
   if (deleteFetcher.state !== 'idle') {
     return null;
   }
-
-  // If it failed, trigger an error
-  const hasError = deleteFetcher.state === 'idle' && deleteFetcher.data && !deleteFetcher.data.ok;
-
-  const label = getRoleLabel(role);
 
   // TODO: resend email functionality
 
@@ -742,6 +740,7 @@ function ListItemPublicLink({
           <Button
             variant="link"
             onClick={() => {
+              mixpanel.track('[FileSharing].publicLinkAccess.clickCopyLink');
               const url = `${window.location.origin}/files/${uuid}`;
               navigator.clipboard
                 .writeText(url)

--- a/quadratic-client/src/dashboard/components/FilesListItem.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListItem.tsx
@@ -124,7 +124,7 @@ export function FileListItem({
 
   const handleShare = () => {
     setActiveShareMenuFileId(uuid);
-    mixpanel.track('[FileSharing].menu.open', { context: window.location.pathname });
+    mixpanel.track('[FileSharing].menu.open', { context: 'dashboard', pathname: window.location.pathname });
   };
 
   const displayName = fetcherRename.json ? (fetcherRename.json as FileAction['request.rename']).name : name;

--- a/quadratic-client/src/dashboard/components/FilesListItem.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListItem.tsx
@@ -12,6 +12,7 @@ import {
 import { Separator } from '@/shadcn/ui/separator';
 import { cn } from '@/shadcn/utils';
 import { DotsVerticalIcon } from '@radix-ui/react-icons';
+import mixpanel from 'mixpanel-browser';
 import { useEffect, useState } from 'react';
 import { Link, SubmitOptions, useFetcher } from 'react-router-dom';
 import { deleteFile, downloadFileAction, duplicateFileAction, renameFileAction } from '../../actions';
@@ -123,6 +124,7 @@ export function FileListItem({
 
   const handleShare = () => {
     setActiveShareMenuFileId(uuid);
+    mixpanel.track('[FileSharing].menu.open', { context: window.location.pathname });
   };
 
   const displayName = fetcherRename.json ? (fetcherRename.json as FileAction['request.rename']).name : name;

--- a/quadratic-client/src/ui/menus/TopBar/TopBarShareButton.tsx
+++ b/quadratic-client/src/ui/menus/TopBar/TopBarShareButton.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import { useRootRouteLoaderData } from '@/router';
+import mixpanel from 'mixpanel-browser';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
 import { ROUTES } from '../../../constants/routes';
 
@@ -17,6 +18,7 @@ export const TopBarShareButton = () => {
           size="sm"
           onClick={() => {
             setEditorInteractionState((prev) => ({ ...prev, showShareFileMenu: !prev.showShareFileMenu }));
+            mixpanel.track('[FileSharing].menu.open', { context: '/file/:uuid' });
           }}
           className="self-center"
         >

--- a/quadratic-client/src/ui/menus/TopBar/TopBarShareButton.tsx
+++ b/quadratic-client/src/ui/menus/TopBar/TopBarShareButton.tsx
@@ -18,7 +18,7 @@ export const TopBarShareButton = () => {
           size="sm"
           onClick={() => {
             setEditorInteractionState((prev) => ({ ...prev, showShareFileMenu: !prev.showShareFileMenu }));
-            mixpanel.track('[FileSharing].menu.open', { context: '/file/:uuid' });
+            mixpanel.track('[FileSharing].menu.open', { context: 'app' });
           }}
           className="self-center"
         >


### PR DESCRIPTION
Mixpanel events related to file sharing (based on [Slack conversation](https://quadratichq.slack.com/archives/C03VC0Q1MPA/p1704999356266969)).

```sh
# pathname tells us _where_ in the dashboard it was clicked, e.g. my files, shared with me, team file list
# but we don't log it for the app (we don't want the file uuid's)
[FileSharing].menu.open, { context: 'app' | 'dashboard', pathname?: string }

[FileSharing].invite.create
[FileSharing].invite.delete

[FileSharing].user.updateRole
[FileSharing].user.remove

[FileSharing].publicLinkAccess.update, { value: 'NOT_SHARED' | 'EDIT' | 'READONLY' }
[FileSharing].publicLinkAccess.clickCopyLink
```

Notes:

- When updating a role or removing a user, I don't differentiate between this being the user updating/removing themselves or doing it to another user. We _could_ do that, but it'll involve a bit more code. If we care about that differentiation in the analytics, I can do it. Otherwise it's not worth the effort.
- I didn't add any of the `OptimisticUiFail` events because they would have to be run in effects and I don't have a lot of confidence that those would be truly representative of what's happening in prod. More research to do in this area if we want to delve into this tracking this data.


```
# Track how often our optimistic UI updates fail, might be interesting to see how often this happens?
[OptimisticUiFail].invite.remove
[OptimisticUiFail].role.update
[OptimisticUiFail].user.remove
[OptimisticUiFail].publicLinkAccess.update
```