### PR TITLE
fix: email case sensitivity when inviting someone to a file

### DIFF
--- a/quadratic-api/src/routes/v0/files.$uuid.invites.POST.ts
+++ b/quadratic-api/src/routes/v0/files.$uuid.invites.POST.ts
@@ -9,32 +9,28 @@ import { templates } from '../../email/templates';
 import { getFile } from '../../middleware/getFile';
 import { userMiddleware } from '../../middleware/user';
 import { validateAccessToken } from '../../middleware/validateAccessToken';
-import { validateRequestSchema } from '../../middleware/validateRequestSchema';
+import { parseRequest } from '../../middleware/validateRequestSchema';
 import { RequestWithUser } from '../../types/Request';
 import { ApiError } from '../../utils/ApiError';
 const { FILE_EDIT } = FilePermissionSchema.enum;
 
-export default [
-  validateRequestSchema(
-    z.object({
-      params: z.object({
-        uuid: z.string().uuid(),
-      }),
-      body: ApiSchemas['/v0/files/:uuid/invites.POST.request'],
-    })
-  ),
-  validateAccessToken,
-  userMiddleware,
-  handler,
-];
+export default [validateAccessToken, userMiddleware, handler];
+
+const schema = z.object({
+  params: z.object({
+    uuid: z.string().uuid(),
+  }),
+  body: ApiSchemas['/v0/files/:uuid/invites.POST.request'],
+});
 
 async function handler(req: RequestWithUser, res: Response<ApiTypes['/v0/files/:uuid/invites.POST.response']>) {
   const {
-    body,
+    body: { email, role },
     params: { uuid },
+  } = parseRequest(req, schema);
+  const {
     user: { id: userMakingRequestId, auth0Id: userMakingRequestAuth0Id },
   } = req;
-  const { email, role } = body as ApiTypes['/v0/files/:uuid/invites.POST.request'];
   const {
     file: { id: fileId, name: fileName, ownerUserId },
     userMakingRequest: { filePermissions },

--- a/quadratic-client/src/components/ShareDialog.tsx
+++ b/quadratic-client/src/components/ShareDialog.tsx
@@ -388,18 +388,19 @@ export function InviteForm({
 
     // Get the data from the form
     const formData = new FormData(e.currentTarget);
-    const email = String(formData.get('email_search')).trim();
+    const emailFromUser = String(formData.get('email_search')).trim();
     const roleIndex = Number(formData.get('roleIndex'));
 
     // Validate email
-    if (disallowedEmails.includes(email)) {
-      setError('This email has already been invited.');
-      return;
-    }
+    let email;
     try {
-      emailSchema.parse(email);
+      email = emailSchema.parse(emailFromUser);
     } catch (e) {
       setError('Invalid email.');
+      return;
+    }
+    if (disallowedEmails.includes(email)) {
+      setError('This email has already been invited.');
       return;
     }
 

--- a/quadratic-shared/typesAndSchemas.ts
+++ b/quadratic-shared/typesAndSchemas.ts
@@ -27,7 +27,10 @@ export type TeamPermission = z.infer<typeof TeamPermissionSchema>;
 // =============================================================================
 // TODO share these with the API
 
-export const emailSchema = z.string().email();
+export const emailSchema = z
+  .string()
+  .email()
+  .transform((v) => v.toLowerCase());
 
 const BaseUserSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
When somebody invites someone else by email, e.g. `Jim.nielsen@quadratichq.com`, we lookup that email via auth0 and it does a case-insensitive search for the email. 

That means if I already have an account in auth0 with the email `jim.nielsen@quadratichq.com`, a match will be sent back from Auth0 and we will associate that user with the file on our side (email case sensitivity doesn't matter here, as we don't store the email).

However, if no match is found, that email will be stored as an invite in our database _just the way it was typed_. Then an email will be sent to `Jim.nielsen@qudartichq.com` and, because (most) emails are case-insensitive, it will be received.

If that person then comes to Quadratic and creates an account (whether through manual credentials or Google), Auth0 is going to tell us that their email is (the case insensitive) `jim.nielsen@quadratichq.com`. We cross reference that email for any invites in our database. Because we stored the invite as `Jim.nielsen@quadratichq.com` our system won't know to associate the new user with that existing invitation.

**What this means**

This should not be a problem for existing users because auth0 doesn't respect casing in emails.

However, for new users of Quadratic, they will likely receive the email but then not see the file when they login (because we don't know to associate their case-insensitive file from auth0 with the case-sensitive invite in our database).

**How to fix this**

I added a transform rule to the zod schema so all emails are case-insensitive. This way, all invitations will be stored in the database as the case-insensitive version of themselves.

**UI Implications**

When the user types in an email and hits "Invite", we strip whitespace and turn whatever the user typed into a case-insensitive version of that email.

<img src=https://github.com/quadratichq/quadratic/assets/1316441/29e6a89c-92d4-40e5-97bb-23fe7b4217a1 width="600" />

This might seem a little strange, because it's not precisely what you typed. However, since we are enforcing all emails as lowercase, this approach seemed better than transforming the users characters as they typed (e.g. you type `R` and the input fills in with a `r`) or simply disallowing uppercase characters (you type `R` and nothing happens with the input).


**Notes**

- [Auth0 emails are case insensitive](https://community.auth0.com/t/api-v2-handle-email-local-part-as-case-insensitive/91649/4) for manual credentials. For social providers, it gets the email from the provider and so case sensitivity depends on the provider. In our case, Google is case insensitive.
- If we ever switch from auth0 or add a new social connection, we will have to verify that case-insensitive emails are still what we want. Otherwise this could become a problem again.
- Any outstanding invites that have been created _for people who don’t yet have accounts_ will be forever lost. The only way to recover from this would be to create a migration script — probably not a big deal since we've only been live for a day or so at this point.
- An alternative to the above approach would be to accept and store all emails however the user typed them, then use [prisma's case insensitivity filtering](https://www.prisma.io/docs/orm/prisma-client/queries/case-sensitivity#postgresql-provider) to lookup users. However, it seemed better to be explicit about how we treat emails rather than magical.