### PR TITLE
fix: log extra data to sentry when no auth0 profile is found

### DIFF
--- a/quadratic-api/src/auth0/profile.ts
+++ b/quadratic-api/src/auth0/profile.ts
@@ -63,7 +63,8 @@ export const getUsersFromAuth0 = async (users: { id: number; auth0Id: string }[]
         message: 'Auth0 user returned without `email`',
         level: 'error',
         extra: {
-          auth0User,
+          auth0IdInOurDb: auth0Id,
+          auth0UserResult: auth0User,
         },
       });
       throw new Error('Failed to retrieve all user info from Auth0');


### PR DESCRIPTION
A sentry error got triggered but we can't see any information in Sentry about who triggered it.

![image](https://github.com/quadratichq/quadratic/assets/1316441/981c918d-164f-4c7e-8880-ab6acf263d8f)

I believe this is because the entire `auth0User` was undefined and so it got serialized as JSON to `{}`

So now we explicitly pass in the auth0Id that it was trying to get, so we'll know who triggered this. e.g. in the future this would log something like:

```
extra: {
    auth0IdInOurDb: "google-oauth2|000...",
    // `auth0UserResult` would be `undefined`,
}
```