### PR TITLE
bug: Fix File updatedDate

### DIFF
--- a/quadratic-api/src/routes/v0/files.$uuid.thumbnail.POST.ts
+++ b/quadratic-api/src/routes/v0/files.$uuid.thumbnail.POST.ts
@@ -46,6 +46,7 @@ async function handler(req: RequestWithUser & RequestWithFile, res: Response) {
     },
     data: {
       thumbnail: req.file?.key,
+      updatedDate: new Date(),
     },
   });
 

--- a/quadratic-api/src/routes/v0/files.GET.ts
+++ b/quadratic-api/src/routes/v0/files.GET.ts
@@ -27,15 +27,6 @@ async function handler(req: RequestWithUser, res: Response<ApiTypes['/v0/files.G
       createdDate: true,
       updatedDate: true,
       publicLinkAccess: true,
-      FileCheckpoint: {
-        take: 1,
-        orderBy: {
-          timestamp: 'desc',
-        },
-        select: {
-          timestamp: true,
-        },
-      },
     },
     orderBy: [
       {
@@ -56,7 +47,7 @@ async function handler(req: RequestWithUser, res: Response<ApiTypes['/v0/files.G
   const data: ApiTypes['/v0/files.GET.response'] = dbFiles.map((file) => ({
     ...file,
     createdDate: file.createdDate.toISOString(),
-    updatedDate: file.FileCheckpoint[0].timestamp.toISOString() || file.updatedDate.toISOString(),
+    updatedDate: file.updatedDate.toISOString(),
   }));
   return res.status(200).json(data);
 }

--- a/quadratic-api/src/routes/v0/files.GET.ts
+++ b/quadratic-api/src/routes/v0/files.GET.ts
@@ -27,6 +27,15 @@ async function handler(req: RequestWithUser, res: Response<ApiTypes['/v0/files.G
       createdDate: true,
       updatedDate: true,
       publicLinkAccess: true,
+      FileCheckpoint: {
+        take: 1,
+        orderBy: {
+          timestamp: 'desc',
+        },
+        select: {
+          timestamp: true,
+        },
+      },
     },
     orderBy: [
       {
@@ -47,7 +56,7 @@ async function handler(req: RequestWithUser, res: Response<ApiTypes['/v0/files.G
   const data: ApiTypes['/v0/files.GET.response'] = dbFiles.map((file) => ({
     ...file,
     createdDate: file.createdDate.toISOString(),
-    updatedDate: file.updatedDate.toISOString(),
+    updatedDate: file.FileCheckpoint[0].timestamp.toISOString() || file.updatedDate.toISOString(),
   }));
   return res.status(200).json(data);
 }


### PR DESCRIPTION
Files used to be ordered by last modified by default.

This adds `updatedDate: new Date(),` to the thumbnail endpoint.