### PR TITLE
Fixes a bug with Sheet Not Found in Python

### DIFF
--- a/quadratic-client/src/web-workers/pythonWebWorker/python.ts
+++ b/quadratic-client/src/web-workers/pythonWebWorker/python.ts
@@ -97,16 +97,15 @@ class PythonWebWorker {
         if (!range) {
           throw new Error('Expected range to be defined in get-cells');
         }
-        const cells = grid.calculationGetCells(
-          transactionId,
-          pointsToRect(range.x0, range.y0, range.x1 - range.x0, range.y1 - range.y0),
-          range.sheet !== undefined ? range.sheet.toString() : undefined,
-          event.range?.lineNumber
-        );
-        // cells will be undefined if there was a problem getting the cells. In this case, the python execution is done.
-        if (cells) {
+        try {
+          const cells = grid.calculationGetCells(
+            transactionId,
+            pointsToRect(range.x0, range.y0, range.x1 - range.x0, range.y1 - range.y0),
+            range.sheet !== undefined ? range.sheet.toString() : undefined,
+            event.range?.lineNumber
+          );
           this.worker!.postMessage({ type: 'get-cells', cells });
-        } else {
+        } catch (e) {
           this.calculationComplete();
         }
       } else if (event.type === 'python-loaded') {

--- a/quadratic-client/src/web-workers/pythonWebWorker/python.ts
+++ b/quadratic-client/src/web-workers/pythonWebWorker/python.ts
@@ -1,5 +1,6 @@
 import { SheetPos } from '@/gridGL/types/size';
 import { multiplayer } from '@/multiplayer/multiplayer';
+import { TransactionSummary } from '@/quadratic-core/types';
 import mixpanel from 'mixpanel-browser';
 import { grid, pointsToRect } from '../../grid/controller/Grid';
 import { JsCodeResult } from '../../quadratic-core/quadratic_core';
@@ -107,6 +108,7 @@ class PythonWebWorker {
           this.worker!.postMessage({ type: 'get-cells', cells });
         } catch (e) {
           this.calculationComplete();
+          grid.transactionResponse(e as TransactionSummary);
         }
       } else if (event.type === 'python-loaded') {
         window.dispatchEvent(new CustomEvent('python-loaded'));


### PR DESCRIPTION
In main, if you try to get a value from a different sheet, it throws an error. This fixes this so the code's console properly shows the error instead of throwing an exception.

To replicate run this:

```
cell(1, 2, "no sheet")
```
in Python in both main and this branch.