### PR TITLE
feat: move files

### DIFF
--- a/quadratic-client/src/constants/routes.ts
+++ b/quadratic-client/src/constants/routes.ts
@@ -27,4 +27,5 @@ export const ROUTE_LOADER_IDS = {
   ROOT: 'root',
   FILE: 'file',
   TEAM: 'team',
+  DASHBOARD: 'dashboard',
 };

--- a/quadratic-client/src/router.tsx
+++ b/quadratic-client/src/router.tsx
@@ -90,7 +90,7 @@ export const router = createBrowserRouter(
             shouldRevalidate={() => false}
           />
 
-          <Route lazy={() => import('./routes/_dashboard')}>
+          <Route id={ROUTE_LOADER_IDS.DASHBOARD} lazy={() => import('./routes/_dashboard')}>
             <Route path={ROUTES.FILES}>
               <Route index lazy={() => import('./routes/files')} />
 

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -34,9 +34,10 @@ import {
   useNavigation,
   useParams,
   useRevalidator,
+  useRouteLoaderData,
   useSubmit,
 } from 'react-router-dom';
-import { ROUTES } from '../constants/routes';
+import { ROUTES, ROUTE_LOADER_IDS } from '../constants/routes';
 import QuadraticLogo from '../dashboard/components/quadratic-logo.svg';
 import QuadraticLogotype from '../dashboard/components/quadratic-logotype.svg';
 import { useRootRouteLoaderData } from '../router';
@@ -53,7 +54,9 @@ const DashboardContext = createContext([initialDashboardState, () => {}] as [
 ]);
 export const useDashboardContext = () => useContext(DashboardContext);
 
-export const loader = async (): Promise<ApiTypes['/v0/teams.GET.response']> => {
+type LoaderData = ApiTypes['/v0/teams.GET.response'];
+export const useDashboardRouteLoaderData = () => useRouteLoaderData(ROUTE_LOADER_IDS.DASHBOARD) as LoaderData;
+export const loader = async (): Promise<LoaderData> => {
   const data = await apiClient.teams.list();
   return data;
 };
@@ -212,9 +215,10 @@ function Navbar({ isLoading }: { isLoading: boolean }) {
                 key={uuid}
                 to={ROUTES.TEAM(uuid)}
                 dropTarget={teamPermissions.includes('TEAM_EDIT') ? { type: 'team', id: ownerTeamId } : undefined}
+                className="truncate"
               >
                 <AvatarTeam className={`-my-0.5 h-6 w-6`} />
-                {name}
+                <span className="block truncate">{name}</span>
               </SidebarNavLink>
             );
           })}


### PR DESCRIPTION
Adds an option to move a file in the file context menu.

It will only ever show, at max, 2 teams in the menu.

If you're on a team, it will show the option to move to "my files" as well as (up to 2) other teams

![CleanShot 2024-02-23 at 21 50 53@2x](https://github.com/quadratichq/quadratic/assets/1316441/1c2ed280-5bd1-48fa-a5a2-11f5f6e18a93)

If you're in your personal files, it will show (up to 2) teams

![CleanShot 2024-02-23 at 21 50 12@2x](https://github.com/quadratichq/quadratic/assets/1316441/7d773e65-5de8-4cce-9df4-4089088d3d47)

You have to have edit access to the team to be able to see the option to move it.