### PR TITLE
Remove `realpath` flag that doesn't support OSX

### DIFF
--- a/quadratic-kernels/python-wasm/package.sh
+++ b/quadratic-kernels/python-wasm/package.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
-SCRIPT_DIR="$(realpath -e -- "$SCRIPT_DIR")"
+SCRIPT_DIR="$(realpath "$SCRIPT_DIR")"
 
 use_poetry=true
 

--- a/quadratic-kernels/python-wasm/setup-poetry.sh
+++ b/quadratic-kernels/python-wasm/setup-poetry.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
-SCRIPT_DIR="$(realpath -e -- "$SCRIPT_DIR")"
+SCRIPT_DIR="$(realpath "$SCRIPT_DIR")"
 
 if [[ ! -x $(command -v poetry) ]]; then
     echo "Poetry could not be found. Installing..."


### PR DESCRIPTION
The flag only verifies that the file in the path exists; without it, the command verifies all directories exist, but it ignores the last file. In this scenario, since we're getting the file from `BASH_SOURCE`, the behavior should still be sufficient.