### PR TITLE
fix AI tab when output has a chart

### DIFF
--- a/quadratic-client/src/ui/menus/CodeEditor/AITab.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/AITab.tsx
@@ -18,7 +18,7 @@ import { QuadraticDocs } from './QuadraticDocs';
 
 interface Props {
   editorMode: EditorInteractionState['mode'];
-  evalResult: any | undefined; // CodeCellRunOutput
+  evalResult: string | null | undefined; // CodeCellRunOutput
   editorContent: string | undefined;
   isActive: boolean;
 }
@@ -29,6 +29,9 @@ type Message = {
 };
 
 export const AITab = ({ evalResult, editorMode, editorContent, isActive }: Props) => {
+  const evalResultObj = JSON.parse(evalResult || '{}');
+  const stdErr = evalResultObj?.std_err;
+
   // TODO: Improve these messages. Pass current location and more docs.
   // store in a separate location for different cells
   const systemMessages = [
@@ -48,7 +51,7 @@ export const AITab = ({ evalResult, editorMode, editorContent, isActive }: Props
     },
     {
       role: 'system',
-      content: 'If the code was recently run here was the result:' + JSON.stringify(evalResult),
+      content: 'If the code was recently run here is the std error:' + stdErr,
     },
   ] as Message[];
 

--- a/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/CodeEditor.tsx
@@ -27,7 +27,7 @@ export const CodeEditor = () => {
 
   // code info
   const [out, setOut] = useState<{ stdOut?: string; stdErr?: string } | undefined>(undefined);
-  const [evaluationResult, setEvaluationResult] = useState<any>(undefined);
+  const [evaluationResult, setEvaluationResult] = useState<string | null>(null);
   const [spillError, setSpillError] = useState<Coordinate[] | undefined>();
 
   const [editorWidth, setEditorWidth] = useState<number>(

--- a/quadratic-client/src/ui/menus/CodeEditor/Console.tsx
+++ b/quadratic-client/src/ui/menus/CodeEditor/Console.tsx
@@ -15,7 +15,7 @@ interface ConsoleProps {
   consoleOutput?: { stdOut?: string; stdErr?: string };
   editorMode: EditorInteractionState['mode'];
   editorContent: string | undefined;
-  evaluationResult?: any;
+  evaluationResult?: string | null | undefined;
   spillError?: Coordinate[];
 }
 


### PR DESCRIPTION
AI doesn't work in prod on any cell with a chart output. This is because the ~ 3mb that each chart takes up (wow!) is sent as context to the AI API.

I changed it to simply send the std error, this fixes the issue.