### PR TITLE
fix: incognito mode gets edit access

### DIFF
--- a/quadratic-api/src/middleware/getFile.ts
+++ b/quadratic-api/src/middleware/getFile.ts
@@ -58,19 +58,21 @@ export async function getFile<T extends number | undefined>({ uuid, userId }: { 
   const fileRole =
     file.UserFileRole[0] && file.UserFileRole[0].userId === userId ? file.UserFileRole[0].role : undefined;
 
-  // Determine the user's relationship to the file
   //
   // TODO: probably want to use this as part of the `userMakingRequest` object
   // as it encompasses all _expected_ possibilities of the user's relationship
   // with the file (whereas, for example, `isFileOwner` being true and `teamRole`
   // having a value at the same time is considered an invalid combo in the codebase).
   let userFileRelationship: Parameters<typeof getFilePermissions>[0]['userFileRelationship'] = undefined;
-  if (isFileOwner) {
-    userFileRelationship = { owner: 'me' };
-  } else if (file.ownerUserId) {
-    userFileRelationship = { owner: 'another-user', fileRole };
-  } else if (file.ownerTeamId) {
-    userFileRelationship = { owner: 'team', teamRole, fileRole };
+  // Only define the relationship if they're logged in
+  if (userId !== undefined) {
+    if (isFileOwner) {
+      userFileRelationship = { owner: 'me' };
+    } else if (file.ownerUserId) {
+      userFileRelationship = { owner: 'another-user', fileRole };
+    } else if (file.ownerTeamId) {
+      userFileRelationship = { owner: 'team', teamRole, fileRole };
+    }
   }
 
   const filePermissions = getFilePermissions({

--- a/quadratic-api/src/middleware/getFile.ts
+++ b/quadratic-api/src/middleware/getFile.ts
@@ -58,6 +58,7 @@ export async function getFile<T extends number | undefined>({ uuid, userId }: { 
   const fileRole =
     file.UserFileRole[0] && file.UserFileRole[0].userId === userId ? file.UserFileRole[0].role : undefined;
 
+  // Determine the user's relationship to the file
   //
   // TODO: probably want to use this as part of the `userMakingRequest` object
   // as it encompasses all _expected_ possibilities of the user's relationship

--- a/quadratic-api/src/utils/permissions.ts
+++ b/quadratic-api/src/utils/permissions.ts
@@ -45,10 +45,15 @@ export const getFilePermissions = ({
   userFileRelationship,
 }: {
   publicLinkAccess: PublicLinkAccess;
+  // prettier-ignore
   userFileRelationship:
+    // Not logged in
     | undefined
+    // Logged in + i'm the owner
     | { owner: 'me' }
+    // Logged in + another user owns the file but it's shared with me
     | { owner: 'another-user'; fileRole?: UserFileRole }
+    // Logged in + a team owns the file
     | { owner: 'team'; teamRole?: UserTeamRole; fileRole?: UserFileRole };
 }) => {
   const permissions = new Set<FilePermission>();


### PR DESCRIPTION
To reproduce:

- Create a file
- Turn on the public link to "Edit"
- Open the shared link in incognito mode

See that the user, who is not logged in, is receiving a `FILE_EDIT` permission.

![CleanShot 2024-03-04 at 09 29 05@2x](https://github.com/quadratichq/quadratic/assets/1316441/1ef02ccb-4172-420e-892c-73fef2f59c5e)

This fixes the issue so a user who is not logged in will never get a `FILE_EDIT` permission.

![CleanShot 2024-03-04 at 09 29 37@2x](https://github.com/quadratichq/quadratic/assets/1316441/f682bf99-eee6-4776-92a1-57d8a583142e)
