### PR TITLE
bug: Thumbnails on Dashboard

### DIFF
--- a/quadratic-api/src/aws/s3.ts
+++ b/quadratic-api/src/aws/s3.ts
@@ -49,5 +49,5 @@ export const generatePresignedUrl = async (key: string) => {
     Key: key,
   });
 
-  return await getSignedUrl(s3Client, command, { expiresIn: 60 * 2 }); // 2 minutes
+  return await getSignedUrl(s3Client, command, { expiresIn: 60 * 60 * 24 * 7 }); // 7 days
 };


### PR DESCRIPTION
If you load the dashboard and scroll down to all your files after 2 minutes, the images won't load. This is because the browser lazy loads them and the URLs are only valid for 2 minutes. 

This ups that to 7 days.