### PR TITLE
🚢 Refactor run_python to make it more testable

### DIFF
--- a/quadratic-kernels/python-wasm/quadratic_py/process_output.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/process_output.py
@@ -1,0 +1,95 @@
+import pandas as pd
+
+from .utils import to_quadratic_type
+
+
+def process_output_value(output_value):
+    # return array_output if output is an array
+    array_output = None
+    output_type = type(output_value).__name__
+    output_size = None
+
+    # TODO(ddimaria): figure out if we need to covert back to a list for array_output
+    # We should have a single output
+    if isinstance(output_value, list):
+        if len(output_value) > 0:
+            array_output = output_value
+            if (isinstance(output_value[0], list)):
+                output_size = (len(output_value[0]), len(output_value))
+            else:
+                output_size = (1, len(output_value))
+        else:
+            output_value = ''
+
+    if isinstance(output_value, pd.Series):
+        output_size = (1, len(output_value))
+
+    # Convert DF to array_output
+    if isinstance(output_value, pd.DataFrame):
+        # flip the dataframe shape
+        shape = output_value.shape
+        output_size = (shape[1], shape[0])
+        
+        # If output_value columns is not the default (RangeIndex)
+        if type(output_value.columns) != pd.core.indexes.range.RangeIndex:
+            # Return Column names and values
+            array_output = [
+                output_value.columns.tolist()
+            ] + output_value.values.tolist()
+
+        else:
+            # convert nan to None, return PD values list
+            array_output = output_value.where(
+                output_value.notnull(), None
+            ).values.tolist()
+
+    try:
+        import plotly
+        if isinstance(output_value, plotly.graph_objs._figure.Figure):
+            output_value = output_value.to_html()
+            output_type = "Chart"
+    except:
+        pass
+
+    # Convert Pandas.Series to array_output
+    if isinstance(output_value, pd.Series):
+        array_output = output_value.to_numpy().tolist()
+
+
+    typed_array_output = None
+
+    if array_output is not None:
+        typed_array_output = []
+        is_2d_array = isinstance(array_output[0], list)
+
+        # insure that all rows are the same length
+        if not is_2d_array:
+            typed_array_output = list(map(to_quadratic_type, array_output))
+        else:
+            length_1d = len(array_output)
+            length_2d = max(len(row) for row in array_output)
+            
+            # TODO(ddimaria): is this efficient?
+            typed_array_output = [[0 for i in range(length_2d)] for j in range(length_1d)]
+
+            for row in range(0, length_1d):
+                col_length_2d = len(array_output[row])
+                for col in range(0, length_2d):
+                    if col > col_length_2d - 1:
+                        typed_array_output[row][col] = ("", "blank")
+                    else:
+                        typed_array_output[row][col] = to_quadratic_type(array_output[row][col])
+
+    # removes output_value if there's an array or None
+    if array_output is not None or output_value is None:
+        output_value = None
+    else:
+        output_value = to_quadratic_type(output_value)
+
+    return {
+        "typed_array_output": typed_array_output,
+        "array_output": array_output,
+        "output_value": output_value,
+        "output_type": output_type,
+        "output_size": output_size,
+    }

--- a/quadratic-kernels/python-wasm/quadratic_py/run_python.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/run_python.py
@@ -1,15 +1,14 @@
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from typing import Tuple
 
-from .quadratic_api.quadratic import getCell, getCells
-from .utils import attempt_fix_await, to_quadratic_type
 import micropip
 import pandas as pd
 import pyodide
+from quadratic_py import code_trace, plotly_patch, process_output
 
-from quadratic_py import code_trace, plotly_patch
-
+from .quadratic_api.quadratic import getCell, getCells
+from .utils import attempt_fix_await, to_quadratic_type
 
 cells_accessed = []
 
@@ -88,54 +87,6 @@ async def run_python(code: str):
         )  # fixes a timing bug where autopep8 is not yet installed when attempting to import
         import autopep8
 
-        # return array_output if output is an array
-        array_output = None
-        output_type = type(output_value).__name__
-        output_size = None
-
-        # TODO(ddimaria): figure out if we need to covert back to a list for array_output
-        # We should have a single output
-        if isinstance(output_value, list):
-            if len(output_value) > 0:
-                array_output = output_value
-                output_size = (1, len(output_value))
-            else:
-                output_value = ''
-
-        if isinstance(output_value, pd.Series):
-            output_size = (1, len(output_value))
-
-        # Convert DF to array_output
-        if isinstance(output_value, pd.DataFrame):
-            # flip the dataframe shape
-            shape = output_value.shape
-            output_size = (shape[1], shape[0])
-            
-            # If output_value columns is not the default (RangeIndex)
-            if type(output_value.columns) != pd.core.indexes.range.RangeIndex:
-                # Return Column names and values
-                array_output = [
-                    output_value.columns.tolist()
-                ] + output_value.values.tolist()
-
-            else:
-                # convert nan to None, return PD values list
-                array_output = output_value.where(
-                    output_value.notnull(), None
-                ).values.tolist()
-
-        try:
-            import plotly
-            if isinstance(output_value, plotly.graph_objs._figure.Figure):
-                output_value = output_value.to_html()
-                output_type = "Chart"
-        except:
-            pass
-
-        # Convert Pandas.Series to array_output
-        if isinstance(output_value, pd.Series):
-            array_output = output_value.to_numpy().tolist()
-
         # Attempt to format code
         formatted_code = code
         try:
@@ -145,6 +96,15 @@ async def run_python(code: str):
         except Exception:
             pass
 
+        # Process the output
+        output = process_output.process_output_value(output_value)
+        array_output = output["array_output"]
+        output_value = output["output_value"]
+        output_type = output["output_type"]
+        output_size = output["output_size"]
+        typed_array_output = output["typed_array_output"]
+
+        # Plotly HTML
         if plotly_html is not None and plotly_html.result is not None:
             if output_value is not None or array_output is not None:
                 err = RuntimeError(
@@ -159,36 +119,6 @@ async def run_python(code: str):
                 output_value = plotly_html.result
                 output_type = "Chart"
 
-        typed_array_output = None
-
-        if array_output is not None:
-            typed_array_output = []
-            is_2d_array = isinstance(array_output[0], list)
-
-            # insure that all rows are the same length
-            if not is_2d_array:
-                typed_array_output = list(map(to_quadratic_type, array_output))
-            else:
-                length_1d = len(array_output)
-                length_2d = max(len(row) for row in array_output)
-                
-                # TODO(ddimaria): is this efficient?
-                typed_array_output = [[0 for i in range(length_2d)] for j in range(length_1d)]
-
-                for row in range(0, length_1d):
-                    col_length_2d = len(array_output[row])
-                    for col in range(0, length_2d):
-                        if col > col_length_2d - 1:
-                            typed_array_output[row][col] = ("", "blank")
-                        else:
-                            typed_array_output[row][col] = to_quadratic_type(array_output[row][col])
-
-
-        # removes output_value if there's an array or None
-        if array_output is not None or output_value is None:
-            output_value = None
-        else:
-            output_value = to_quadratic_type(output_value)
 
         return {
             "output": output_value,

--- a/quadratic-kernels/python-wasm/tests/process_output_test.py
+++ b/quadratic-kernels/python-wasm/tests/process_output_test.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+from unittest import TestCase
+
+import pandas as pd
+from quadratic_py.process_output import process_output_value
+
+
+def assert_pov(self, input, typed_array_output, array_output, output_size, output_value, output_type):
+    result = process_output_value(input)
+    self.assertEqual(result['typed_array_output'], typed_array_output)
+    self.assertEqual(result['array_output'], array_output)
+    self.assertEqual(result['output_size'], output_size)
+    self.assertEqual(result['output_value'], output_value)
+    self.assertEqual(result['output_type'], output_type)
+
+class TestProcessOutput(TestCase):
+    def test_value(self):
+    
+        assert_pov(self, 1, None, None, None, ('1', 'number'), 'int')
+        assert_pov(self, 1.1, None, None, None, ('1.1', 'number'), 'float')
+        assert_pov(self, -1, None, None, None, ('-1', 'number'), 'int')
+        assert_pov(self, "1", None, None, None, ('1', 'number'), 'str')
+        assert_pov(self, "hello", None, None, None, ('hello', 'text'), 'str')
+        assert_pov(self, True, None, None, None, ('True', 'logical'), 'bool')
+        assert_pov(self, False, None, None, None, ('False', 'logical'), 'bool')
+        assert_pov(self, "True", None, None, None, ('True', 'logical'), 'str')
+        assert_pov(self, "False", None, None, None, ('False', 'logical'), 'str')
+        assert_pov(self, "true", None, None, None, ('True', 'logical'), 'str')
+        assert_pov(self, "false", None, None, None, ('False', 'logical'), 'str')
+        assert_pov(self, "abc", None, None, None, ('abc', 'text'), 'str')
+        assert_pov(self, "123abc", None, None, None, ('123abc', 'text'), 'str')
+        assert_pov(self, "abc123", None, None, None, ('abc123', 'text'), 'str')
+        assert_pov(self, None, None, None, None, None, 'NoneType')
+        assert_pov(self, "", None, None, None, ('', 'blank'), 'str')
+        assert_pov(self, " ", None, None, None, (' ', 'text'), 'str')
+        assert_pov(self, datetime(2021, 1, 1), None, None, None, ('1609459200', 'instant'), 'datetime')
+        assert_pov(self, datetime(2021, 1, 1, 0, 0, 0), None, None, None, ('1609459200', 'instant'), 'datetime')
+        assert_pov(self, datetime(2021, 1, 1, 0, 0, 0, 0), None, None, None, ('1609459200', 'instant'), 'datetime')
+        assert_pov(self, datetime(2021, 1, 1, 0, 0, 0, 0, None), None, None, None, ('1609459200', 'instant'), 'datetime')
+
+
+    def test_list(self):
+        assert_pov(self, [1, 2, 3], [('1', 'number'), ('2', 'number'), ('3', 'number')], [1, 2, 3], (1, 3), None, 'list')
+        assert_pov(self, [1.1, 2.2, 3.3], [('1.1', 'number'), ('2.2', 'number'), ('3.3', 'number')], [1.1, 2.2, 3.3], (1, 3), None, 'list')
+        assert_pov(self, [-1, -2, -3], [('-1', 'number'), ('-2', 'number'), ('-3', 'number')], [-1, -2, -3], (1, 3), None, 'list')
+        assert_pov(self, ["1", "2", "3"], [('1', 'number'), ('2', 'number'), ('3', 'number')], ["1", "2", "3"], (1, 3), None, 'list')
+        assert_pov(self, ["hello", "world"], [('hello', 'text'), ('world', 'text')], ["hello", "world"], (1, 2), None, 'list')
+        assert_pov(self, [True, False], [('True', 'logical'), ('False', 'logical')], [True, False], (1, 2), None, 'list')
+        assert_pov(self, [None, None], [('', 'blank'), ('', 'blank')], [None, None], (1, 2), None, 'list')
+        assert_pov(self, ["", " "], [('', 'blank'), (' ', 'text')], ["", " "], (1, 2), None, 'list')
+        assert_pov(self, [datetime(2021, 1, 1), datetime(2021, 1, 2)], [('1609459200', 'instant'), ('1609545600', 'instant')], [datetime(2021, 1, 1), datetime(2021, 1, 2)], (1, 2), None, 'list')
+
+    def test_2d_list(self):
+        assert_pov(self, [[1,2,3]], [[('1', 'number'), ('2', 'number'), ('3', 'number')]], [[1,2,3]], (3, 1), None, 'list')
+        assert_pov(self, [[1, 2, 3], [4, 5, 6]], [[('1', 'number'), ('2', 'number'), ('3', 'number')], [('4', 'number'), ('5', 'number'), ('6', 'number')]], [[1, 2, 3], [4, 5, 6]], (3, 2), None, 'list')
+        assert_pov(self, [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]], [[('1.1', 'number'), ('2.2', 'number'), ('3.3', 'number')], [('4.4', 'number'), ('5.5', 'number'), ('6.6', 'number')]], [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]], (3, 2), None, 'list')
+        assert_pov(self, [[-1, -2, -3], [-4, -5, -6]], [[('-1', 'number'), ('-2', 'number'), ('-3', 'number')], [('-4', 'number'), ('-5', 'number'), ('-6', 'number')]], [[-1, -2, -3], [-4, -5, -6]], (3, 2), None, 'list')
+        assert_pov(self, [["1", "2", "3"], ["4", "5", "6"]], [[('1', 'number'), ('2', 'number'), ('3', 'number')], [('4', 'number'), ('5', 'number'), ('6', 'number')]], [["1", "2", "3"], ["4", "5", "6"]], (3, 2), None, 'list')
+        assert_pov(self, [["hello", "world"], ["hello", "world"]], [[('hello', 'text'), ('world', 'text')], [('hello', 'text'), ('world', 'text')]], [["hello", "world"], ["hello", "world"]], (2, 2), None, 'list')
+        assert_pov(self, [[True, False], [True, False]], [[('True', 'logical'), ('False', 'logical')], [('True', 'logical'), ('False', 'logical')]], [[True, False], [True, False]], (2, 2), None, 'list')
+        assert_pov(self, [[None, None], [None, None]], [[('', 'blank'), ('', 'blank')], [('', 'blank'), ('', 'blank')]], [[None, None], [None, None]], (2, 2), None, 'list')
+        assert_pov(self, [["", " "], ["", " "]], [[('', 'blank'), (' ', 'text')], [('', 'blank'), (' ', 'text')]], [["", " "], ["", " "]], (2, 2), None, 'list')
+        assert_pov(self, [[datetime(2021, 1, 1), datetime(2021, 1, 2)], [datetime(2021, 1, 3), datetime(2021, 1, 4)]], [[('1609459200', 'instant'), ('1609545600', 'instant')], [('1609632000', 'instant'), ('1609718400', 'instant')]], [[datetime(2021, 1, 1), datetime(2021, 1, 2)], [datetime(2021, 1, 3), datetime(2021, 1, 4)]], (2, 2), None, 'list')
+
+
+    def test_pandas(self):
+        
+        assert_pov(self, pd.Series([1, 2, 3]), [('1', 'number'), ('2', 'number'), ('3', 'number')], [1, 2, 3], (1, 3), None, 'Series')
+        assert_pov(self, pd.Series([1.1, 2.2, 3.3]), [('1.1', 'number'), ('2.2', 'number'), ('3.3', 'number')], [1.1, 2.2, 3.3], (1, 3), None, 'Series')
+        assert_pov(self, pd.Series([-1, -2, -3]), [('-1', 'number'), ('-2', 'number'), ('-3', 'number')], [-1, -2, -3], (1, 3), None, 'Series')
+        assert_pov(self, pd.Series(["1", "2", "3"]), [('1', 'number'), ('2', 'number'), ('3', 'number')], ["1", "2", "3"], (1, 3), None, 'Series')
+        assert_pov(self, pd.Series(["hello", "world"]), [('hello', 'text'), ('world', 'text')], ["hello", "world"], (1, 2), None, 'Series')
+        assert_pov(self, pd.Series([True, False]), [('True', 'logical'), ('False', 'logical')], [True, False], (1, 2), None, 'Series')
+        assert_pov(self, pd.Series([None, None]), [('', 'blank'), ('', 'blank')], [None, None], (1, 2), None, 'Series')
+        assert_pov(self, pd.Series(["", " "]), [('', 'blank'), (' ', 'text')], ["", " "], (1, 2), None, 'Series')
+        # assert_pov(self, pd.Series([datetime(2021, 1, 1), datetime(2021, 1, 2)]), [('1609459200', 'instant'), ('1609545600', 'instant')], [datetime(2021, 1, 1), datetime(2021, 1, 2)], (1, 2), None, 'Series')
+
+        # test 2d
+        assert_pov(self, pd.DataFrame([[1, 2, 3], [4, 5, 6]]), [[('1', 'number'), ('2', 'number'), ('3', 'number')], [('4', 'number'), ('5', 'number'), ('6', 'number')]], [[1, 2, 3], [4, 5, 6]], (3, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]), [[('1.1', 'number'), ('2.2', 'number'), ('3.3', 'number')], [('4.4', 'number'), ('5.5', 'number'), ('6.6', 'number')]], [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]], (3, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([[-1, -2, -3], [-4, -5, -6]]), [[('-1', 'number'), ('-2', 'number'), ('-3', 'number')], [('-4', 'number'), ('-5', 'number'), ('-6', 'number')]], [[-1, -2, -3], [-4, -5, -6]], (3, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([["1", "2", "3"], ["4", "5", "6"]]), [[('1', 'number'), ('2', 'number'), ('3', 'number')], [('4', 'number'), ('5', 'number'), ('6', 'number')]], [["1", "2", "3"], ["4", "5", "6"]], (3, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([["hello", "world"], ["hello", "world"]]), [[('hello', 'text'), ('world', 'text')], [('hello', 'text'), ('world', 'text')]], [["hello", "world"], ["hello", "world"]], (2, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([[True, False], [True, False]]), [[('True', 'logical'), ('False', 'logical')], [('True', 'logical'), ('False', 'logical')]], [[True, False], [True, False]], (2, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([[None, None], [None, None]]), [[('', 'blank'), ('', 'blank')], [('', 'blank'), ('', 'blank')]], [[None, None], [None, None]], (2, 2), None, 'DataFrame')
+        assert_pov(self, pd.DataFrame([["", " "], ["", " "]]), [[('', 'blank'), (' ', 'text')], [('', 'blank'), (' ', 'text')]], [["", " "], ["", " "]], (2, 2), None, 'DataFrame')
+        # assert_pov(self, pd.DataFrame([[datetime(2021, 1, 1), datetime(2021, 1, 2)], [datetime(2021, 1, 3), datetime(2021, 1, 4)]]), [[('1609459200', 'instant'), ('1609545600', 'instant')], [('1609632000', 'instant'), ('1609718400', 'instant')]], [[datetime(2021, 1, 1), datetime(2021, 1, 2)], [datetime(2021, 1, 3), datetime(2021, 1, 4)]], (2, 2), None, 'DataFrame')
+        

--- a/quadratic-kernels/python-wasm/tests/test.py
+++ b/quadratic-kernels/python-wasm/tests/test.py
@@ -2,13 +2,15 @@ import importlib
 import inspect
 import sys
 import unittest
+from datetime import datetime
 from unittest import IsolatedAsyncioTestCase, TestCase
-from unittest.mock import Mock, patch, MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import numpy as np
+import pandas as pd
+from process_output_test import *
 from quadratic_py.utils import attempt_fix_await, to_quadratic_type
 
-import pandas as pd
-import numpy as np
-from datetime import datetime
 
 #  Mock definitions
 class Cell:
@@ -46,7 +48,7 @@ sys.modules["autopep8"] = MagicMock()
 sys.modules["autopep8.fix_code"] = MagicMock()
 
 # import after mocks to in order to use them
-from quadratic_py import run_python, code_trace
+from quadratic_py import code_trace, run_python
 from quadratic_py.quadratic_api.quadratic import getCells
 
 run_python.fetch_module = mock_fetch_module
@@ -213,6 +215,7 @@ class TestUtils(TestCase):
 
         # TODO(ddimaria): implement when we implement duration in Rust
         # duration
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Moves processing output into it's own function to make it possible to test

- [x] move logic to a function
- [x] write tests