### PR TITLE
Update vite config to turn off sentryVitePlugin when env not defined

### DIFF
--- a/quadratic-client/vite.config.js
+++ b/quadratic-client/vite.config.js
@@ -6,6 +6,26 @@ import checker from 'vite-plugin-checker';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(() => {
+  const plugins = [
+    react(),
+    tsconfigPaths(),
+    checker({
+      typescript: true,
+      eslint: {
+        lintCommand: 'eslint --ext .ts,.tsx src',
+      },
+    }),
+  ];
+  if (process.env.SENTRY_AUTH_TOKEN) {
+    plugins.push(
+      sentryVitePlugin({
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        org: 'quadratic',
+        project: 'quadratic',
+      })
+    );
+  }
+
   return {
     build: {
       outDir: '../build',
@@ -24,21 +44,7 @@ export default defineConfig(() => {
       },
       dedupe: ['monaco-editor', 'vscode'],
     },
-    plugins: [
-      react(),
-      tsconfigPaths(),
-      checker({
-        typescript: true,
-        eslint: {
-          lintCommand: 'eslint --ext .ts,.tsx src',
-        },
-      }),
-      sentryVitePlugin({
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: 'quadratic',
-        project: 'quadratic',
-      }),
-    ],
+    plugins,
     worker: {
       format: 'iife',
       plugins: () => [


### PR DESCRIPTION
I was having problems runnig main in dev. I changed vite.config.js so plugins only includes the `sentryVitePlugin` when the SENTRY_AUTH_TOKEN is defined.