### PR TITLE
Fix bug when redefining `c` in Python

### DIFF
--- a/quadratic-client/src/web-workers/pythonWebWorker/python.worker.ts
+++ b/quadratic-client/src/web-workers/pythonWebWorker/python.worker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-globals */
 
-import { InspectPythonReturnType, PythonMessage } from './pythonTypes';
+import type { InspectPythonReturnType, PythonMessage } from './pythonTypes';
 
 const TRY_AGAIN_TIMEOUT = 500;
 

--- a/quadratic-kernels/python-wasm/quadratic_py/run_python.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/run_python.py
@@ -44,18 +44,18 @@ async def getCellsInner(p0: Tuple[int, int], p1: Tuple[int, int], sheet: str=Non
             cells_accessed.append([x, y, sheet])
 
     return await getCells(p0, p1, sheet, first_row_header)
-    
-globals = {
-    "getCells": getCellsInner,
-    "getCell": getCellInner,
-    "c": getCellInner,
-    "result": None,
-    "cell": getCellInner,
-    "cells": getCellsInner,
-}
 
 async def run_python(code: str, pos: Tuple[int, int]):
-    sout = StringIO()   
+    globals = {
+        "getCells": getCellsInner,
+        "getCell": getCellInner,
+        "c": getCellInner,
+        "result": None,
+        "cell": getCellInner,
+        "cells": getCellsInner,
+    }
+
+    sout = StringIO()
     serr = StringIO()
     output_value = None
     globals['pos'] = lambda: (pos.x, pos.y)


### PR DESCRIPTION
Moves global definition to `run_python` so it is called on every run instead of only on first load.