### PR TITLE
fix: text selection on code editor resize (safari)

### DIFF
--- a/quadratic-client/src/ui/menus/CodeEditor/ResizeControl.css
+++ b/quadratic-client/src/ui/menus/CodeEditor/ResizeControl.css
@@ -47,9 +47,12 @@
   transition: 0.2s ease background-color 300ms;
 }
 
-/* When control is being dragged, applies styles to body to prevent text
+/* When control is being dragged, applies styles to prevent text
    selection and try to keep correct cursor displayed */
-body:has(.resize-control--is-dragging) {
+body:has(.resize-control--is-dragging) * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 body:has(.resize-control--is-dragging.resize-control--position-VERTICAL) {


### PR DESCRIPTION
Today (in Safari) when you resize the code editor, the browser tries to do text selection making the experience really strange as you drag.

https://github.com/quadratichq/quadratic/assets/1316441/e77281c5-7503-431c-a33e-e975f688a2c3

This fixes that.


