### PR TITLE
Show import errors to users

### DIFF
--- a/quadratic-client/src/app/ui/components/FileUploadWrapper.tsx
+++ b/quadratic-client/src/app/ui/components/FileUploadWrapper.tsx
@@ -68,9 +68,15 @@ export const FileUploadWrapper = (props: PropsWithChildren) => {
         const insertAtCellLocation = { x: column, y: row } as Coordinate;
 
         if (fileType === 'csv') {
-          await quadraticCore.importCsv(sheets.sheet.id, file, insertAtCellLocation);
+          const error = await quadraticCore.importCsv(sheets.sheet.id, file, insertAtCellLocation);
+          if (error) {
+            addGlobalSnackbar(`Error loading ${file.name}: ${error}`, { severity: 'warning' });
+          }
         } else if (fileType === 'parquet') {
-          await quadraticCore.importParquet(sheets.sheet.id, file, insertAtCellLocation);
+          const error = await quadraticCore.importParquet(sheets.sheet.id, file, insertAtCellLocation);
+          if (error) {
+            addGlobalSnackbar(`Error loading ${file.name}: ${error}`, { severity: 'warning' });
+          }
         } else {
           addGlobalSnackbar('Unsupported file type', { severity: 'warning' });
         }

--- a/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
+++ b/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
@@ -414,7 +414,6 @@ class Core {
         } catch (error) {
           // TODO(ddimaria): standardize on how WASM formats errors for a consistent error
           // type in the UI.
-          console.error(error);
           reportError(error);
           Sentry.captureException(error);
           resolve(error as string);


### PR DESCRIPTION
Importing a bad .parquet or .csv file will trigger a snackbar error:

<img width="732" alt="Screenshot 2024-04-30 at 10 19 57 AM" src="https://github.com/quadratichq/quadratic/assets/442879/f06a2061-aa3b-45f4-a0d9-822db8ae4e44">
