### PR TITLE
fix: border offset

### DIFF
--- a/quadratic-client/src/routes/files.tsx
+++ b/quadratic-client/src/routes/files.tsx
@@ -63,7 +63,7 @@ export const Component = () => {
                         Open starter file
                       </Link>
                     ),
-                    className: 'border border-primary bg-yellow-5000',
+                    className: 'border border-primary',
                   },
                   {
                     title: 'Get started',
@@ -79,7 +79,7 @@ export const Component = () => {
                         Create blank file
                       </Link>
                     ),
-                    className: 'border-b border-border',
+                    className: 'border-l border-l-transparent border-r border-r-transparent border-b border-b-border',
                   },
                   {
                     title: 'See what’s possible',
@@ -94,7 +94,7 @@ export const Component = () => {
                         Explore examples
                       </Link>
                     ),
-                    className: 'border-b border-border',
+                    className: 'border-l border-l-transparent border-r border-r-transparent border-b border-b-border',
                   },
                   {
                     title: 'Deep dive',
@@ -111,6 +111,7 @@ export const Component = () => {
                         <ExternalLinkIcon className="ml-2" />
                       </Link>
                     ),
+                    className: 'border-l border-l-transparent border-r border-r-transparent',
                   },
                 ].map(({ title, description, link, className }, i) => (
                   <div


### PR DESCRIPTION
Fixes the small 2px offset for all non-highlighted items in the files list zero state (previously the non-highlited items were inset)

![CleanShot 2024-05-03 at 15 51 40@2x](https://github.com/quadratichq/quadratic/assets/1316441/e38b9e25-7323-4f3f-a83f-8b5cc6cd1209)
