### PR TITLE
fix: FloatingContextMenu should not overflow on the right, when possible

### DIFF
--- a/quadratic-client/src/app/ui/menus/ContextMenu/FloatingContextMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/ContextMenu/FloatingContextMenu.tsx
@@ -160,6 +160,12 @@ export const FloatingContextMenu = (props: Props) => {
     if (x < container.offsetLeft + 35) {
       x = container.offsetLeft + 35;
     } // left
+    if (x + menuDiv.current.clientWidth > container.offsetLeft + container.clientWidth - 15) {
+      x = Math.max(
+        container.offsetLeft + container.clientWidth - menuDiv.current.clientWidth - 15,
+        container.offsetLeft + 35
+      );
+    } // right
     if (y < container.offsetTop + 35) {
       y = container.offsetTop + 35;
     } // top


### PR DESCRIPTION
closes #1343 

Changes:
- Added logic to adjust position of the floating menu on right overflow, if there is space available on the viewport.

[Screencast from 11-05-24 08:28:21 AM IST.webm](https://github.com/quadratichq/quadratic/assets/54364088/6035d67e-5246-4dac-b917-614d009fed27)
