### PR TITLE
feat: toggle borders

### DIFF
--- a/quadratic-core/src/controller/operations/borders.rs
+++ b/quadratic-core/src/controller/operations/borders.rs
@@ -1,6 +1,6 @@
 use crate::{
     controller::GridController,
-    grid::{generate_borders, BorderSelection, BorderStyle},
+    grid::{generate_borders, get_rect_borders, BorderSelection, BorderStyle},
     SheetRect,
 };
 
@@ -16,7 +16,13 @@ impl GridController {
         let Some(sheet) = self.try_sheet(sheet_rect.sheet_id) else {
             return vec![];
         };
-        let borders = generate_borders(sheet, &sheet_rect.into(), selections, style);
+        let cur_borders = get_rect_borders(sheet, &sheet_rect.into());
+        let new_borders = generate_borders(sheet, &sheet_rect.into(), selections.clone(), style);
+        let borders = if cur_borders.render_lookup == new_borders.render_lookup {
+            generate_borders(sheet, &sheet_rect.into(), selections.clone(), None)
+        } else {
+            new_borders
+        };
         vec![Operation::SetBorders {
             sheet_rect,
             borders,

--- a/quadratic-core/src/controller/user_actions/borders.rs
+++ b/quadratic-core/src/controller/user_actions/borders.rs
@@ -37,7 +37,13 @@ mod tests {
         let mut grid_controller = GridController::test();
         let sheet_id = grid_controller.grid.sheets()[0].id;
         let sheet_rect = SheetRect::single_pos(Pos { x: 0, y: 0 }, sheet_id);
-        let selections = vec![BorderSelection::Top, BorderSelection::Left];
+
+        // apply top, left & right border
+        let selections = vec![
+            BorderSelection::Left,
+            BorderSelection::Top,
+            BorderSelection::Right,
+        ];
         let style = Some(BorderStyle {
             color: Rgba::default(),
             line: CellBorderLine::Line1,
@@ -63,8 +69,86 @@ mod tests {
         assert_eq!(borders.len(), 4);
         assert_eq!(borders[0], style);
         assert_eq!(borders[1], style);
-        assert_eq!(borders[2], None);
+        assert_eq!(borders[2], style);
         assert_eq!(borders[3], None);
+
+        // toggle left border
+        let selections = vec![BorderSelection::Left];
+
+        grid_controller.set_borders(sheet_rect, selections, style, None);
+
+        let borders = grid_controller.grid.sheets()[0]
+            .borders()
+            .per_cell
+            .borders
+            .iter()
+            .next()
+            .unwrap()
+            .1
+            .blocks()
+            .next()
+            .unwrap()
+            .content
+            .value
+            .borders;
+
+        assert_eq!(borders.len(), 4);
+        assert_eq!(borders[0], None);
+        assert_eq!(borders[1], style);
+        assert_eq!(borders[2], style);
+        assert_eq!(borders[3], None);
+
+        // apply top & bottom border
+        let selections = vec![BorderSelection::Bottom, BorderSelection::Top];
+
+        grid_controller.set_borders(sheet_rect, selections, style, None);
+
+        let borders = grid_controller.grid.sheets()[0]
+            .borders()
+            .per_cell
+            .borders
+            .iter()
+            .next()
+            .unwrap()
+            .1
+            .blocks()
+            .next()
+            .unwrap()
+            .content
+            .value
+            .borders;
+
+        assert_eq!(borders.len(), 4);
+        assert_eq!(borders[0], None);
+        assert_eq!(borders[1], style);
+        assert_eq!(borders[2], style);
+        assert_eq!(borders[3], style);
+
+        // toggle top & right border
+        let selections = vec![BorderSelection::Top, BorderSelection::Right];
+
+        grid_controller.set_borders(sheet_rect, selections, style, None);
+
+        let borders = grid_controller.grid.sheets()[0]
+            .borders()
+            .per_cell
+            .borders
+            .iter()
+            .next()
+            .unwrap()
+            .1
+            .blocks()
+            .next()
+            .unwrap()
+            .content
+            .value
+            .borders;
+
+        assert_eq!(borders.len(), 4);
+        assert_eq!(borders[0], None);
+        assert_eq!(borders[1], None);
+        assert_eq!(borders[2], None);
+        assert_eq!(borders[3], style);
     }
 
     #[test]

--- a/quadratic-core/src/grid/borders/sheet.rs
+++ b/quadratic-core/src/grid/borders/sheet.rs
@@ -100,7 +100,7 @@ pub fn get_cell_borders_in_rect(sheet: &Sheet, rect: Rect) -> Vec<(i64, i64, Opt
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct SheetBorders {
     pub per_cell: IdSpaceBorders,
-    pub(super) render_lookup: GridSpaceBorders,
+    pub render_lookup: GridSpaceBorders,
 }
 
 impl SheetBorders {
@@ -130,6 +130,10 @@ impl SheetBorders {
         let mut sheet_borders = SheetBorders::default();
         let cloned_id_space = self.per_cell.clone_rect(rect);
         sheet_borders.per_cell.replace_rect(&cloned_id_space, rect);
+        let cloned_render_lookup = self.render_lookup.clone_rect(rect);
+        sheet_borders
+            .render_lookup
+            .replace_rect(&cloned_render_lookup, rect);
         sheet_borders
     }
 }


### PR DESCRIPTION
closes #1231 

Changes:-
- Check if the new SheetBorder render for the rect is same as current SheetBorder render, then toggle the selected border.
- If new render is different, apply new border selection as before.


[toggle_borders.webm](https://github.com/quadratichq/quadratic/assets/54364088/7294d7f5-bf37-4d5e-957c-05fc9aef0a37)

