### PR TITLE
feat: PgUp, PgDown, Home, End, Cmd+Home, Cmd+End support

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
+++ b/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
@@ -66,7 +66,8 @@ export function moveViewport(options: {
 
   const sheet = sheets.sheet;
   const bounds = pixiApp.viewport.getVisibleBounds();
-  const adjust = pixiAppSettings.showHeadings ? HEADING_SIZE : 0;
+  const zoom = pixiApp.viewport.scale.x;
+  const adjust = pixiAppSettings.showHeadings ? HEADING_SIZE / zoom : 0;
 
   if (center) {
     const cell = sheet.getCellOffsets(center.x, center.y);


### PR DESCRIPTION
closes #1053 

Changes:
- Added support for PgUp, PgDown, Home, End, Cmd+Home, Cmd+End with following behaviour:
   - PgUp - Moves the sheet to exact one screen up.
   - PgDown - Moves the sheet to exact one screen down.
   - Home - Moves the cursor to the beginning of row, if the row has content. Nothing happens if the row is empty.
   - Cmd+Home - Moves the cursor to (0, 0). Also resets the viewport with (0, 0) in top corner.
   - End - Moves the cursor to the end of row, if the row has content. Nothing happens if the row is empty.
   - Cmd+End - Moves the cursor to the last occupied cell in sheet.