### PR TITLE
fix(python): wrap async functions in `(await <function-call>)`, replace `c((x,y), ...)` `cell((x,y), ...)` with `cells((x,y), ...)`

### DIFF
--- a/quadratic-kernels/python-wasm/quadratic_py/utils.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/utils.py
@@ -12,8 +12,10 @@ import pytz
 
 
 def attempt_fix_await(code: str) -> str:
-    # Wrap known async functions with "(await <function-call>)" to improve the UX
+    # Convert c((x,y), ...) cell((x,y), ...) to cells((x,y), ...)
     code = re.sub(r"([^a-zA-Z0-9_]|^)c(?:ell)?(\([^\(\)]*\([^\)]*\)(?:[^\(\)]*|\([^\)]*\))*\))", r"\1cells\2", code) # captures c((x,y), ...) cell((x,y), ...)
+    
+    # Wrap known async functions with "(await <function-call>)" to improve the UX
     code = re.sub(r"([^a-zA-Z0-9_]|^)(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
     code = re.sub(r"([^a-zA-Z0-9_]|^)(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
     code = re.sub(r"([^a-zA-Z0-9_]|^)(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(

--- a/quadratic-kernels/python-wasm/quadratic_py/utils.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/utils.py
@@ -13,14 +13,14 @@ import pytz
 
 def attempt_fix_await(code: str) -> str:
     # Convert c((x,y), ...) cell((x,y), ...) to cells((x,y), ...)
-    code = re.sub(r"([^a-zA-Z0-9_]|^)c(?:ell)?(\([^\(\)]*\([^\)]*\)(?:[^\(\)]*|\([^\)]*\))*\))", r"\1cells\2", code) # captures c((x,y), ...) cell((x,y), ...)
+    code = re.sub(r"(^|\W)c(?:ell)?(\([^\(\)]*\([^\)]*\)(?:[^\(\)]*|\([^\)]*\))*\))", r"\1cells\2", code) # captures c((x,y), ...) cell((x,y), ...)
     
     # Wrap known async functions with "(await <function-call>)" to improve the UX
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(rel_cell\([^\)]*\))", r"\1(await \2)", code)                      # captures rel_cell(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(rc\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)          # captures rc(
+    code = re.sub(r"(^|\W)(?:await +)?(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
+    code = re.sub(r"(^|\W)(?:await +)?(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
+    code = re.sub(r"(^|\W)(?:await +)?(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(
+    code = re.sub(r"(^|\W)(?:await +)?(rel_cell\([^\)]*\))", r"\1(await \2)", code)                      # captures rel_cell(
+    code = re.sub(r"(^|\W)(?:await +)?(rc\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)          # captures rc(
 
     return code
 

--- a/quadratic-kernels/python-wasm/quadratic_py/utils.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/utils.py
@@ -12,22 +12,19 @@ import pytz
 
 
 def attempt_fix_await(code: str) -> str:
-    # Insert a "await" keyword between known async functions to improve the UX
-    code = re.sub(r"([^a-zA-Z0-9]|^)cells\(", r"\1await cells(", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)cell\(", r"\1await cell(", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)c\(", r"\1await c(", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)getCell\(", r"\1await getCell(", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)getCells\(", r"\1await getCells(", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)cells\[", r"\1await cells[", code)
-    code = re.sub(r"([^a-zA-Z0-9]|^)rel_await cell\(", r"\1await rel_cell(", code) # intentional
-    code = re.sub(r"([^a-zA-Z0-9]|^)rc\(", r"\1await rc(", code)
+    # Wrap known async functions with "(await <function-call>)" to improve the UX
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(rel_cell\([^\)]*\))", r"\1(await \2)", code)                      # captures rel_cell(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(rc\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)          # captures rc(
 
-    code = code.replace("await await getCell", "await getCell")
-    code = code.replace("await await getCells", "await getCells")
     code = code.replace("await await c(", "await c(")
     code = code.replace("await await cell(", "await cell(")
     code = code.replace("await await cells(", "await cells(")
     code = code.replace("await await cells[", "await cells[")
+    code = code.replace("await await getCell", "await getCell")
+    code = code.replace("await await getCells", "await getCells")
     code = code.replace("await await rel_cell[", "await rel_cell(")
     code = code.replace("await await rc[", "await rc(")
 

--- a/quadratic-kernels/python-wasm/quadratic_py/utils.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/utils.py
@@ -16,20 +16,11 @@ def attempt_fix_await(code: str) -> str:
     code = re.sub(r"([^a-zA-Z0-9_]|^)c(?:ell)?(\([^\(\)]*\([^\)]*\)(?:[^\(\)]*|\([^\)]*\))*\))", r"\1cells\2", code) # captures c((x,y), ...) cell((x,y), ...)
     
     # Wrap known async functions with "(await <function-call>)" to improve the UX
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(rel_cell\([^\)]*\))", r"\1(await \2)", code)                      # captures rel_cell(
-    code = re.sub(r"([^a-zA-Z0-9_]|^)(rc\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)          # captures rc(
-
-    code = code.replace("await await c(", "await c(")
-    code = code.replace("await await cell(", "await cell(")
-    code = code.replace("await await cells(", "await cells(")
-    code = code.replace("await await cells[", "await cells[")
-    code = code.replace("await await getCell", "await getCell")
-    code = code.replace("await await getCells", "await getCells")
-    code = code.replace("await await rel_cell[", "await rel_cell(")
-    code = code.replace("await await rc[", "await rc(")
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(rel_cell\([^\)]*\))", r"\1(await \2)", code)                      # captures rel_cell(
+    code = re.sub(r"([^a-zA-Z0-9_]|^)(?:await )?(rc\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)          # captures rc(
 
     return code
 

--- a/quadratic-kernels/python-wasm/quadratic_py/utils.py
+++ b/quadratic-kernels/python-wasm/quadratic_py/utils.py
@@ -13,6 +13,7 @@ import pytz
 
 def attempt_fix_await(code: str) -> str:
     # Wrap known async functions with "(await <function-call>)" to improve the UX
+    code = re.sub(r"([^a-zA-Z0-9_]|^)c(?:ell)?(\([^\(\)]*\([^\)]*\)(?:[^\(\)]*|\([^\)]*\))*\))", r"\1cells\2", code) # captures c((x,y), ...) cell((x,y), ...)
     code = re.sub(r"([^a-zA-Z0-9_]|^)(c(?:ells?)?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code) # captures c( cell( cells(
     code = re.sub(r"([^a-zA-Z0-9_]|^)(cells\[[^\]]*\])", r"\1(await \2)", code)                         # captures cells[
     code = re.sub(r"([^a-zA-Z0-9_]|^)(getCells?\((?:[^\(\)]*|\([^\)]*\))*\))", r"\1(await \2)", code)   # captures get_cell( get_cells(

--- a/quadratic-kernels/python-wasm/tests/test.py
+++ b/quadratic-kernels/python-wasm/tests/test.py
@@ -74,38 +74,45 @@ class TestTesting(IsolatedAsyncioTestCase):
         self.assertEqual(attempt_fix_await("1 + 1"), "1 + 1")
 
         # simple adding await
-        self.assertEqual(attempt_fix_await("a = cells(0, 0)"), "a = await cells(0, 0)")
-        self.assertEqual(attempt_fix_await("a = cell(0, 0)"), "a = await cell(0, 0)")
-        self.assertEqual(attempt_fix_await("a = c(0, 0)"), "a = await c(0, 0)")
-        self.assertEqual(attempt_fix_await("a = rel_cell(0, 0)"), "a = await rel_cell(0, 0)")
-        self.assertEqual(attempt_fix_await("a = rc(0, 0)"), "a = await rc(0, 0)")
+        self.assertEqual(attempt_fix_await("a = cells(0, 0)"), "a = (await cells(0, 0))")
+        self.assertEqual(attempt_fix_await("a = cell(0, 0)"), "a = (await cell(0, 0))")
+        self.assertEqual(attempt_fix_await("a = c(0, 0)"), "a = (await c(0, 0))")
+        self.assertEqual(attempt_fix_await("a = rel_cell(0, 0)"), "a = (await rel_cell(0, 0))")
+        self.assertEqual(attempt_fix_await("a = rc(0, 0)"), "a = (await rc(0, 0))")
         self.assertEqual(
-            attempt_fix_await("a = getCells(0, 0)"), "a = await getCells(0, 0)"
+            attempt_fix_await("a = getCells(0, 0)"), "a = (await getCells(0, 0))"
         )
 
         # simple already has await
         self.assertEqual(
-            attempt_fix_await("a = await cells(0, 0)"), "a = await cells(0, 0)"
+            attempt_fix_await("a = await cells(0, 0)"), "a = (await cells(0, 0))"
         )
         self.assertEqual(
-            attempt_fix_await("a = await cell(0, 0)"), "a = await cell(0, 0)"
+            attempt_fix_await("a = await cell(0, 0)"), "a = (await cell(0, 0))"
         )
-        self.assertEqual(attempt_fix_await("a = await c(0, 0)"), "a = await c(0, 0)")
+        self.assertEqual(attempt_fix_await("a = await c(0, 0)"), "a = (await c(0, 0))")
         self.assertEqual(
-            attempt_fix_await("a = await getCells(0, 0)"), "a = await getCells(0, 0)"
+            attempt_fix_await("a = await getCells(0, 0)"), "a = (await getCells(0, 0))"
         )
 
         # other
         self.assertEqual(attempt_fix_await("a = cac(0, 0)"), "a = cac(0, 0)")
-        self.assertEqual(attempt_fix_await("c(0, 0)"), "await c(0, 0)")
-        self.assertEqual(attempt_fix_await("int(c(0,0))"), "int(await c(0,0))")
+        self.assertEqual(attempt_fix_await("c(0, 0)"), "(await c(0, 0))")
+        self.assertEqual(attempt_fix_await("int(c(0,0))"), "int((await c(0,0)))")
         self.assertEqual(
             attempt_fix_await("float((await c(2, -4)).value)"),
+            "float(((await c(2, -4))).value)",
+        )
+        self.assertEqual(
+            attempt_fix_await("float(c(2, -4).value)"),
             "float((await c(2, -4)).value)",
         )
         self.assertEqual(
-            attempt_fix_await("c(0, 0)\nc(0, 0)"), "await c(0, 0)\nawait c(0, 0)"
+            attempt_fix_await("cells((0,0), (0,10)).sum()"), "(await cells((0,0), (0,10))).sum()"
         )
+        self.assertEqual(
+            attempt_fix_await("c(0, 0)\nc(0, 0)"), "(await c(0, 0))\n(await c(0, 0))"
+        )        
 
 
 class TestImports(TestCase):

--- a/quadratic-kernels/python-wasm/tests/test.py
+++ b/quadratic-kernels/python-wasm/tests/test.py
@@ -112,7 +112,21 @@ class TestTesting(IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             attempt_fix_await("c(0, 0)\nc(0, 0)"), "(await c(0, 0))\n(await c(0, 0))"
-        )        
+        )
+
+        # convert c((x,y), ...) cell((x,y), ...) to cells((x,y), ...)
+        self.assertEqual(
+            attempt_fix_await("c((0,0), (0,10), (10,10), (10,0)).sum()"), "(await cells((0,0), (0,10), (10,10), (10,0))).sum()"
+        )
+        self.assertEqual(
+            attempt_fix_await("cell((0,0), (0,10), (10,10), (10,0)).sum()"), "(await cells((0,0), (0,10), (10,10), (10,0))).sum()"
+        )
+        self.assertEqual(
+            attempt_fix_await("cells((0,0), (0,10), (10,10), (10,0)).sum()"), "(await cells((0,0), (0,10), (10,10), (10,0))).sum()"
+        )
+        self.assertEqual(
+            attempt_fix_await("gc((0,0), (0,10), (10,10), (10,0)).sum()"), "gc((0,0), (0,10), (10,10), (10,0)).sum()"
+        )
 
 
 class TestImports(TestCase):


### PR DESCRIPTION
closes #1113 
closes #1396 
closes #1395 

Bug:
`cells((0,0), (0,10)).sum()` is converted into `await cells((0,0), (0,10)).sum()`

Solution:
Wrap async function call in `(await <function-call>)` 
i.e. convert `cells((0,0), (0,10)).sum()` into `(await cells((0,0), (0,10))).sum()`

Changes:
- Updated regex to wrap async function calls in `(await <function-call>)`
- Updated regex to replace `c((x,y), ...)` & `cell((x,y), ...)` with `cells((x,y), ...)`