### PR TITLE
replace \n from code to ensure we don't wrap

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -86,9 +86,10 @@ export class CellLabel {
         return RUN_ERROR_TEXT;
       case 'Chart':
         return CHART_TEXT;
-      default:
-        return cell?.value;
     }
+
+    // strip any line breaks
+    return cell.value.replace(/\n/g, ' ');
   }
 
   constructor(cellsLabels: CellsLabels, cell: JsRenderCell, screenRectangle: Rectangle) {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
@@ -85,11 +85,10 @@ export class CellsTextHash {
     return this.labels.get(`${column},${row}`);
   }
 
-  private createLabel(cell: JsRenderCell): CellLabel {
+  private createLabel(cell: JsRenderCell) {
     const rectangle = this.cellsLabels.getCellOffsets(Number(cell.x), Number(cell.y));
     const cellLabel = new CellLabel(this.cellsLabels, cell, rectangle);
     this.labels.set(this.getKey(cell), cellLabel);
-    return cellLabel;
   }
 
   async createLabels(cells: JsRenderCell[]) {


### PR DESCRIPTION
This fixes a bug where a line may wrap if it finds \n in a CodeCell (we already strip \n from text entered by the user).

The \n is stripped in the renderer for now.

We may want to revisit this once we actually support word wrapping (see https://github.com/quadratichq/quadratic/pull/1406)

Closes #1433 