### PR TITLE
feat: track cell type selection in mixpanel

### DIFF
--- a/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
@@ -99,6 +99,7 @@ export default function CellTypeMenu() {
 
   const openEditor = useCallback(
     (mode: CodeCellLanguage) => {
+      mixpanel.track('[CellTypeMenu].selected', { mode });
       setEditorInteractionState({
         ...editorInteractionState,
         showCodeEditor: true,


### PR DESCRIPTION
We track how many times people open the cell type menu, but not when they actually select a language. This starts tracking that.