### PR TITLE
Fix bug with leaving edit cell with up or down arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ _Quadratic is in Beta._
 
 Want to learn more about how Quadratic works? Read the [How Quadratic Works](./docs/how_quadratic_works.md) doc.
 
-
 ## Examples
 
 Example sheets - [Examples](https://www.quadratichq.com/examples)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## ![quadratic icon small](https://user-images.githubusercontent.com/3479421/162039117-02f85f2c-e382-4ed8-ac39-64efab17a144.svg) **_The technical multiplayer spreadsheet, with Python, SQL, and AI_**
 
-Modern multiplayer spreadsheet with Python, AI, and SQL built-in. 
+Modern multiplayer spreadsheet with Python, AI, and SQL built-in.
 
 Built with Rust + WASM + WebGL to run seamlessly at 60+ FPS in the browser.
 
@@ -56,6 +56,7 @@ _Quadratic is in Beta._
 **Want to contribute?** Read our [Contributing Guide](./CONTRIBUTING.md).
 
 Want to learn more about how Quadratic works? Read the [How Quadratic Works](./docs/how_quadratic_works.md) doc.
+
 
 ## Examples
 

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
@@ -121,6 +121,7 @@ class InlineEditorKeyboard {
           await keyboardPosition(e);
         }
       } else {
+        e.stopPropagation();
         inlineEditorHandler.close(0, e.code === 'ArrowDown' ? 1 : -1, false);
       }
     }


### PR DESCRIPTION
Pressing up or down arrow when editing a normal cell properly moves you one cell.