### PR TITLE
Improve mouse interaction with move cells

### DIFF
--- a/quadratic-client/src/app/gridGL/UI/Cursor.ts
+++ b/quadratic-client/src/app/gridGL/UI/Cursor.ts
@@ -136,8 +136,8 @@ export class Cursor extends Graphics {
       this.cursorRectangle = new Rectangle(
         startCell.x,
         startCell.y,
-        this.endCell.x + this.endCell.width - this.startCell.x,
-        this.endCell.y + this.endCell.height - this.startCell.y
+        this.endCell.x + this.endCell.width - startCell.x,
+        this.endCell.y + this.endCell.height - startCell.y
       );
     } else {
       this.endCell = sheet.getCellOffsets(cursor.cursorPosition.x, cursor.cursorPosition.y);

--- a/quadratic-client/src/app/gridGL/UI/Cursor.ts
+++ b/quadratic-client/src/app/gridGL/UI/Cursor.ts
@@ -131,10 +131,11 @@ export class Cursor extends Graphics {
       // endCell is only interesting for one multiCursor since we use it to draw
       // the indicator, which is only active for one multiCursor
       const multiCursor = cursor.multiCursor[0];
+      const startCell = sheet.getCellOffsets(multiCursor.left, multiCursor.top);
       this.endCell = sheet.getCellOffsets(multiCursor.right - 1, multiCursor.bottom - 1);
       this.cursorRectangle = new Rectangle(
-        this.startCell.x,
-        this.startCell.y,
+        startCell.x,
+        startCell.y,
         this.endCell.x + this.endCell.width - this.startCell.x,
         this.endCell.y + this.endCell.height - this.startCell.y
       );

--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerCellMoving.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerCellMoving.ts
@@ -212,11 +212,17 @@ export class PointerCellMoving {
         // unsaved content.
         if (pixiAppSettings.unsavedEditorChanges) {
           const state = pixiAppSettings.editorInteractionState;
-          if (state.selectedCellSheet === sheets.sheet.id && intersects.rectanglePoint(rectangle, new Point(state.selectedCell.x, state.selectedCell.y))) {
+          if (
+            state.selectedCellSheet === sheets.sheet.id &&
+            intersects.rectanglePoint(rectangle, new Point(state.selectedCell.x, state.selectedCell.y))
+          ) {
             pixiAppSettings.setEditorInteractionState?.({
               ...pixiAppSettings.editorInteractionState,
               initialCode: pixiAppSettings.unsavedEditorChanges,
-              selectedCell: { x: state.selectedCell.x + this.moving.toColumn - this.moving.column, y: state.selectedCell.y + this.moving.toRow - this.moving.row },
+              selectedCell: {
+                x: state.selectedCell.x + this.moving.toColumn - this.moving.column,
+                y: state.selectedCell.y + this.moving.toRow - this.moving.row,
+              },
             });
           }
         }

--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerCellMoving.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerCellMoving.ts
@@ -207,6 +207,19 @@ export class PointerCellMoving {
           this.moving.toRow,
           sheets.sheet.id
         );
+
+        // if we moved the code cell, we need to repopulate the code editor with
+        // unsaved content.
+        if (pixiAppSettings.unsavedEditorChanges) {
+          const state = pixiAppSettings.editorInteractionState;
+          if (state.selectedCellSheet === sheets.sheet.id && intersects.rectanglePoint(rectangle, new Point(state.selectedCell.x, state.selectedCell.y))) {
+            pixiAppSettings.setEditorInteractionState?.({
+              ...pixiAppSettings.editorInteractionState,
+              initialCode: pixiAppSettings.unsavedEditorChanges,
+              selectedCell: { x: state.selectedCell.x + this.moving.toColumn - this.moving.column, y: state.selectedCell.y + this.moving.toRow - this.moving.row },
+            });
+          }
+        }
       }
       this.reset();
       return true;

--- a/quadratic-client/src/app/gridGL/pixiApp/PixiAppSettings.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/PixiAppSettings.ts
@@ -28,7 +28,10 @@ class PixiAppSettings {
   private lastSettings: GridSettings;
   private _panMode: PanMode;
   private _input: Input;
-  unsavedEditorChanges = false;
+
+  // Keeps track of code editor content. This is used when moving code cells to
+  // keep track of any unsaved changes, and keyboardCell.
+  unsavedEditorChanges?: string;
 
   temporarilyHideCellTypeOutlines = false;
   editorInteractionState = editorInteractionStateDefault;

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditor.tsx
@@ -86,7 +86,8 @@ export const CodeEditor = () => {
 
     // we use the for keyboardCell so we know whether we can delete a cell with
     // the code editor open
-    pixiAppSettings.unsavedEditorChanges = unsaved;
+    pixiAppSettings.unsavedEditorChanges = unsaved ? editorContent : undefined;
+
     return unsaved;
   }, [codeString, editorContent]);
 

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorBody.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorBody.tsx
@@ -71,7 +71,6 @@ export const CodeEditorBody = (props: Props) => {
 
   useEffect(() => {
     const insertText = (text: string) => {
-      debugger;
       if (!editorRef.current) return;
       const position = editorRef.current.getPosition();
       const model = editorRef.current.getModel();

--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
@@ -79,7 +79,6 @@ export function javascriptAddLineNumberVars(transform: JavascriptTransformedCode
       add++;
     }
   }
-  console.log(s);
   return s;
 }
 

--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
@@ -23,7 +23,7 @@ export async function javascriptFindSyntaxError(transformed: {
   imports: string;
 }): Promise<{ text: string; lineNumber?: number } | false> {
   try {
-    await esbuild.transform(`${transformed.imports};(async() => {;${transformed.code};})()`, { loader: 'js' });
+    await esbuild.transform(`${transformed.imports};(async() => {;${transformed.code};\n})()`, { loader: 'js' });
     return false;
   } catch (e: any) {
     const error = e as esbuild.TransformFailure;


### PR DESCRIPTION
Fixes #1470

- [x] Move cells is now always relative to the cell, not the mouse position
- [x] Fixed bug where a reverse selection (selecting cells from bottom-right to top-left) would not allow move to work