### PR TITLE
Code hint shouldn't show on when content in cell

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/CodeHint.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/CodeHint.tsx
@@ -21,7 +21,7 @@ export const CodeHint = () => {
   useEffect(() => {
     const updateCursor = async () => {
       const { x, y } = sheets.sheet.cursor.cursorPosition;
-      const newCellHasValue = await quadraticCore.hasRenderCells(sheets.sheet.id, x, y, 0, 0);
+      const newCellHasValue = await quadraticCore.hasRenderCells(sheets.sheet.id, x, y, 1, 1);
       setHide(true);
       setCellHasValue(newCellHasValue);
 


### PR DESCRIPTION
Fixes bug with `press / to code` showing over content.

See https://quadratichq.slack.com/archives/C06Q34HGV8A/p1720119206871539