### PR TITLE
Fix bug with double clicking in cell within CodeRun

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
@@ -40,6 +40,12 @@ export function doubleClickCell(options: {
       });
     } else {
       if (hasPermission && formula) {
+        const cursor = sheets.sheet.cursor.cursorPosition;
+
+        // ensure we're in the right cell (which may change if we double clicked on a CodeRun)
+        if (cursor.x !== column || cursor.y !== row) {
+          sheets.sheet.cursor.changePosition({ cursorPosition: { x: column, y: row } });
+        }
         settings.changeInput(true, cell);
       } else {
         settings.setEditorInteractionState({


### PR DESCRIPTION
Fixes #1484 

The correct behavior is if you double click on a CodeRun, you open the code cell that generated the CodeRun. We were not adjusting the cursor with one of the PR changes.