### PR TITLE
sql (enhancement): separate API calls for files

### DIFF
--- a/quadratic-api/src/routes/v0/teams.$uuid.files.GET.ts
+++ b/quadratic-api/src/routes/v0/teams.$uuid.files.GET.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express';
+import { ApiTypes } from 'quadratic-shared/typesAndSchemas';
+import { z } from 'zod';
+import { generatePresignedUrl } from '../../aws/s3';
+import dbClient from '../../dbClient';
+import { getTeam } from '../../middleware/getTeam';
+import { userMiddleware } from '../../middleware/user';
+import { validateAccessToken } from '../../middleware/validateAccessToken';
+import { parseRequest } from '../../middleware/validateRequestSchema';
+import { RequestWithUser } from '../../types/Request';
+import { getFilePermissions } from '../../utils/permissions';
+
+export default [validateAccessToken, userMiddleware, handler];
+
+// /teams/:uuid/files - public files in team
+// /teams/:uuid/files?private=true - private files in team
+const schema = z.object({
+  query: z.object({
+    private: z.string().transform((val) => val.toLowerCase() === 'true'),
+  }),
+  params: z.object({
+    uuid: z.string().uuid(),
+  }),
+});
+
+async function handler(req: Request, res: Response<ApiTypes['/v0/teams/:uuid/files.GET.response']>) {
+  const {
+    params: { uuid },
+    query: { private: isPrivate },
+  } = parseRequest(req, schema);
+  console.log('isPrivate', isPrivate, req.url);
+  const {
+    user: { id: userMakingRequestId },
+  } = req as RequestWithUser;
+  const { team, userMakingRequest } = await getTeam({ uuid, userId: userMakingRequestId });
+
+  // Get team data
+  const dbTeam = await dbClient.team.findUniqueOrThrow({
+    where: {
+      id: team.id,
+    },
+    include: {
+      File: {
+        where: {
+          ownerTeamId: team.id,
+          deleted: false,
+          // Make sure not to return files that are private to other users
+          ownerUserId: isPrivate ? userMakingRequestId : null,
+        },
+        include: {
+          UserFileRole: {
+            where: {
+              userId: userMakingRequestId,
+            },
+          },
+        },
+        orderBy: {
+          createdDate: 'asc',
+        },
+      },
+    },
+  });
+
+  const dbFiles = dbTeam.File ? dbTeam.File : [];
+  console.log('files & privacy', isPrivate, dbFiles.length);
+
+  // Get signed thumbnail URLs
+  await Promise.all(
+    dbFiles.map(async (file) => {
+      if (file.thumbnail) {
+        file.thumbnail = await generatePresignedUrl(file.thumbnail);
+      }
+    })
+  );
+
+  const response = {
+    userMakingRequest: {
+      id: userMakingRequestId,
+      teamRole: userMakingRequest.role,
+      teamPermissions: userMakingRequest.permissions,
+    },
+    files: dbFiles.map((file) => ({
+      file: {
+        uuid: file.uuid,
+        name: file.name,
+        createdDate: file.createdDate.toISOString(),
+        updatedDate: file.updatedDate.toISOString(),
+        publicLinkAccess: file.publicLinkAccess,
+        thumbnail: file.thumbnail,
+      },
+      userMakingRequest: {
+        filePermissions: getFilePermissions({
+          publicLinkAccess: file.publicLinkAccess,
+          userFileRelationship: isPrivate
+            ? {
+                context: 'private-to-me',
+                teamRole: userMakingRequest.role,
+              }
+            : {
+                context: 'public-to-team',
+                teamRole: userMakingRequest.role,
+                fileRole: file.UserFileRole.find(({ userId }) => userId === userMakingRequestId)?.role,
+              },
+        }),
+      },
+    })),
+  };
+
+  return res.status(200).json(response);
+}

--- a/quadratic-client/src/routes/teams.$teamUuid.index.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.index.tsx
@@ -4,12 +4,24 @@ import { Empty } from '@/dashboard/components/Empty';
 import { FilesList } from '@/dashboard/components/FilesList';
 import { FilesListEmptyState } from '@/dashboard/components/FilesListEmptyState';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
+import { apiClient } from '@/shared/api/apiClient';
 import { FileIcon } from '@radix-ui/react-icons';
+import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
+
+type LoaderData = Awaited<ReturnType<typeof loader>>;
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const teamUuid = params.teamUuid;
+  if (!teamUuid) throw new Error('No team UUID provided');
+
+  const data = await apiClient.teams.files.list(teamUuid, false);
+  return data;
+};
 
 export const Component = () => {
+  const { files } = useLoaderData() as LoaderData;
   const {
     activeTeam: {
-      files,
       userMakingRequest: { teamPermissions },
     },
   } = useDashboardRouteLoaderData();

--- a/quadratic-client/src/shared/api/apiClient.ts
+++ b/quadratic-client/src/shared/api/apiClient.ts
@@ -101,6 +101,15 @@ export const apiClient = {
         );
       },
     },
+    files: {
+      async list(teamUuid: string, isPrivate: boolean = false) {
+        return fetchFromApi(
+          `/v0/teams/${teamUuid}/files?private=${isPrivate}`,
+          { method: 'GET' },
+          ApiSchemas['/v0/teams/:uuid/files.GET.response']
+        );
+      },
+    },
   },
 
   files: {

--- a/quadratic-shared/typesAndSchemas.ts
+++ b/quadratic-shared/typesAndSchemas.ts
@@ -316,6 +316,15 @@ export const ApiSchemas = {
   '/v0/teams/:uuid.PATCH.request': TeamSchema.pick({ name: true }),
   '/v0/teams/:uuid.PATCH.response': TeamSchema.pick({ name: true }),
 
+  '/v0/teams/:uuid/files.GET.response': z.object({
+    files: TeamFilesSchema,
+    userMakingRequest: z.object({
+      id: TeamUserSchema.shape.id,
+      teamPermissions: z.array(TeamPermissionSchema),
+      teamRole: UserTeamRoleSchema,
+    }),
+  }),
+
   '/v0/teams/:uuid/invites.POST.request': TeamUserSchema.pick({ email: true, role: true }),
   '/v0/teams/:uuid/invites.POST.response': z
     .object({


### PR DESCRIPTION
Rather than have one `/team/:uuid` call that returns all data needed across all tabs in the dashboard for a team (and that re-validates each time you navigate), this would begin the process of breaking up that single API call into multiple calls that only return the data needed by each sub-resource of a team.

Today:

- Navigate to public team files, the API returns the public & private files on a team, team members, and more
- Navigate to private team files, the API returns the public & private files on a team, team members, and more
- Navigate to team members, the API returns the public & private files on a team, team members, and more

This change:

- Navigate to public team files, the API returns only public team files
- Navigate to private team files, the API returns only private team files
- Navigate to team members, the API returns only team members

**TODO**:

- [ ] This implements the API fix for files, but still needs to remove the old file data from the `/teams/:uuid` call.
