### PR TITLE
Next connections infra prod 2

### DIFF
--- a/infra/connection/connection.ts
+++ b/infra/connection/connection.ts
@@ -5,6 +5,17 @@ import { isPreviewEnvironment } from "../helpers/isPreviewEnvironment";
 import { latestAmazonLinuxAmi } from "../helpers/latestAmazonAmi";
 import { runDockerImageBashScript } from "../helpers/runDockerImageBashScript";
 import { instanceProfileIAMContainerRegistry } from "../shared/instanceProfileIAMContainerRegistry";
+import {
+  connectionEc2SecurityGroup,
+  connectionEip1,
+  connectionEip2,
+  connectionNlbSecurityGroup,
+  connectionPrivateSubnet1,
+  connectionPrivateSubnet2,
+  connectionPublicSubnet1,
+  connectionPublicSubnet2,
+  connectionVPC,
+} from "./connection_network";
 const config = new pulumi.Config();
 
 // Configuration from command line
@@ -17,185 +28,14 @@ const connectionECRName = config.require("connection-ecr-repo-name");
 const domain = config.require("domain");
 const certificateArn = config.require("certificate-arn");
 
-// Create a new VPC
-const vpc = new aws.ec2.Vpc("connection-vpc", {
-  cidrBlock: "10.0.0.0/16",
-  enableDnsSupport: true,
-  enableDnsHostnames: true,
-  tags: { Name: "connection-vpc" },
-});
-
-// Create an Internet Gateway
-const internetGateway = new aws.ec2.InternetGateway("connection-igw", {
-  vpcId: vpc.id,
-  tags: { Name: "connection-igw" },
-});
-
-// Create Elastic IPs
-const natEip1 = new aws.ec2.Eip("nat-eip-1", {
-  vpc: true,
-});
-
-const natEip2 = new aws.ec2.Eip("nat-eip-2", {
-  vpc: true,
-});
-
-// Create public subnets
-const publicSubnet1 = new aws.ec2.Subnet("connection-public-subnet-1", {
-  vpcId: vpc.id,
-  cidrBlock: "10.0.1.0/24",
-  availabilityZone: "us-west-2a",
-  mapPublicIpOnLaunch: true,
-  tags: { Name: "connection-public-subnet-1" },
-});
-
-const publicSubnet2 = new aws.ec2.Subnet("connection-public-subnet-2", {
-  vpcId: vpc.id,
-  cidrBlock: "10.0.2.0/24",
-  availabilityZone: "us-west-2b",
-  mapPublicIpOnLaunch: true,
-  tags: { Name: "connection-public-subnet-2" },
-});
-
-// Create a NAT Gateway in each public subnet
-const natGateway1 = new aws.ec2.NatGateway("nat-gateway-1", {
-  allocationId: natEip1.id,
-  subnetId: publicSubnet1.id,
-  tags: { Name: "nat-gateway-1" },
-});
-
-const natGateway2 = new aws.ec2.NatGateway("nat-gateway-2", {
-  allocationId: natEip2.id,
-  subnetId: publicSubnet2.id,
-  tags: { Name: "nat-gateway-2" },
-});
-
-// Create private subnets
-const privateSubnet1 = new aws.ec2.Subnet("connection-private-subnet-1", {
-  vpcId: vpc.id,
-  cidrBlock: "10.0.3.0/24",
-  availabilityZone: "us-west-2a",
-  tags: { Name: "connection-private-subnet-1" },
-});
-
-const privateSubnet2 = new aws.ec2.Subnet("connection-private-subnet-2", {
-  vpcId: vpc.id,
-  cidrBlock: "10.0.4.0/24",
-  availabilityZone: "us-west-2b",
-  tags: { Name: "connection-private-subnet-2" },
-});
-
-// Create route tables
-const publicRouteTable = new aws.ec2.RouteTable("public-route-table", {
-  vpcId: vpc.id,
-  routes: [
-    {
-      cidrBlock: "0.0.0.0/0",
-      gatewayId: internetGateway.id,
-    },
-  ],
-  tags: { Name: "public-route-table" },
-});
-
-const privateRouteTable1 = new aws.ec2.RouteTable("private-route-table-1", {
-  vpcId: vpc.id,
-  routes: [
-    {
-      cidrBlock: "0.0.0.0/0",
-      natGatewayId: natGateway1.id,
-    },
-  ],
-  tags: { Name: "private-route-table-1" },
-});
-
-const privateRouteTable2 = new aws.ec2.RouteTable("private-route-table-2", {
-  vpcId: vpc.id,
-  routes: [
-    {
-      cidrBlock: "0.0.0.0/0",
-      natGatewayId: natGateway2.id,
-    },
-  ],
-  tags: { Name: "private-route-table-2" },
-});
-
-// Associate subnets with route tables
-new aws.ec2.RouteTableAssociation("public-route-table-association-1", {
-  subnetId: publicSubnet1.id,
-  routeTableId: publicRouteTable.id,
-});
-
-new aws.ec2.RouteTableAssociation("public-route-table-association-2", {
-  subnetId: publicSubnet2.id,
-  routeTableId: publicRouteTable.id,
-});
-
-new aws.ec2.RouteTableAssociation("private-route-table-association-1", {
-  subnetId: privateSubnet1.id,
-  routeTableId: privateRouteTable1.id,
-});
-
-new aws.ec2.RouteTableAssociation("private-route-table-association-2", {
-  subnetId: privateSubnet2.id,
-  routeTableId: privateRouteTable2.id,
-});
-
-// Create a Security Group for the Connection NLB
-export const connectionNlbSecurityGroup = new aws.ec2.SecurityGroup(
-  "connection-nlb-security-group-1",
-  {
-    vpcId: vpc.id,
-    ingress: [
-      {
-        protocol: "tcp",
-        fromPort: 443,
-        toPort: 443,
-        cidrBlocks: ["0.0.0.0/0"],
-      },
-    ],
-    egress: [
-      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
-    ],
-  }
-);
-
-// Create a Security Group for the Multiplayer EC2 instance
-export const connectionEc2SecurityGroup = new aws.ec2.SecurityGroup(
-  "connection-sg-1",
-  {
-    vpcId: vpc.id,
-    ingress: [
-      {
-        protocol: "tcp",
-        fromPort: 80,
-        toPort: 80,
-        securityGroups: [connectionNlbSecurityGroup.id],
-      },
-    ],
-    egress: [
-      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
-    ],
-  }
-);
-
-if (isPreviewEnvironment)
-  new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
-    type: "ingress",
-    fromPort: 22,
-    toPort: 22,
-    protocol: "tcp",
-    cidrBlocks: ["0.0.0.0/0"],
-    securityGroupId: connectionEc2SecurityGroup.id,
-  });
-
 // Create an Auto Scaling Group
 const launchConfiguration = new aws.ec2.LaunchConfiguration("connection-lc", {
   instanceType: "t2.micro",
   iamInstanceProfile: instanceProfileIAMContainerRegistry,
   imageId: latestAmazonLinuxAmi.id,
   securityGroups: [connectionEc2SecurityGroup.id],
-  userData: natEip1.publicIp.apply((publicIp1) =>
-    natEip2.publicIp.apply((publicIp2) =>
+  userData: connectionEip1.publicIp.apply((publicIp1) =>
+    connectionEip2.publicIp.apply((publicIp2) =>
       runDockerImageBashScript(
         connectionECRName,
         dockerImageTag,
@@ -215,15 +55,24 @@ const targetGroup = new aws.lb.TargetGroup("connection-nlb-tg", {
   port: 80,
   protocol: "TCP",
   targetType: "instance",
-  vpcId: vpc.id,
+  vpcId: connectionVPC.id,
 });
 
+// Calculate the number of instances to launch
+let minSize = 2;
+let maxSize = 5;
+let desiredCapacity = 2;
+if (isPreviewEnvironment) minSize = maxSize = desiredCapacity = 1;
+
 const autoScalingGroup = new aws.autoscaling.Group("connection-asg", {
-  vpcZoneIdentifiers: [privateSubnet1.id, privateSubnet2.id],
+  vpcZoneIdentifiers: [
+    connectionPrivateSubnet1.id,
+    connectionPrivateSubnet2.id,
+  ],
   launchConfiguration: launchConfiguration.id,
-  minSize: 2,
-  maxSize: 4,
-  desiredCapacity: 2,
+  minSize,
+  maxSize,
+  desiredCapacity,
   tags: [
     {
       key: "Name",
@@ -238,7 +87,7 @@ const autoScalingGroup = new aws.autoscaling.Group("connection-asg", {
 const nlb = new aws.lb.LoadBalancer("connection-nlb", {
   internal: false,
   loadBalancerType: "network",
-  subnets: [publicSubnet1.id, publicSubnet2.id],
+  subnets: [connectionPublicSubnet1.id, connectionPublicSubnet2.id],
   enableCrossZoneLoadBalancing: true,
   securityGroups: [connectionNlbSecurityGroup.id],
 });

--- a/infra/connection/connection.ts
+++ b/infra/connection/connection.ts
@@ -1,6 +1,7 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
+import { isPreviewEnvironment } from "../helpers/isPreviewEnvironment";
 import { latestAmazonLinuxAmi } from "../helpers/latestAmazonAmi";
 import { runDockerImageBashScript } from "../helpers/runDockerImageBashScript";
 import { instanceProfileIAMContainerRegistry } from "../shared/instanceProfileIAMContainerRegistry";
@@ -61,6 +62,16 @@ export const connectionEc2SecurityGroup = new aws.ec2.SecurityGroup(
     ],
   }
 );
+
+if (isPreviewEnvironment)
+  new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
+    type: "ingress",
+    fromPort: 22,
+    toPort: 22,
+    protocol: "tcp",
+    cidrBlocks: ["0.0.0.0/0"],
+    securityGroupId: connectionEc2SecurityGroup.id,
+  });
 
 // Create Subnets
 const subnet1 = new aws.ec2.Subnet("connection-subnet-1", {

--- a/infra/connection/connection.ts
+++ b/infra/connection/connection.ts
@@ -115,22 +115,48 @@ const natGateway2 = new aws.ec2.NatGateway("connection-nat-gateway-2", {
   tags: { Name: "connection-nat-gateway-2" },
 });
 
-// Create a Route Table
-const routeTable = new aws.ec2.RouteTable("connection-route-table", {
-  vpcId: vpc.id,
-  routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: internetGateway.id }],
-  tags: { Name: "connection-route-table" },
-});
+// Create Route Tables
+const publicRouteTable = new aws.ec2.RouteTable(
+  "connection-public-route-table",
+  {
+    vpcId: vpc.id,
+    routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: internetGateway.id }],
+    tags: { Name: "connection-public-route-table" },
+  }
+);
 
-// Associate Subnets with Route Table
-new aws.ec2.RouteTableAssociation("connection-subnet-1-association", {
+const privateRouteTable1 = new aws.ec2.RouteTable(
+  "connection-private-route-table-1",
+  {
+    vpcId: vpc.id,
+    routes: [{ cidrBlock: "0.0.0.0/0", natGatewayId: natGateway1.id }],
+    tags: { Name: "connection-private-route-table-1" },
+  }
+);
+
+const privateRouteTable2 = new aws.ec2.RouteTable(
+  "connection-private-route-table-2",
+  {
+    vpcId: vpc.id,
+    routes: [{ cidrBlock: "0.0.0.0/0", natGatewayId: natGateway2.id }],
+    tags: { Name: "connection-private-route-table-2" },
+  }
+);
+
+// Associate Subnets with Route Tables
+new aws.ec2.RouteTableAssociation("connection-public-subnet-1-association", {
   subnetId: subnet1.id,
-  routeTableId: routeTable.id,
+  routeTableId: publicRouteTable.id,
 });
 
-new aws.ec2.RouteTableAssociation("connection-subnet-2-association", {
+new aws.ec2.RouteTableAssociation("connection-private-subnet-1-association", {
+  subnetId: subnet1.id,
+  routeTableId: privateRouteTable1.id,
+});
+
+new aws.ec2.RouteTableAssociation("connection-private-subnet-2-association", {
   subnetId: subnet2.id,
-  routeTableId: routeTable.id,
+  routeTableId: privateRouteTable2.id,
 });
 
 // Create an Auto Scaling Group

--- a/infra/connection/connection_network.ts
+++ b/infra/connection/connection_network.ts
@@ -1,0 +1,186 @@
+import * as aws from "@pulumi/aws";
+
+import { isPreviewEnvironment } from "../helpers/isPreviewEnvironment";
+
+// Create a new VPC
+export const connectionVPC = new aws.ec2.Vpc("connection-vpc", {
+  cidrBlock: "10.0.0.0/16",
+  enableDnsSupport: true,
+  enableDnsHostnames: true,
+  tags: { Name: "connection-vpc" },
+});
+
+// Create an Internet Gateway
+const internetGateway = new aws.ec2.InternetGateway("connection-igw", {
+  vpcId: connectionVPC.id,
+  tags: { Name: "connection-igw" },
+});
+
+// Create Elastic IPs
+export const connectionEip1 = new aws.ec2.Eip("nat-eip-1", {
+  vpc: true,
+});
+
+export const connectionEip2 = new aws.ec2.Eip("nat-eip-2", {
+  vpc: true,
+});
+
+// Create public subnets
+export const connectionPublicSubnet1 = new aws.ec2.Subnet(
+  "connection-public-subnet-1",
+  {
+    vpcId: connectionVPC.id,
+    cidrBlock: "10.0.1.0/24",
+    availabilityZone: "us-west-2a",
+    mapPublicIpOnLaunch: true,
+    tags: { Name: "connection-public-subnet-1" },
+  }
+);
+
+export const connectionPublicSubnet2 = new aws.ec2.Subnet(
+  "connection-public-subnet-2",
+  {
+    vpcId: connectionVPC.id,
+    cidrBlock: "10.0.2.0/24",
+    availabilityZone: "us-west-2b",
+    mapPublicIpOnLaunch: true,
+    tags: { Name: "connection-public-subnet-2" },
+  }
+);
+
+// Create a NAT Gateway in each public subnet
+const natGateway1 = new aws.ec2.NatGateway("nat-gateway-1", {
+  allocationId: connectionEip1.id,
+  subnetId: connectionPublicSubnet1.id,
+  tags: { Name: "nat-gateway-1" },
+});
+
+const natGateway2 = new aws.ec2.NatGateway("nat-gateway-2", {
+  allocationId: connectionEip2.id,
+  subnetId: connectionPublicSubnet2.id,
+  tags: { Name: "nat-gateway-2" },
+});
+
+// Create private subnets
+export const connectionPrivateSubnet1 = new aws.ec2.Subnet(
+  "connection-private-subnet-1",
+  {
+    vpcId: connectionVPC.id,
+    cidrBlock: "10.0.3.0/24",
+    availabilityZone: "us-west-2a",
+    tags: { Name: "connection-private-subnet-1" },
+  }
+);
+
+export const connectionPrivateSubnet2 = new aws.ec2.Subnet(
+  "connection-private-subnet-2",
+  {
+    vpcId: connectionVPC.id,
+    cidrBlock: "10.0.4.0/24",
+    availabilityZone: "us-west-2b",
+    tags: { Name: "connection-private-subnet-2" },
+  }
+);
+
+// Create route tables
+const publicRouteTable = new aws.ec2.RouteTable("public-route-table", {
+  vpcId: connectionVPC.id,
+  routes: [
+    {
+      cidrBlock: "0.0.0.0/0",
+      gatewayId: internetGateway.id,
+    },
+  ],
+  tags: { Name: "public-route-table" },
+});
+
+const privateRouteTable1 = new aws.ec2.RouteTable("private-route-table-1", {
+  vpcId: connectionVPC.id,
+  routes: [
+    {
+      cidrBlock: "0.0.0.0/0",
+      natGatewayId: natGateway1.id,
+    },
+  ],
+  tags: { Name: "private-route-table-1" },
+});
+
+const privateRouteTable2 = new aws.ec2.RouteTable("private-route-table-2", {
+  vpcId: connectionVPC.id,
+  routes: [
+    {
+      cidrBlock: "0.0.0.0/0",
+      natGatewayId: natGateway2.id,
+    },
+  ],
+  tags: { Name: "private-route-table-2" },
+});
+
+// Associate subnets with route tables
+new aws.ec2.RouteTableAssociation("public-route-table-association-1", {
+  subnetId: connectionPublicSubnet1.id,
+  routeTableId: publicRouteTable.id,
+});
+
+new aws.ec2.RouteTableAssociation("public-route-table-association-2", {
+  subnetId: connectionPublicSubnet2.id,
+  routeTableId: publicRouteTable.id,
+});
+
+new aws.ec2.RouteTableAssociation("private-route-table-association-1", {
+  subnetId: connectionPrivateSubnet1.id,
+  routeTableId: privateRouteTable1.id,
+});
+
+new aws.ec2.RouteTableAssociation("private-route-table-association-2", {
+  subnetId: connectionPrivateSubnet2.id,
+  routeTableId: privateRouteTable2.id,
+});
+
+// Create a Security Group for the Connection NLB
+export const connectionNlbSecurityGroup = new aws.ec2.SecurityGroup(
+  "connection-nlb-security-group-1",
+  {
+    vpcId: connectionVPC.id,
+    ingress: [
+      {
+        protocol: "tcp",
+        fromPort: 443,
+        toPort: 443,
+        cidrBlocks: ["0.0.0.0/0"],
+      },
+    ],
+    egress: [
+      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+  }
+);
+
+// Create a Security Group for the Multiplayer EC2 instance
+export const connectionEc2SecurityGroup = new aws.ec2.SecurityGroup(
+  "connection-sg-1",
+  {
+    vpcId: connectionVPC.id,
+    ingress: [
+      {
+        protocol: "tcp",
+        fromPort: 80,
+        toPort: 80,
+        securityGroups: [connectionNlbSecurityGroup.id],
+      },
+    ],
+    egress: [
+      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+  }
+);
+
+if (isPreviewEnvironment)
+  new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
+    type: "ingress",
+    fromPort: 22,
+    toPort: 22,
+    protocol: "tcp",
+    cidrBlocks: ["0.0.0.0/0"],
+    securityGroupId: connectionEc2SecurityGroup.id,
+  });

--- a/infra/shared/securityGroups.ts
+++ b/infra/shared/securityGroups.ts
@@ -85,12 +85,4 @@ if (isPreviewEnvironment) {
     cidrBlocks: ["0.0.0.0/0"],
     securityGroupId: multiplayerEc2SecurityGroup.id,
   });
-  // new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
-  //   type: "ingress",
-  //   fromPort: 22,
-  //   toPort: 22,
-  //   protocol: "tcp",
-  //   cidrBlocks: ["0.0.0.0/0"],
-  //   securityGroupId: connectionEc2SecurityGroup.id,
-  // });
 }

--- a/infra/shared/securityGroups.ts
+++ b/infra/shared/securityGroups.ts
@@ -67,42 +67,6 @@ export const redisSecurityGroup = new aws.ec2.SecurityGroup("redis-sg", {
   ],
 });
 
-// Create a Security Group for the Connection NLB
-export const connectionNlbSecurityGroup = new aws.ec2.SecurityGroup(
-  "connection-nlb-security-group",
-  {
-    ingress: [
-      {
-        protocol: "tcp",
-        fromPort: 443,
-        toPort: 443,
-        cidrBlocks: ["0.0.0.0/0"],
-      },
-    ],
-    egress: [
-      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
-    ],
-  }
-);
-
-// Create a Security Group for the Multiplayer EC2 instance
-export const connectionEc2SecurityGroup = new aws.ec2.SecurityGroup(
-  "connection-sg",
-  {
-    ingress: [
-      {
-        protocol: "tcp",
-        fromPort: 80,
-        toPort: 80,
-        securityGroups: [connectionNlbSecurityGroup.id],
-      },
-    ],
-    egress: [
-      { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
-    ],
-  }
-);
-
 // Allow SSH traffic to the Preview Instances
 if (isPreviewEnvironment) {
   new aws.ec2.SecurityGroupRule(`files-ssh-ingress-rule`, {
@@ -121,12 +85,12 @@ if (isPreviewEnvironment) {
     cidrBlocks: ["0.0.0.0/0"],
     securityGroupId: multiplayerEc2SecurityGroup.id,
   });
-  new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
-    type: "ingress",
-    fromPort: 22,
-    toPort: 22,
-    protocol: "tcp",
-    cidrBlocks: ["0.0.0.0/0"],
-    securityGroupId: connectionEc2SecurityGroup.id,
-  });
+  // new aws.ec2.SecurityGroupRule(`connection-ssh-ingress-rule`, {
+  //   type: "ingress",
+  //   fromPort: 22,
+  //   toPort: 22,
+  //   protocol: "tcp",
+  //   cidrBlocks: ["0.0.0.0/0"],
+  //   securityGroupId: connectionEc2SecurityGroup.id,
+  // });
 }


### PR DESCRIPTION
- Scaling connection service via autoscaling group
- All outbound connections are made via NAT with 2 static IPs
- Instances are closed to inbound traffic except via ELB with SSL termination
- Uses a new VPC that is not the same as the one with the other services in it (so our connection service can't try to connect to any private redis or postgres datastores)