### PR TITLE
feat: new hierarchy for code editor

### DIFF
--- a/quadratic-client/src/app/ui/components/LanguageIcon.tsx
+++ b/quadratic-client/src/app/ui/components/LanguageIcon.tsx
@@ -10,15 +10,15 @@ interface LanguageIconProps extends SvgIconProps {
 
 export function LanguageIcon({ language, ...props }: LanguageIconProps) {
   return language === 'Python' ? (
-    <Python sx={{ color: colors.languagePython }} {...props} />
+    <Python {...props} sx={{ color: colors.languagePython, ...(props.sx ? props.sx : {}) }} />
   ) : language === 'Formula' ? (
-    <Formula sx={{ color: colors.languageFormula }} {...props} />
+    <Formula {...props} sx={{ color: colors.languageFormula, ...(props.sx ? props.sx : {}) }} />
   ) : language === 'Javascript' ? (
-    <JavaScript className="text-gray-700" sx={{ color: colors.languageJavascript }} />
+    <JavaScript className="text-gray-700" sx={{ color: colors.languageJavascript, ...(props.sx ? props.sx : {}) }} />
   ) : language === 'POSTGRES' ? (
-    <PostgresIcon sx={{ color: colors.languagePostgres }} {...props} />
+    <PostgresIcon {...props} sx={{ color: colors.languagePostgres, ...(props.sx ? props.sx : {}) }} />
   ) : language === 'MYSQL' ? (
-    <MysqlIcon sx={{ color: colors.languageMysql }} {...props} />
+    <MysqlIcon {...props} sx={{ color: colors.languageMysql, ...(props.sx ? props.sx : {}) }} />
   ) : (
     <Subject {...props} />
   );

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditor.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditor.tsx
@@ -15,6 +15,7 @@ import { useJavascriptState } from '@/app/atoms/useJavascriptState';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
 import { getLanguage } from '@/app/helpers/codeCellLanguage';
 import { useCodeEditor } from '@/app/ui/menus/CodeEditor/CodeEditorContext';
+import { CodeEditorToolbar } from '@/app/ui/menus/CodeEditor/CodeEditorToolbar';
 import { CodeEditorPanel } from '@/app/ui/menus/CodeEditor/panels/CodeEditorPanel';
 import { CodeEditorPanels } from '@/app/ui/menus/CodeEditor/panels/CodeEditorPanelsResize';
 import { useCodeEditorPanelData } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
@@ -368,100 +369,103 @@ export const CodeEditor = () => {
 
   return (
     <div
-      id="code-editor-container"
-      className={cn(
-        'relative flex h-full bg-background',
-        codeEditorPanelData.panelPosition === 'left' ? '' : 'flex-col'
-      )}
+      className="relative flex flex-col"
       style={{
         width: `${
           codeEditorPanelData.editorWidth +
           (codeEditorPanelData.panelPosition === 'left' ? codeEditorPanelData.panelWidth : 0)
         }px`,
-        borderLeft: '1px solid black',
+        borderLeft: '1px solid transparent',
       }}
     >
-      <div
-        id="QuadraticCodeEditorID"
-        className={cn(
-          'flex min-h-0 shrink select-none flex-col',
-          codeEditorPanelData.panelPosition === 'left' ? 'order-2' : 'order-1'
-        )}
-        style={{
-          width: `${codeEditorPanelData.editorWidth}px`,
-          height:
-            codeEditorPanelData.panelPosition === 'left' || codeEditorPanelData.bottomHidden
-              ? '100%'
-              : `${codeEditorPanelData.editorHeightPercentage}%`,
-        }}
-        onKeyDownCapture={onKeyDownEditor}
-        onPointerEnter={() => {
-          // todo: handle multiplayer code editor here
-          multiplayer.sendMouseMove();
-        }}
-      >
-        {showSaveChangesAlert && (
-          <SaveChangesAlert
-            onCancel={() => {
-              setShowSaveChangesAlert(!showSaveChangesAlert);
-              setEditorInteractionState((old) => ({
-                ...old,
-                editorEscapePressed: false,
-                waitingForEditorClose: undefined,
-              }));
-            }}
-            onSave={() => {
-              saveAndRunCell();
-              afterDialog();
-            }}
-            onDiscard={() => {
-              afterDialog();
-            }}
-          />
-        )}
-
-        <CodeEditorHeader
+      <div className="border-b border-border">
+        <CodeEditorToolbar
           cellLocation={cellLocation}
           unsaved={unsaved}
-          saveAndRunCell={saveAndRunCell}
-          cancelRun={cancelRun}
           closeEditor={() => closeEditor(false)}
+          codeEditorPanelData={codeEditorPanelData}
         />
-        <CodeEditorBody
-          editorContent={editorContent}
-          setEditorContent={setEditorContent}
-          closeEditor={closeEditor}
-          evaluationResult={evaluationResult}
-          cellsAccessed={!unsaved ? cellsAccessed : []}
-          cellLocation={cellLocation}
-        />
-        {editorInteractionState.mode !== 'Formula' && showReturnType && (
-          <ReturnTypeInspector
-            language={editorInteractionState.mode}
-            evaluationResult={evaluationResult}
-            show={showReturnType}
-          />
-        )}
       </div>
-
       <div
-        className={cn(
-          codeEditorPanelData.panelPosition === 'left' ? 'order-1' : 'order-2',
-          'relative flex flex-col bg-background'
-        )}
-        style={{
-          width: codeEditorPanelData.panelPosition === 'left' ? `${codeEditorPanelData.panelWidth}px` : '100%',
-          height:
-            codeEditorPanelData.panelPosition === 'left'
-              ? '100%'
-              : codeEditorPanelData.bottomHidden
-              ? 'auto'
-              : 100 - codeEditorPanelData.editorHeightPercentage + '%',
-        }}
+        id="code-editor-container"
+        className={cn('flex h-full bg-background', codeEditorPanelData.panelPosition === 'left' ? '' : 'flex-col')}
       >
-        <CodeEditorPanel codeEditorPanelData={codeEditorPanelData} />
+        <div
+          id="QuadraticCodeEditorID"
+          className={cn(
+            'flex min-h-0 shrink select-none flex-col',
+            codeEditorPanelData.panelPosition === 'left' ? 'order-2' : 'order-1'
+          )}
+          style={{
+            width: `${codeEditorPanelData.editorWidth}px`,
+            height:
+              codeEditorPanelData.panelPosition === 'left' || codeEditorPanelData.bottomHidden
+                ? '100%'
+                : `${codeEditorPanelData.editorHeightPercentage}%`,
+          }}
+          onKeyDownCapture={onKeyDownEditor}
+          onPointerEnter={() => {
+            // todo: handle multiplayer code editor here
+            multiplayer.sendMouseMove();
+          }}
+        >
+          {showSaveChangesAlert && (
+            <SaveChangesAlert
+              onCancel={() => {
+                setShowSaveChangesAlert(!showSaveChangesAlert);
+                setEditorInteractionState((old) => ({
+                  ...old,
+                  editorEscapePressed: false,
+                  waitingForEditorClose: undefined,
+                }));
+              }}
+              onSave={() => {
+                saveAndRunCell();
+                afterDialog();
+              }}
+              onDiscard={() => {
+                afterDialog();
+              }}
+            />
+          )}
+
+          <CodeEditorHeader cancelRun={cancelRun} cellLocation={cellLocation} saveAndRunCell={saveAndRunCell} />
+          <CodeEditorBody
+            editorContent={editorContent}
+            setEditorContent={setEditorContent}
+            closeEditor={closeEditor}
+            evaluationResult={evaluationResult}
+            cellsAccessed={!unsaved ? cellsAccessed : []}
+            cellLocation={cellLocation}
+          />
+          {editorInteractionState.mode !== 'Formula' && showReturnType && (
+            <ReturnTypeInspector
+              language={editorInteractionState.mode}
+              evaluationResult={evaluationResult}
+              show={showReturnType}
+            />
+          )}
+        </div>
+
+        <div
+          className={cn(
+            codeEditorPanelData.panelPosition === 'left' ? 'order-1' : 'order-2',
+            'relative flex flex-col bg-background'
+          )}
+          style={{
+            width: codeEditorPanelData.panelPosition === 'left' ? `${codeEditorPanelData.panelWidth}px` : '100%',
+            height:
+              codeEditorPanelData.panelPosition === 'left'
+                ? '100%'
+                : codeEditorPanelData.bottomHidden
+                ? 'auto'
+                : 100 - codeEditorPanelData.editorHeightPercentage + '%',
+          }}
+        >
+          <CodeEditorPanel codeEditorPanelData={codeEditorPanelData} />
+        </div>
+        <CodeEditorPanels codeEditorPanelData={codeEditorPanelData} />
       </div>
-      <CodeEditorPanels codeEditorPanelData={codeEditorPanelData} />
     </div>
   );
 };

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -1,19 +1,15 @@
 import { events } from '@/app/events/events';
 import { sheets } from '@/app/grid/controller/Sheets';
 import { SheetPosTS } from '@/app/gridGL/types/size';
-import { codeCellIsAConnection, getCodeCell, getConnectionUuid, getLanguage } from '@/app/helpers/codeCellLanguage';
-import { LanguageIcon } from '@/app/ui/components/LanguageIcon';
+import { codeCellIsAConnection, getLanguage } from '@/app/helpers/codeCellLanguage';
 import { CodeEditorRefButton } from '@/app/ui/menus/CodeEditor/CodeEditorRefButton';
 import type { CodeRun } from '@/app/web-workers/CodeRun';
 import { LanguageState } from '@/app/web-workers/languageTypes';
 import { MultiplayerUser } from '@/app/web-workers/multiplayerWebWorker/multiplayerTypes';
-import { GetConnections } from '@/routes/api.connections';
 import { useFileRouteLoaderData } from '@/routes/file.$uuid';
-import { cn } from '@/shared/shadcn/utils';
-import { Close, PlayArrow, Stop } from '@mui/icons-material';
+import { PlayArrow, Stop } from '@mui/icons-material';
 import { CircularProgress, IconButton } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { useFetcher } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { hasPermissionToEditFile } from '../../../actions';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
@@ -23,49 +19,23 @@ import { SnippetsPopover } from './SnippetsPopover';
 
 interface Props {
   cellLocation: SheetPosTS | undefined;
-  unsaved: boolean;
-
   saveAndRunCell: () => void;
   cancelRun: () => void;
-  closeEditor: () => void;
 }
 
 export const CodeEditorHeader = (props: Props) => {
-  const { cellLocation, unsaved, saveAndRunCell, cancelRun, closeEditor } = props;
+  const { cellLocation, saveAndRunCell, cancelRun } = props;
   const {
     userMakingRequest: { teamPermissions },
   } = useFileRouteLoaderData();
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
-  const [currentSheetId, setCurrentSheetId] = useState<string>(sheets.sheet.id);
+
   const isConnection = codeCellIsAConnection(editorInteractionState.mode);
   const hasPermission =
     hasPermissionToEditFile(editorInteractionState.permissions) &&
     (isConnection ? teamPermissions?.includes('TEAM_EDIT') : true);
-  const codeCell = getCodeCell(editorInteractionState.mode);
-  const connectionsFetcher = useFetcher<GetConnections>({ key: 'CONNECTIONS_FETCHER_KEY' });
+
   const language = getLanguage(editorInteractionState.mode);
-
-  // Get the connection name (it's possible the user won't have access to it
-  // because they're in a file they have access to but not the team — or
-  // the connection was deleted)
-  let currentConnectionName = '';
-  if (connectionsFetcher.data) {
-    const connectionUuid = getConnectionUuid(editorInteractionState.mode);
-    const foundConnection = connectionsFetcher.data.connections.find(({ uuid }) => uuid === connectionUuid);
-    if (foundConnection) currentConnectionName = foundConnection.name;
-  }
-
-  // Keep track of the current sheet ID so we know whether to show the sheet name or not
-  const currentCodeEditorCellIsNotInActiveSheet = currentSheetId !== editorInteractionState.selectedCellSheet;
-  const currentSheetNameOfActiveCodeEditorCell = sheets.getById(editorInteractionState.selectedCellSheet)?.name;
-  useEffect(() => {
-    const updateSheetName = () => setCurrentSheetId(sheets.sheet.id);
-    events.on('changeSheet', updateSheetName);
-    return () => {
-      events.off('changeSheet', updateSheetName);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // show when this cell is already in the execution queue
   const [isRunningComputation, setIsRunningComputation] = useState<false | 'multiplayer' | 'player'>(false);
@@ -138,34 +108,9 @@ export const CodeEditorHeader = (props: Props) => {
     };
   }, [cellLocation]);
 
-  if (!cellLocation) return null;
-
   return (
-    <div className="flex items-center px-3 py-1">
-      <div
-        className={cn(
-          `relative`,
-          unsaved &&
-            `after:pointer-events-none after:absolute after:-bottom-0.5 after:-right-0.5 after:h-3 after:w-3 after:rounded-full after:border-2 after:border-solid after:border-background after:bg-gray-400 after:content-['']`
-        )}
-      >
-        <TooltipHint title={`${codeCell?.label}${unsaved ? ' · Unsaved changes' : ''}`} placement="bottom">
-          <div className="flex items-center">
-            <LanguageIcon language={codeCell?.id} fontSize="small" />
-          </div>
-        </TooltipHint>
-      </div>
-      <div className="mx-2 flex flex-col truncate">
-        <div className="text-sm font-medium leading-4">
-          Cell ({cellLocation.x}, {cellLocation.y})
-          {currentCodeEditorCellIsNotInActiveSheet && (
-            <span className="ml-1 min-w-0 truncate">- {currentSheetNameOfActiveCodeEditorCell}</span>
-          )}
-        </div>
-        {currentConnectionName && (
-          <div className="text-xs leading-4 text-muted-foreground">Connection: {currentConnectionName}</div>
-        )}
-      </div>
+    <div className="flex items-center px-2 py-1">
+      <div className="ml-1 flex flex-col text-sm font-medium leading-4">Code</div>
       <div className="ml-auto flex flex-shrink-0 items-center gap-2">
         {isRunningComputation && (
           <TooltipHint title={`${language} executing…`} placement="bottom">
@@ -179,7 +124,7 @@ export const CodeEditorHeader = (props: Props) => {
             <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`} placement="bottom">
               <span>
                 <IconButton id="QuadraticCodeEditorRunButtonID" size="small" color="primary" onClick={saveAndRunCell}>
-                  <PlayArrow />
+                  <PlayArrow fontSize="small" />
                 </IconButton>
               </span>
             </TooltipHint>
@@ -187,16 +132,11 @@ export const CodeEditorHeader = (props: Props) => {
             <TooltipHint title="Cancel execution" shortcut={`${KeyboardSymbols.Command}␛`} placement="bottom">
               <span>
                 <IconButton size="small" color="primary" onClick={cancelRun} disabled={!isRunningComputation}>
-                  <Stop />
+                  <Stop fontSize="small" />
                 </IconButton>
               </span>
             </TooltipHint>
           ))}
-        <TooltipHint title="Close" shortcut="ESC" placement="bottom">
-          <IconButton id="QuadraticCodeEditorCloseButtonID" size="small" onClick={closeEditor}>
-            <Close />
-          </IconButton>
-        </TooltipHint>
       </div>
     </div>
   );

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -7,7 +7,7 @@ import type { CodeRun } from '@/app/web-workers/CodeRun';
 import { LanguageState } from '@/app/web-workers/languageTypes';
 import { MultiplayerUser } from '@/app/web-workers/multiplayerWebWorker/multiplayerTypes';
 import { useFileRouteLoaderData } from '@/routes/file.$uuid';
-import { PlayArrow, Stop } from '@mui/icons-material';
+import { PlayCircleFilled, StopCircleOutlined } from '@mui/icons-material';
 import { CircularProgress, IconButton } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -122,19 +122,27 @@ export const CodeEditorHeader = (props: Props) => {
         {hasPermission &&
           (!isRunningComputation ? (
             <TooltipHint title="Save & run" shortcut={`${KeyboardSymbols.Command}↵`} placement="bottom">
-              <span>
-                <IconButton id="QuadraticCodeEditorRunButtonID" size="small" color="primary" onClick={saveAndRunCell}>
-                  <PlayArrow fontSize="small" />
-                </IconButton>
-              </span>
+              <IconButton
+                id="QuadraticCodeEditorRunButtonID"
+                size="small"
+                color="primary"
+                onClick={saveAndRunCell}
+                style={{ margin: '0 -1px' }}
+              >
+                <PlayCircleFilled />
+              </IconButton>
             </TooltipHint>
           ) : (
             <TooltipHint title="Cancel execution" shortcut={`${KeyboardSymbols.Command}␛`} placement="bottom">
-              <span>
-                <IconButton size="small" color="primary" onClick={cancelRun} disabled={!isRunningComputation}>
-                  <Stop fontSize="small" />
-                </IconButton>
-              </span>
+              <IconButton
+                size="small"
+                color="primary"
+                onClick={cancelRun}
+                disabled={!isRunningComputation}
+                style={{ margin: '0 -1px' }}
+              >
+                <StopCircleOutlined />
+              </IconButton>
             </TooltipHint>
           ))}
       </div>

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorToolbar.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorToolbar.tsx
@@ -1,0 +1,134 @@
+import { events } from '@/app/events/events';
+import { sheets } from '@/app/grid/controller/Sheets';
+import { SheetPosTS } from '@/app/gridGL/types/size';
+import { getCodeCell, getConnectionUuid } from '@/app/helpers/codeCellLanguage';
+import { LanguageIcon } from '@/app/ui/components/LanguageIcon';
+import { PanelPositionBottomIcon, PanelPositionLeftIcon } from '@/app/ui/icons';
+import { PanelPosition } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
+import { GetConnections } from '@/routes/api.connections';
+import { Circle, Close } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { useFetcher } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
+import { TooltipHint } from '../../components/TooltipHint';
+
+interface Props {
+  cellLocation: SheetPosTS | undefined;
+  unsaved: boolean;
+  closeEditor: () => void;
+  codeEditorPanelData: any; // TODO: fix types
+}
+
+export const CodeEditorToolbar = (props: Props) => {
+  const { cellLocation, unsaved, closeEditor, codeEditorPanelData } = props;
+  const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
+  const [currentSheetId, setCurrentSheetId] = useState<string>(sheets.sheet.id);
+  const codeCell = getCodeCell(editorInteractionState.mode);
+  const connectionsFetcher = useFetcher<GetConnections>({ key: 'CONNECTIONS_FETCHER_KEY' });
+
+  // Get the connection name (it's possible the user won't have access to it
+  // because they're in a file they have access to but not the team — or
+  // the connection was deleted)
+  let currentConnectionName = '';
+  if (connectionsFetcher.data) {
+    const connectionUuid = getConnectionUuid(editorInteractionState.mode);
+    const foundConnection = connectionsFetcher.data.connections.find(({ uuid }) => uuid === connectionUuid);
+    if (foundConnection) currentConnectionName = foundConnection.name;
+  }
+
+  // Keep track of the current sheet ID so we know whether to show the sheet name or not
+  const currentCodeEditorCellIsNotInActiveSheet = currentSheetId !== editorInteractionState.selectedCellSheet;
+  const currentSheetNameOfActiveCodeEditorCell = sheets.getById(editorInteractionState.selectedCellSheet)?.name;
+  useEffect(() => {
+    const updateSheetName = () => setCurrentSheetId(sheets.sheet.id);
+    events.on('changeSheet', updateSheetName);
+    return () => {
+      events.off('changeSheet', updateSheetName);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const { panelPosition, setPanelPosition } = codeEditorPanelData;
+
+  const changePanelPosition = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      setPanelPosition((prev: PanelPosition) => (prev === 'left' ? 'bottom' : 'left'));
+      e.currentTarget.blur();
+    },
+    [setPanelPosition]
+  );
+
+  if (!cellLocation) return null;
+
+  return (
+    <div className="flex items-center px-2 py-1">
+      <div className={`relative`}>
+        <TooltipHint title={String(codeCell?.label)} placement="bottom">
+          <div className="flex items-center">
+            <LanguageIcon language={codeCell?.id} fontSize="small" />
+          </div>
+        </TooltipHint>
+      </div>
+      <div className="mx-2 flex flex-col truncate">
+        <div className="text-sm font-medium leading-4">
+          Cell ({cellLocation.x}, {cellLocation.y})
+          {currentCodeEditorCellIsNotInActiveSheet && (
+            <span className="ml-1 min-w-0 truncate">- {currentSheetNameOfActiveCodeEditorCell}</span>
+          )}
+        </div>
+        {currentConnectionName && (
+          <div className="text-xs leading-4 text-muted-foreground">Connection: {currentConnectionName}</div>
+        )}
+      </div>
+      <div className="ml-auto flex flex-shrink-0 items-center gap-2">
+        <TooltipHint title={panelPosition === 'bottom' ? 'Move panel left' : 'Move panel bottom'}>
+          <IconButton onClick={changePanelPosition} size="small">
+            {panelPosition === 'left' ? (
+              <PanelPositionBottomIcon fontSize="small" />
+            ) : (
+              <PanelPositionLeftIcon fontSize="small" />
+            )}
+          </IconButton>
+        </TooltipHint>
+
+        <TooltipHint title={'Close'} shortcut="ESC" placement="bottom">
+          <IconButton
+            id="QuadraticCodeEditorCloseButtonID"
+            size="small"
+            onClick={closeEditor}
+            sx={{
+              ...(unsaved
+                ? {
+                    '> #btn-close': {
+                      opacity: '0',
+                    },
+                    '&:hover #btn-close': {
+                      opacity: '1',
+                    },
+                    '&:hover #btn-unsaved': {
+                      opacity: '0',
+                    },
+                  }
+                : {}),
+            }}
+          >
+            <Close id="btn-close" fontSize="small" />
+            {unsaved && (
+              <Circle
+                id="btn-unsaved"
+                sx={{
+                  position: 'absolute',
+                  left: '9px',
+                  top: '10px',
+                  fontSize: '12px',
+                }}
+              />
+            )}
+          </IconButton>
+        </TooltipHint>
+      </div>
+    </div>
+  );
+};

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorToolbar.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorToolbar.tsx
@@ -1,15 +1,13 @@
 import { events } from '@/app/events/events';
 import { sheets } from '@/app/grid/controller/Sheets';
 import { SheetPosTS } from '@/app/gridGL/types/size';
-import { getCodeCell, getConnectionUuid } from '@/app/helpers/codeCellLanguage';
+import { getCodeCell } from '@/app/helpers/codeCellLanguage';
 import { LanguageIcon } from '@/app/ui/components/LanguageIcon';
 import { PanelPositionBottomIcon, PanelPositionLeftIcon } from '@/app/ui/icons';
 import { PanelPosition } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
-import { GetConnections } from '@/routes/api.connections';
 import { Circle, Close } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
-import { useFetcher } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { editorInteractionStateAtom } from '../../../atoms/editorInteractionStateAtom';
 import { TooltipHint } from '../../components/TooltipHint';
@@ -26,17 +24,6 @@ export const CodeEditorToolbar = (props: Props) => {
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
   const [currentSheetId, setCurrentSheetId] = useState<string>(sheets.sheet.id);
   const codeCell = getCodeCell(editorInteractionState.mode);
-  const connectionsFetcher = useFetcher<GetConnections>({ key: 'CONNECTIONS_FETCHER_KEY' });
-
-  // Get the connection name (it's possible the user won't have access to it
-  // because they're in a file they have access to but not the team — or
-  // the connection was deleted)
-  let currentConnectionName = '';
-  if (connectionsFetcher.data) {
-    const connectionUuid = getConnectionUuid(editorInteractionState.mode);
-    const foundConnection = connectionsFetcher.data.connections.find(({ uuid }) => uuid === connectionUuid);
-    if (foundConnection) currentConnectionName = foundConnection.name;
-  }
 
   // Keep track of the current sheet ID so we know whether to show the sheet name or not
   const currentCodeEditorCellIsNotInActiveSheet = currentSheetId !== editorInteractionState.selectedCellSheet;
@@ -63,36 +50,27 @@ export const CodeEditorToolbar = (props: Props) => {
   if (!cellLocation) return null;
 
   return (
-    <div className="flex items-center px-2 py-1">
-      <div className={`relative`}>
-        <TooltipHint title={String(codeCell?.label)} placement="bottom">
-          <div className="flex items-center">
-            <LanguageIcon language={codeCell?.id} fontSize="small" />
+    <div className="flex h-10 items-stretch pr-2">
+      <div
+        className={
+          'relative flex items-center gap-2 border-r border-border pl-2 pr-1 after:absolute after:-bottom-[1px] after:left-0 after:h-[1px] after:w-full after:bg-background after:content-[""]'
+        }
+      >
+        <div className={'flex items-stretch gap-2'}>
+          <TooltipHint title={String(codeCell?.label)} placement="bottom">
+            <div className="flex items-center">
+              <LanguageIcon language={codeCell?.id} sx={{ fontSize: '16px' }} />
+            </div>
+          </TooltipHint>
+          <div className="flex items-center truncate">
+            <div className="text-sm leading-4">
+              Cell ({cellLocation.x}, {cellLocation.y})
+              {currentCodeEditorCellIsNotInActiveSheet && (
+                <span className="ml-1 min-w-0 truncate">- {currentSheetNameOfActiveCodeEditorCell}</span>
+              )}
+            </div>
           </div>
-        </TooltipHint>
-      </div>
-      <div className="mx-2 flex flex-col truncate">
-        <div className="text-sm font-medium leading-4">
-          Cell ({cellLocation.x}, {cellLocation.y})
-          {currentCodeEditorCellIsNotInActiveSheet && (
-            <span className="ml-1 min-w-0 truncate">- {currentSheetNameOfActiveCodeEditorCell}</span>
-          )}
         </div>
-        {currentConnectionName && (
-          <div className="text-xs leading-4 text-muted-foreground">Connection: {currentConnectionName}</div>
-        )}
-      </div>
-      <div className="ml-auto flex flex-shrink-0 items-center gap-2">
-        <TooltipHint title={panelPosition === 'bottom' ? 'Move panel left' : 'Move panel bottom'}>
-          <IconButton onClick={changePanelPosition} size="small">
-            {panelPosition === 'left' ? (
-              <PanelPositionBottomIcon fontSize="small" />
-            ) : (
-              <PanelPositionLeftIcon fontSize="small" />
-            )}
-          </IconButton>
-        </TooltipHint>
-
         <TooltipHint title={'Close'} shortcut="ESC" placement="bottom">
           <IconButton
             id="QuadraticCodeEditorCloseButtonID"
@@ -114,7 +92,7 @@ export const CodeEditorToolbar = (props: Props) => {
                 : {}),
             }}
           >
-            <Close id="btn-close" fontSize="small" />
+            <Close id="btn-close" fontSize="small" sx={{ fontSize: '15px' }} />
             {unsaved && (
               <Circle
                 id="btn-unsaved"
@@ -125,6 +103,17 @@ export const CodeEditorToolbar = (props: Props) => {
                   fontSize: '12px',
                 }}
               />
+            )}
+          </IconButton>
+        </TooltipHint>
+      </div>
+      <div className="ml-auto flex flex-shrink-0 items-center gap-2">
+        <TooltipHint title={panelPosition === 'bottom' ? 'Move panel left' : 'Move panel bottom'}>
+          <IconButton onClick={changePanelPosition} size="small">
+            {panelPosition === 'left' ? (
+              <PanelPositionBottomIcon fontSize="small" />
+            ) : (
+              <PanelPositionLeftIcon fontSize="small" />
             )}
           </IconButton>
         </TooltipHint>

--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanel.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanel.tsx
@@ -1,13 +1,9 @@
 import { editorInteractionStateAtom } from '@/app/atoms/editorInteractionStateAtom';
 import { codeCellIsAConnection } from '@/app/helpers/codeCellLanguage';
-import { TooltipHint } from '@/app/ui/components/TooltipHint';
-import { PanelPositionBottomIcon, PanelPositionLeftIcon } from '@/app/ui/icons';
-import { CodeEditorPanelData, PanelPosition } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
+import { CodeEditorPanelData } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { useFileRouteLoaderData } from '@/routes/file.$uuid';
-import { cn } from '@/shared/shadcn/utils';
-import { IconButton } from '@mui/material';
-import { MouseEvent, memo, useCallback } from 'react';
+import { memo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { CodeEditorPanelBottom } from './CodeEditorPanelBottom';
 import { CodeEditorPanelSide } from './CodeEditorPanelSide';
@@ -24,30 +20,13 @@ export const CodeEditorPanel = memo((props: Props) => {
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
   const isConnection = codeCellIsAConnection(editorInteractionState.mode);
   const { codeEditorPanelData } = props;
-  const { panelPosition, setPanelPosition } = codeEditorPanelData;
-
-  const changePanelPosition = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      setPanelPosition((prev: PanelPosition) => (prev === 'left' ? 'bottom' : 'left'));
-      e.currentTarget.blur();
-    },
-    [setPanelPosition]
-  );
+  const { panelPosition } = codeEditorPanelData;
 
   const showSchemaViewer = Boolean(isAuthenticated && isConnection && teamPermissions?.includes('TEAM_EDIT'));
   const showAiAssistant = Boolean(isAuthenticated);
 
   return (
     <>
-      {/* Panel position (left/bottom) control */}
-      <div className={cn('absolute z-10', panelPosition === 'bottom' ? 'right-1.5 top-1' : 'right-0.5 top-0.5')}>
-        <TooltipHint title={panelPosition === 'bottom' ? 'Move panel left' : 'Move panel bottom'}>
-          <IconButton onClick={changePanelPosition} size="small">
-            {panelPosition === 'left' ? <PanelPositionBottomIcon /> : <PanelPositionLeftIcon />}
-          </IconButton>
-        </TooltipHint>
-      </div>
-
       {panelPosition === 'left' && (
         <CodeEditorPanelSide
           showSchemaViewer={showSchemaViewer}

--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelsResize.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelsResize.tsx
@@ -40,7 +40,7 @@ export const CodeEditorPanels = memo((props: Props) => {
         <>
           {/* left-to-right: outer edge */}
           <ResizeControl
-            style={{ left: `-1px` }}
+            style={{ left: `-1px`, top: 0 }}
             setState={(mouseEvent) => {
               const offsetFromRight = window.innerWidth - mouseEvent.x;
               const min = MIN_WIDTH_PANEL + MIN_WIDTH_EDITOR;
@@ -86,7 +86,7 @@ export const CodeEditorPanels = memo((props: Props) => {
         <>
           {/* top-to-bottom: editor width */}
           <ResizeControl
-            style={{ left: '-1px' }}
+            style={{ left: '-1px', top: 0 }}
             setState={(mouseEvent) => {
               const offsetFromRight = window.innerWidth - mouseEvent.x;
               const min = MIN_WIDTH_EDITOR;

--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/ResizeControl.css
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/ResizeControl.css
@@ -1,6 +1,6 @@
 /* Shared styles for the 1px line */
 .resize-control {
-  background-color: var(--resize-control-background);
+  background-color: hsl(var(--border));
   z-index: 1;
 }
 

--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/ResizeControl.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/ResizeControl.tsx
@@ -21,7 +21,6 @@ export function ResizeControl({ disabled, setState, position, style }: ResizeCon
         ...style,
         // @ts-expect-error typescript doesn't like us setting CSS custom properties
         '--resize-control-highlight': colors.quadraticPrimary,
-        '--resize-control-background': colors.mediumGray,
       }}
       onMouseDown={(e) => {
         if (disabled) return;


### PR DESCRIPTION
Creates a new hierarchical configuration for the code editor. Makes it look/feel a lot more like VSCode (also opens the door to the option of having multiple tabs "open" in the code editor

![image](https://github.com/user-attachments/assets/6d9e46d0-4445-4c0c-b054-52e88107715d)


**Alternative**: don't make the tab like a cell, instead just make it the whole top bar

![image](https://github.com/user-attachments/assets/295be99c-f58a-4880-ae64-eddd29b989d6)


**Todos**

- [ ] Resizing controls are off because of the new top header. Will need fixing.
