### PR TITLE
Remove cells from selection

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerDown.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerDown.ts
@@ -149,9 +149,7 @@ export class PointerDown {
         const inSelection = this.inSelectionRange(column, row);
         if (inSelection === 'except') {
         } else if (inSelection) {
-          cursor.changeExcept({
-            except:
-          })
+          // cursor.changeExcept({});
         }
         const multiCursor = cursor.multiCursor ?? [new Rectangle(cursorPosition.x, cursorPosition.y, 1, 1)];
         multiCursor.push(new Rectangle(column, row, 1, 1));

--- a/quadratic-client/src/app/quadratic-core-types/index.d.ts
+++ b/quadratic-client/src/app/quadratic-core-types/index.d.ts
@@ -34,7 +34,7 @@ export interface Span { start: number, end: number, }
 export interface SearchOptions { case_sensitive?: boolean, whole_cell?: boolean, search_code?: boolean, sheet_id?: string, }
 export interface SheetPos { x: bigint, y: bigint, sheet_id: SheetId, }
 export interface SheetRect { min: Pos, max: Pos, sheet_id: SheetId, }
-export interface Selection { sheet_id: SheetId, x: bigint, y: bigint, rects: Array<Rect> | null, rows: Array<bigint> | null, columns: Array<bigint> | null, all: boolean, }
+export interface Selection { sheet_id: SheetId, x: bigint, y: bigint, rects: Array<Rect> | null, rows: Array<bigint> | null, columns: Array<bigint> | null, all: boolean, except: Array<Rect> | null, }
 export interface Placement { index: number, position: number, size: number, }
 export interface ColumnRow { column: number, row: number, }
 export interface SheetInfo { sheet_id: string, name: string, order: string, color: string | null, offsets: string, bounds: GridBounds, bounds_without_formatting: GridBounds, }

--- a/quadratic-core/src/controller/operations/formats.rs
+++ b/quadratic-core/src/controller/operations/formats.rs
@@ -27,12 +27,8 @@ mod tests {
         let gc = GridController::test();
         let selection = Selection {
             sheet_id: gc.sheet_ids()[0],
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         };
         let ops = gc.clear_format_selection_operations(&selection);
         assert_eq!(

--- a/quadratic-core/src/controller/thumbnail.rs
+++ b/quadratic-core/src/controller/thumbnail.rs
@@ -124,24 +124,8 @@ mod test {
     fn thumbnail_dirty_selection_all() {
         let gc = GridController::test();
         let sheet_id = gc.sheet_ids()[0];
-        assert!(!gc.thumbnail_dirty_selection(&Selection {
-            sheet_id: SheetId::test(),
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
-            columns: None,
-            all: true,
-        }));
-        assert!(gc.thumbnail_dirty_selection(&Selection {
-            sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
-            columns: None,
-            all: true,
-        }));
+        assert!(!gc.thumbnail_dirty_selection(&Selection::all(SheetId::test())));
+        assert!(gc.thumbnail_dirty_selection(&Selection::all(sheet_id)));
     }
 
     #[test]
@@ -150,41 +134,25 @@ mod test {
         let sheet_id = gc.sheet_ids()[0];
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id: SheetId::test(),
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(vec![0]),
-            all: false,
+            ..Default::default()
         }));
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(vec![0]),
-            all: false,
+            ..Default::default()
         }));
         let sheet = gc.sheet(sheet_id);
         let max_column = sheet.offsets.thumbnail().max.x;
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(vec![max_column]),
-            all: false,
+            ..Default::default()
         }));
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(vec![max_column + 1]),
-            all: false,
+            ..Default::default()
         }));
     }
 
@@ -194,41 +162,25 @@ mod test {
         let sheet_id = gc.sheet_ids()[0];
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id: SheetId::test(),
-            x: 0,
-            y: 0,
-            rects: None,
             rows: Some(vec![0]),
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
             rows: Some(vec![0]),
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         let sheet = gc.sheet(sheet_id);
         let max_row = sheet.offsets.thumbnail().max.y;
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
             rows: Some(vec![max_row]),
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
             rows: Some(vec![max_row + 1]),
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
     }
 
@@ -238,33 +190,23 @@ mod test {
         let sheet_id = gc.sheet_ids()[0];
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id: SheetId::test(),
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect {
                 min: Pos { x: 0, y: 0 },
                 max: Pos { x: 1, y: 1 },
             }]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect {
                 min: Pos { x: 0, y: 0 },
                 max: Pos { x: 1, y: 1 },
             }]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         let sheet = gc.sheet(sheet_id);
         assert!(gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect {
                 min: Pos { x: 0, y: 0 },
                 max: Pos {
@@ -272,14 +214,10 @@ mod test {
                     y: sheet.offsets.thumbnail().max.y
                 },
             }]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect {
                 min: Pos {
                     x: sheet.offsets.thumbnail().max.x + 1,
@@ -290,21 +228,15 @@ mod test {
                     y: sheet.offsets.thumbnail().max.y + 2
                 },
             }]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
         assert!(!gc.thumbnail_dirty_selection(&Selection {
             sheet_id,
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect {
                 min: Pos { x: -2, y: -2 },
                 max: Pos { x: -1, y: -1 },
             }]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }));
     }
 }

--- a/quadratic-core/src/controller/user_actions/formats.rs
+++ b/quadratic-core/src/controller/user_actions/formats.rs
@@ -253,12 +253,8 @@ mod test {
         gc.set_align_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             crate::grid::CellAlign::Center,
             None,
@@ -279,12 +275,8 @@ mod test {
         gc.set_bold_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             true,
             None,
@@ -302,12 +294,8 @@ mod test {
         gc.set_cell_wrap_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             CellWrap::Clip,
             None,
@@ -328,12 +316,8 @@ mod test {
         gc.set_currency_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             "€".to_string(),
             None,
@@ -357,12 +341,8 @@ mod test {
         gc.set_numeric_format_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             crate::grid::NumericFormatKind::Exponential,
             None,
@@ -387,12 +367,8 @@ mod test {
         gc.set_numeric_format_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             crate::grid::NumericFormatKind::Percentage,
             None,
@@ -417,12 +393,8 @@ mod test {
         gc.set_commas_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             true,
             None,
@@ -437,12 +409,8 @@ mod test {
         gc.set_commas_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             false,
             None,
@@ -462,12 +430,8 @@ mod test {
         gc.set_italic_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             true,
             None,
@@ -485,12 +449,8 @@ mod test {
         gc.set_text_color_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             Some("red".to_string()),
             None,
@@ -511,12 +471,8 @@ mod test {
         gc.set_fill_color_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             Some("blue".to_string()),
             None,
@@ -539,12 +495,8 @@ mod test {
         gc.change_decimal_places_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             2,
             None,
@@ -565,12 +517,8 @@ mod test {
         gc.set_text_color_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             Some("red".to_string()),
             None,
@@ -586,12 +534,8 @@ mod test {
         gc.clear_format(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
                 rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
-                rows: None,
-                columns: None,
-                all: false,
+                ..Default::default()
             },
             None,
         )
@@ -608,12 +552,8 @@ mod test {
         gc.set_text_color_selection(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
-                rects: None,
-                rows: None,
                 columns: Some(vec![0]),
-                all: false,
+                ..Default::default()
             },
             Some("red".to_string()),
             None,
@@ -626,12 +566,8 @@ mod test {
         gc.clear_format(
             Selection {
                 sheet_id,
-                x: 0,
-                y: 0,
-                rects: None,
-                rows: None,
                 columns: Some(vec![0]),
-                all: false,
+                ..Default::default()
             },
             None,
         )

--- a/quadratic-core/src/grid/sheet/selection.rs
+++ b/quadratic-core/src/grid/sheet/selection.rs
@@ -428,15 +428,7 @@ mod tests {
         );
         sheet.test_set_code_run_array(-1, -10, vec!["1", "2", "3"], true);
 
-        let selection = Selection {
-            sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
-            columns: None,
-            all: true,
-        };
+        let selection = Selection::all(sheet.id);
 
         let results = sheet.selection(&selection, None, false).unwrap();
         assert_eq!(results.len(), 12);
@@ -472,12 +464,8 @@ mod tests {
 
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(vec![0, 1, -1]),
-            all: false,
+            ..Default::default()
         };
 
         let results = sheet.selection(&selection, None, false).unwrap();
@@ -506,12 +494,8 @@ mod tests {
 
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            rects: None,
             rows: Some(vec![0, 1, -10]),
-            columns: None,
-            all: false,
+            ..Default::default()
         };
 
         let results = sheet.selection(&selection, None, false).unwrap();
@@ -543,12 +527,8 @@ mod tests {
             .selection(
                 &Selection {
                     sheet_id: sheet.id,
-                    x: 0,
-                    y: 0,
                     rects: Some(rects.clone()),
-                    rows: None,
-                    columns: None,
-                    all: false,
+                    ..Default::default()
                 },
                 None,
                 false,
@@ -565,12 +545,8 @@ mod tests {
             .selection(
                 &Selection {
                     sheet_id: sheet.id,
-                    x: 0,
-                    y: 0,
                     rects: Some(rects),
-                    rows: None,
-                    columns: None,
-                    all: false,
+                    ..Default::default()
                 },
                 Some(3),
                 false,
@@ -593,12 +569,8 @@ mod tests {
             .selection(
                 &Selection {
                     sheet_id: sheet.id,
-                    x: 0,
-                    y: 0,
                     rects: Some(rects.clone()),
-                    rows: None,
-                    columns: None,
-                    all: false,
+                    ..Default::default()
                 },
                 None,
                 false,
@@ -611,12 +583,8 @@ mod tests {
             .selection(
                 &Selection {
                     sheet_id: sheet.id,
-                    x: 0,
-                    y: 0,
                     rects: Some(rects.clone()),
-                    rows: None,
-                    columns: None,
-                    all: false,
+                    ..Default::default()
                 },
                 Some(1),
                 false,
@@ -627,12 +595,8 @@ mod tests {
             .selection(
                 &Selection {
                     sheet_id: sheet.id,
-                    x: 0,
-                    y: 0,
                     rects: Some(rects),
-                    rows: None,
-                    columns: None,
-                    all: false,
+                    ..Default::default()
                 },
                 None,
                 true,
@@ -662,12 +626,10 @@ mod tests {
 
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
             rects: Some(vec![Rect::single_pos(Pos { x: 0, y: 0 })]),
             rows: Some(vec![4]),
             columns: Some(vec![2]),
-            all: false,
+            ..Default::default()
         };
 
         let results = sheet.selection(&selection, None, false).unwrap();

--- a/quadratic-core/src/grid/sheet/summarize.rs
+++ b/quadratic-core/src/grid/sheet/summarize.rs
@@ -65,12 +65,8 @@ mod tests {
         let rect = Rect::new_span(Pos { x: 1, y: 1 }, Pos { x: 1, y: 10 });
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
-            columns: None,
-            rows: None,
             rects: Some(vec![rect]),
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 3);
@@ -81,12 +77,8 @@ mod tests {
         let rect = Rect::new_span(Pos { x: 100, y: 100 }, Pos { x: 1000, y: 105 });
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
-            columns: None,
-            rows: None,
             rects: Some(vec![rect]),
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9);
         assert_eq!(result, None);
@@ -102,12 +94,8 @@ mod tests {
         let rect = Rect::new_span(Pos { x: 1, y: 1 }, Pos { x: 1, y: 10 });
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
-            columns: None,
-            rows: None,
             rects: Some(vec![rect]),
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 6);
@@ -120,15 +108,7 @@ mod tests {
         let mut sheet = Sheet::test();
 
         // returns none if selection is too large (MAX_SUMMARIZE_SELECTION_SIZE)
-        let selection = Selection {
-            sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: true,
-            columns: None,
-            rows: None,
-            rects: None,
-        };
+        let selection = Selection::all(sheet.id);
         for i in 0..MAX_SUMMARIZE_SELECTION_SIZE + 1 {
             sheet.test_set_value_number(100, 100 + i, "1");
         }
@@ -144,12 +124,8 @@ mod tests {
         let rect = Rect::new_span(Pos { x: -1, y: -1 }, Pos { x: -1, y: 1 });
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
-            columns: None,
-            rows: None,
             rects: Some(vec![rect]),
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 2);
@@ -167,12 +143,8 @@ mod tests {
         sheet.test_set_code_run_array(-1, -10, vec!["1", "2", "", "3"], true);
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
             columns: Some(vec![-2, -1, 0, 1, 2]),
-            rows: None,
-            rects: None,
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 23);
@@ -190,12 +162,8 @@ mod tests {
         sheet.test_set_code_run_array(-10, -1, vec!["1", "2", "", "3"], true);
         let selection = Selection {
             sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: false,
-            columns: None,
             rows: Some(vec![-2, -1, 0, 1, 2]),
-            rects: None,
+            ..Default::default()
         };
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 23);
@@ -212,15 +180,7 @@ mod tests {
             }
         }
         sheet.test_set_code_run_array(-20, -20, vec!["1", "2", "3"], false);
-        let selection = Selection {
-            sheet_id: sheet.id,
-            x: 0,
-            y: 0,
-            all: true,
-            columns: None,
-            rows: None,
-            rects: None,
-        };
+        let selection = Selection::all(sheet.id);
         let result = sheet.summarize_selection(selection, 9).unwrap();
         assert_eq!(result.count, 103);
         assert_eq!(result.sum, Some(206.0));

--- a/quadratic-core/src/selection.rs
+++ b/quadratic-core/src/selection.rs
@@ -17,6 +17,9 @@ pub struct Selection {
     pub rows: Option<Vec<i64>>,
     pub columns: Option<Vec<i64>>,
     pub all: bool,
+
+    // Remove rects from the selection
+    pub except: Option<Vec<Rect>>,
 }
 
 impl Selection {
@@ -27,9 +30,7 @@ impl Selection {
             x: sheet_rect.min.x,
             y: sheet_rect.min.y,
             rects: Some(vec![sheet_rect.into()]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }
     }
 
@@ -37,12 +38,8 @@ impl Selection {
     pub fn all(sheet_id: SheetId) -> Self {
         Selection {
             sheet_id,
-            x: 0,
-            y: 0,
-            rects: None,
-            rows: None,
-            columns: None,
             all: true,
+            ..Default::default()
         }
     }
 
@@ -51,11 +48,8 @@ impl Selection {
         Selection {
             sheet_id,
             x: columns[0],
-            y: 0,
-            rects: None,
-            rows: None,
             columns: Some(columns.to_vec()),
-            all: false,
+            ..Default::default()
         }
     }
 
@@ -63,12 +57,9 @@ impl Selection {
     pub fn rows(rows: &[i64], sheet_id: SheetId) -> Self {
         Selection {
             sheet_id,
-            x: 0,
             y: rows[0],
-            rects: None,
             rows: Some(rows.to_vec()),
-            columns: None,
-            all: false,
+            ..Default::default()
         }
     }
 
@@ -79,9 +70,7 @@ impl Selection {
             x: rect.min.x,
             y: rect.min.y,
             rects: Some(vec![rect]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }
     }
 
@@ -92,9 +81,7 @@ impl Selection {
             x,
             y,
             rects: Some(vec![Rect::from_numbers(x, y, 1, 1)]),
-            rows: None,
-            columns: None,
-            all: false,
+            ..Default::default()
         }
     }
 
@@ -242,12 +229,10 @@ mod test {
             selection,
             Selection {
                 sheet_id: SheetId::test(),
-                x: 0,
                 y: 1,
+                x: 0,
                 rects: Some(vec![Rect::from_numbers(0, 1, 4, 4)]),
-                rows: None,
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -262,10 +247,8 @@ mod test {
                 sheet_id: SheetId::test(),
                 x: 0,
                 y: 3,
-                rects: None,
                 rows: Some(vec!(3, 5)),
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -280,10 +263,8 @@ mod test {
                 x: 7,
                 y: 0,
                 sheet_id: SheetId::test(),
-                rects: None,
-                rows: None,
                 columns: Some(vec!(7, 8, 9)),
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -295,13 +276,9 @@ mod test {
         assert_eq!(
             selection,
             Selection {
-                x: 0,
-                y: 0,
                 sheet_id: SheetId::test(),
-                rects: None,
-                rows: None,
-                columns: None,
-                all: true
+                all: true,
+                ..Default::default()
             }
         );
     }
@@ -313,13 +290,9 @@ mod test {
         assert_eq!(
             selection,
             Selection {
-                x: 0,
-                y: 0,
                 sheet_id: SheetId::test(),
                 rects: Some(vec!(rect)),
-                rows: None,
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -330,13 +303,9 @@ mod test {
         assert_eq!(
             selection,
             Selection {
-                x: 0,
-                y: 0,
                 sheet_id: SheetId::test(),
                 rects: Some(vec!(Rect::from_numbers(0, 0, 1, 1))),
-                rows: None,
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -348,13 +317,9 @@ mod test {
         assert_eq!(
             selection,
             Selection {
-                x: 0,
-                y: 0,
                 sheet_id: SheetId::test(),
                 rects: Some(vec!(Rect::from_numbers(0, 0, 1, 1))),
-                rows: None,
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -491,7 +456,7 @@ mod test {
             rects: Some(vec![Rect::from_numbers(1, 2, 3, 4)]),
             columns: Some(vec![1, 2, 3]),
             rows: Some(vec![4, 5, 6]),
-            all: false,
+            ..Default::default()
         };
         assert_eq!(selection.count(), 18);
 
@@ -503,6 +468,7 @@ mod test {
             columns: Some(vec![1, 2, 3]),
             rows: Some(vec![4, 5, 6]),
             all: true,
+            ..Default::default()
         };
 
         // all is always count = 1
@@ -519,10 +485,8 @@ mod test {
                 sheet_id,
                 x: 1,
                 y: 0,
-                rects: None,
-                rows: None,
                 columns: Some(vec![1, 2, 3]),
-                all: false
+                ..Default::default()
             }
         );
     }
@@ -537,10 +501,8 @@ mod test {
                 sheet_id,
                 x: 0,
                 y: 1,
-                rects: None,
                 rows: Some(vec![1, 2, 3]),
-                columns: None,
-                all: false
+                ..Default::default()
             }
         );
     }


### PR DESCRIPTION
Fixes #1476 

- [x] update Rust's Selection struct
- [x] update SheetCursor.ts's class
- [ ] refactor multiCursor interweave exceptions and additions, which will allow Excel's drawing rectangles within rectangles to select, unselect, and select again- [ ] visually display exceptions (holes, maybe?)
- [ ] allow pointer to remove/replace cells in selection
- [ ] allow pointer to create rectangles that remove/replace cells in selection
