### PR TITLE
fix go to cell in command palette

### DIFF
--- a/quadratic-client/src/app/ui/menus/CommandPalette/commands/Edit.tsx
+++ b/quadratic-client/src/app/ui/menus/CommandPalette/commands/Edit.tsx
@@ -163,7 +163,9 @@ const data: CommandGroup = {
         return (
           <CommandPaletteListItem
             {...props}
-            action={() => setEditorInteractionState({ ...editorInteractionState, showGoToMenu: true })}
+            action={() =>
+              setEditorInteractionState({ ...editorInteractionState, showCommandPalette: false, showGoToMenu: true })
+            }
             // icon={<ThickArrowRightIcon />}
             shortcut={KeyboardSymbols.Command + 'G'}
           />


### PR DESCRIPTION
Fixes #1570

Command palette now properly closes when go to menu dialog is triggered