### PR TITLE
Append characters to the end of the text to avoid false positives

### DIFF
--- a/quadratic-api/src/utils/crypto.test.ts
+++ b/quadratic-api/src/utils/crypto.test.ts
@@ -43,7 +43,7 @@ describe('Encryption and Decryption', () => {
 
   it('should fail to decrypt with a tampered encrypted text', () => {
     const encryptedText = encrypt(key, text);
-    const tamperedText = encryptedText.slice(0, -1) + '0'; // change the last character
+    const tamperedText = encryptedText + 'abc123';
 
     expect(() => decrypt(key, tamperedText)).toThrow();
   });


### PR DESCRIPTION
Fixes a brittle test in CI, though I could not duplicate the false positive locally.