### PR TITLE
Fix clear formatting removes borders if selection contains rects

### DIFF
--- a/quadratic-core/src/controller/execution/execute_operation/execute_borders.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_borders.rs
@@ -30,7 +30,7 @@ impl GridController {
                     },
                 );
 
-                if cfg!(target_family = "wasm") && !transaction.is_server() {
+                if cfg!(test) || (cfg!(target_family = "wasm") && !transaction.is_server()) {
                     self.send_updated_bounds(sheet_rect.sheet_id);
                     if let Some(sheet) = self.try_sheet(sheet_rect.sheet_id) {
                         if let Ok(borders) = serde_json::to_string(&sheet.render_borders()) {

--- a/quadratic-core/src/controller/operations/formats.rs
+++ b/quadratic-core/src/controller/operations/formats.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 impl GridController {
-    fn clear_border_op(sheet: &Sheet, rect: &Rect) -> Operation {
+    pub(crate) fn clear_border_op(sheet: &Sheet, rect: &Rect) -> Operation {
         let selections = vec![BorderSelection::Clear];
         let cur_borders = get_rect_borders(sheet, rect);
         let new_borders = generate_borders(sheet, rect, selections.clone(), None);
@@ -55,8 +55,9 @@ mod tests {
     #[test]
     fn clear_format_selection_operations() {
         let gc = GridController::test();
+        let sheet_id = gc.sheet_ids()[0];
         let selection = Selection {
-            sheet_id: gc.sheet_ids()[0],
+            sheet_id,
             x: 0,
             y: 0,
             rects: Some(vec![Rect::from_numbers(0, 0, 1, 1)]),
@@ -67,10 +68,16 @@ mod tests {
         let ops = gc.clear_format_selection_operations(&selection);
         assert_eq!(
             ops,
-            vec![Operation::SetCellFormatsSelection {
-                selection,
-                formats: Formats::repeat(FormatUpdate::cleared(), 1),
-            }]
+            vec![
+                Operation::SetCellFormatsSelection {
+                    selection,
+                    formats: Formats::repeat(FormatUpdate::cleared(), 1),
+                },
+                GridController::clear_border_op(
+                    gc.sheet(sheet_id),
+                    &Rect::from_numbers(0, 0, 1, 1)
+                )
+            ]
         );
     }
 }

--- a/quadratic-core/src/controller/operations/formats.rs
+++ b/quadratic-core/src/controller/operations/formats.rs
@@ -1,19 +1,49 @@
 use super::operation::Operation;
 use crate::{
     controller::GridController,
-    grid::formats::{format_update::FormatUpdate, Formats},
+    grid::{
+        formats::{format_update::FormatUpdate, Formats},
+        generate_borders, get_rect_borders, BorderSelection, Sheet,
+    },
     selection::Selection,
+    Rect,
 };
 
 impl GridController {
+    fn clear_border_op(sheet: &Sheet, rect: &Rect) -> Operation {
+        let selections = vec![BorderSelection::Clear];
+        let cur_borders = get_rect_borders(sheet, rect);
+        let new_borders = generate_borders(sheet, rect, selections.clone(), None);
+        let borders = if cur_borders.render_lookup == new_borders.render_lookup {
+            generate_borders(sheet, rect, selections.clone(), None)
+        } else {
+            new_borders
+        };
+        Operation::SetBorders {
+            sheet_rect: rect.to_sheet_rect(sheet.id),
+            borders,
+        }
+    }
+
     pub(crate) fn clear_format_selection_operations(
         &self,
         selection: &Selection,
     ) -> Vec<Operation> {
-        vec![Operation::SetCellFormatsSelection {
+        let mut ops = vec![Operation::SetCellFormatsSelection {
             selection: selection.clone(),
             formats: Formats::repeat(FormatUpdate::cleared(), selection.count()),
-        }]
+        }];
+        let sheet_id = selection.sheet_id;
+        if let Some(sheet) = self.try_sheet(sheet_id) {
+            // todo: this is very hacky. We need to refactor borders to make
+            // this work the same as all other formats.
+            if let Some(rects) = selection.rects.as_ref() {
+                rects.iter().for_each(|rect| {
+                    ops.push(GridController::clear_border_op(sheet, rect));
+                });
+            }
+        }
+        ops
     }
 }
 

--- a/quadratic-core/src/controller/user_actions/borders.rs
+++ b/quadratic-core/src/controller/user_actions/borders.rs
@@ -18,9 +18,13 @@ impl GridController {
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use crate::{
         color::Rgba,
         grid::{CellBorderLine, SheetId},
+        selection::Selection,
+        wasm_bindings::js::expect_js_call,
         Pos,
     };
 
@@ -155,5 +159,48 @@ mod tests {
             line: CellBorderLine::Line1,
         });
         grid_controller.set_borders(sheet_rect, selections, style, None);
+    }
+
+    #[test]
+    #[serial]
+    fn clear_borders() {
+        let mut gc = GridController::test();
+        let sheet_id = gc.sheet_ids()[0];
+        let sheet_rect = SheetRect::single_pos(Pos { x: 0, y: 0 }, sheet_id);
+        let selections = vec![BorderSelection::Top, BorderSelection::Left];
+        let style = Some(BorderStyle {
+            color: Rgba::default(),
+            line: CellBorderLine::Line1,
+        });
+        gc.set_borders(sheet_rect, selections, style, None);
+
+        let sheet = gc.sheet(sheet_id);
+        let borders = sheet.render_borders();
+        assert!(!borders.horizontal.is_empty());
+        assert!(!borders.vertical.is_empty());
+        expect_js_call(
+            "jsSheetBorders",
+            format!("{},{}", sheet.id, serde_json::to_string(&borders).unwrap()),
+            true,
+        );
+
+        gc.clear_format(
+            Selection {
+                sheet_id: sheet_rect.sheet_id,
+                rects: Some(vec![sheet_rect.into()]),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        let sheet = gc.sheet(sheet_id);
+        let borders = sheet.render_borders();
+        assert!(borders.horizontal.is_empty());
+        assert!(borders.vertical.is_empty());
+        expect_js_call(
+            "jsSheetBorders",
+            format!("{},{}", sheet.id, serde_json::to_string(&borders).unwrap()),
+            true,
+        );
     }
 }

--- a/quadratic-core/src/grid/bounds.rs
+++ b/quadratic-core/src/grid/bounds.rs
@@ -129,12 +129,4 @@ mod test {
         grid_bounds.extend_y(5);
         assert_eq!(grid_bounds, GridBounds::NonEmpty(Rect::new(1, 2, 3, 5)));
     }
-
-    #[test]
-    fn to_rect() {
-        let grid_bounds = GridBounds::NonEmpty(Rect::new(1, 2, 3, 4));
-        assert_eq!(grid_bounds.to_rect(), Some(Rect::new(1, 2, 3, 4)));
-        let grid_bounds = GridBounds::Empty;
-        assert_eq!(grid_bounds.to_rect(), None);
-    }
 }

--- a/quadratic-core/src/grid/bounds.rs
+++ b/quadratic-core/src/grid/bounds.rs
@@ -129,4 +129,12 @@ mod test {
         grid_bounds.extend_y(5);
         assert_eq!(grid_bounds, GridBounds::NonEmpty(Rect::new(1, 2, 3, 5)));
     }
+
+    #[test]
+    fn to_rect() {
+        let grid_bounds = GridBounds::NonEmpty(Rect::new(1, 2, 3, 4));
+        assert_eq!(grid_bounds.to_rect(), Some(Rect::new(1, 2, 3, 4)));
+        let grid_bounds = GridBounds::Empty;
+        assert_eq!(grid_bounds.to_rect(), None);
+    }
 }

--- a/quadratic-core/src/grid/sheet/bounds.rs
+++ b/quadratic-core/src/grid/sheet/bounds.rs
@@ -107,6 +107,13 @@ impl Sheet {
         }
     }
 
+    pub fn format_bounds(&self) -> Option<Rect> {
+        match self.format_bounds {
+            GridBounds::Empty => None,
+            GridBounds::NonEmpty(rect) => Some(rect),
+        }
+    }
+
     /// Returns the lower and upper bounds of a column, or `None` if the column
     /// is empty.
     ///


### PR DESCRIPTION
Fixes #1583 

Note: the clear borders implementation is limited to selections containing rects (similar to the limitation for setting border). We do not have a good way of setting borders for selections containing all, columns, or rows. (We also don't have bounds for borders, so we can't even fake it for clearing.)