### PR TITLE
fix kernel running indicator

### DIFF
--- a/quadratic-client/src/app/ui/menus/BottomBar/BottomBar.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/BottomBar.tsx
@@ -80,6 +80,7 @@ export const BottomBar = () => {
         display: 'flex',
         justifyContent: 'space-between',
         userSelect: 'none',
+        zIndex: 1,
       }}
     >
       <Stack direction="row">

--- a/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
@@ -73,7 +73,8 @@ export const KernelMenu = () => {
 
   const [running, setRunning] = useState(0);
   useEffect(() => {
-    setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
+    // setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
+    setRunning(10);
   }, [pythonCodeRunning, javascriptCodeRunning, connectionCodeRunning]);
 
   const [open, setOpen] = useState(false);
@@ -85,7 +86,7 @@ export const KernelMenu = () => {
           <div className="text-xs">Kernel</div>
           {running > 0 && (
             <div
-              className="absolute right-0 top-0 rounded-full px-1 text-white"
+              className="absolute left-0 top-0 rounded-full px-1 text-white"
               style={{ background: colors.darkGray, fontSize: '0.5rem' }}
             >
               {running}

--- a/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
@@ -71,7 +71,7 @@ export const KernelMenu = () => {
     };
   });
 
-  const [running, setRunning] = useState(0);
+  const [running, setRunning] = useState(1);
   useEffect(() => {
     setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
   }, [pythonCodeRunning, javascriptCodeRunning, connectionCodeRunning]);
@@ -85,8 +85,8 @@ export const KernelMenu = () => {
           <div className="text-xs">Kernel</div>
           {running > 0 && (
             <div
-              className="absolute top-1 rounded-full px-1 text-xs text-white"
-              style={{ background: colors.darkGray }}
+              className="absolute right-0 top-0 rounded-full px-1 text-white"
+              style={{ background: colors.darkGray, fontSize: '0.5rem' }}
             >
               {running}
             </div>

--- a/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
@@ -73,8 +73,7 @@ export const KernelMenu = () => {
 
   const [running, setRunning] = useState(0);
   useEffect(() => {
-    // setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
-    setRunning(10);
+    setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
   }, [pythonCodeRunning, javascriptCodeRunning, connectionCodeRunning]);
 
   const [open, setOpen] = useState(false);

--- a/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
@@ -71,7 +71,7 @@ export const KernelMenu = () => {
     };
   });
 
-  const [running, setRunning] = useState(1);
+  const [running, setRunning] = useState(0);
   useEffect(() => {
     setRunning((pythonCodeRunning ? 1 : 0) + (javascriptCodeRunning ? 1 : 0) + (connectionCodeRunning ? 1 : 0));
   }, [pythonCodeRunning, javascriptCodeRunning, connectionCodeRunning]);


### PR DESCRIPTION
Fixes number placement for kernel in the bottom bar.

<img width="199" alt="Screenshot 2024-07-24 at 5 20 29 AM" src="https://github.com/user-attachments/assets/056ed48d-b257-4257-aac8-797604a42c52">

Prod has it overlapping in a weird place (I forgot to update its placement when I moved it to the footer).
