### PR TITLE
Fixes number formatting bugs

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -538,11 +538,16 @@ export class CellLabel {
           return this.showPoundLabels(labelMeshes);
         }
         digits = result.currentFractionDigits - 1;
+
         text = result.number;
         this.updateText(labelMeshes, text);
       } while (this.textWidth > this.AABB.width && digits >= 0 && infinityProtection++ < 1000);
-    }
 
+      // we were not able to reduce the number to fit the cell, so we show pound characters
+      if (digits < 0) {
+        return this.showPoundLabels(labelMeshes);
+      }
+    }
     const bounds = new Bounds();
 
     for (let i = 0; i < this.chars.length; i++) {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -49,6 +49,8 @@ export class CellLabel {
   visible = true;
 
   text: string;
+  private originalText: string;
+
   private displayedText?: string;
   number?: JsNumber;
 
@@ -114,6 +116,7 @@ export class CellLabel {
 
   constructor(cellsLabels: CellsLabels, cell: JsRenderCell, screenRectangle: Rectangle) {
     this.cellsLabels = cellsLabels;
+    this.originalText = cell.value;
     this.text = this.getText(cell);
     this.fontSize = fontSize;
     this.roundPixels = true;
@@ -528,7 +531,7 @@ export class CellLabel {
       let text = this.text;
       let infinityProtection = 0;
       do {
-        const result = reduceDecimals(this.displayedText, text, this.number, digits);
+        const result = reduceDecimals(this.originalText, this.text, this.number, digits);
 
         // we cannot reduce decimals anymore, so we show pound characters
         if (!result) {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -35,7 +35,7 @@ describe('convertNumber', () => {
       currentFractionDigits: 2,
     });
     expect(
-      reduceDecimals('$1234.5678', '1234.5678', {
+      reduceDecimals('1234.5678', '1234.5678', {
         commas: null,
         decimals: null,
         format: { type: 'CURRENCY', symbol: '$' },
@@ -43,7 +43,7 @@ describe('convertNumber', () => {
     ).toEqual({ number: '$1,234.568', currentFractionDigits: 3 });
     expect(
       reduceDecimals(
-        '$1234.5678',
+        '1234.5678',
         '1234.5678',
         {
           commas: null,

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -3,29 +3,29 @@ import { convertNumber, reduceDecimals } from './convertNumber';
 
 describe('convertNumber', () => {
   it('using various number formatting', () => {
-    // expect(convertNumber('1234', { commas: null, decimals: null, format: null })).toBe('1234');
-    // expect(convertNumber('1234', { commas: true, decimals: null, format: null })).toBe('1,234');
-    // expect(convertNumber('1234', { commas: true, decimals: 2, format: null })).toBe('1,234.00');
-    // expect(convertNumber('1234', { commas: true, decimals: 2, format: { type: 'CURRENCY', symbol: '$' } })).toBe(
-    //   '$1,234.00'
-    // );
-    // expect(convertNumber('1234.5678', { commas: true, decimals: 2, format: null })).toBe('1,234.57');
-    // expect(convertNumber('1234.5678', { commas: null, decimals: 5, format: null })).toBe('1234.56780');
-    // expect(
-    //   convertNumber('0.01234', { commas: null, decimals: null, format: { type: 'PERCENTAGE', symbol: null } })
-    // ).toBe('1.234%');
-    // expect(
-    //   convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
-    // ).toBe('1.23123222e+8');
-    // expect(
-    //   convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
-    // ).toBe('1.23e+8');
-    // expect(
-    //   convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    // ).toBe('1e-7');
-    // expect(
-    //   convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    // ).toBe('1.23456789e+8');
+    expect(convertNumber('1234', { commas: null, decimals: null, format: null })).toBe('1234');
+    expect(convertNumber('1234', { commas: true, decimals: null, format: null })).toBe('1,234');
+    expect(convertNumber('1234', { commas: true, decimals: 2, format: null })).toBe('1,234.00');
+    expect(convertNumber('1234', { commas: true, decimals: 2, format: { type: 'CURRENCY', symbol: '$' } })).toBe(
+      '$1,234.00'
+    );
+    expect(convertNumber('1234.5678', { commas: true, decimals: 2, format: null })).toBe('1,234.57');
+    expect(convertNumber('1234.5678', { commas: null, decimals: 5, format: null })).toBe('1234.56780');
+    expect(
+      convertNumber('0.01234', { commas: null, decimals: null, format: { type: 'PERCENTAGE', symbol: null } })
+    ).toBe('1.234%');
+    expect(
+      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
+    ).toBe('1.23123222e+8');
+    expect(
+      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
+    ).toBe('1.23e+8');
+    expect(
+      convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1e-7');
+    expect(
+      convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1.23456789e+8');
     expect(
       convertNumber('100200100.1234', { commas: null, decimals: null, format: { type: 'CURRENCY', symbol: '$' } })
     ).toBe('$100,200,100.12');

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -23,6 +23,9 @@ describe('convertNumber', () => {
     expect(
       convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
     ).toBe('1e-7');
+    expect(
+      convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1.23456789e+8');
   });
 
   it('reduceDecimals', () => {
@@ -54,4 +57,24 @@ describe('convertNumber', () => {
       )
     ).toEqual({ number: '$1,234.57', currentFractionDigits: 2 });
   });
+  expect(
+    reduceDecimals(
+      '123456789',
+      '1.23456789e+8',
+      {
+        commas: null,
+        decimals: null,
+        format: { type: 'EXPONENTIAL', symbol: null },
+      },
+      undefined
+    )
+  ).toEqual({ number: '1.2345679e+8', currentFractionDigits: 7 });
+  expect(
+    reduceDecimals(
+      '123456789',
+      '1e+8',
+      { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } },
+      0
+    )
+  ).toEqual(undefined);
 });

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -3,29 +3,32 @@ import { convertNumber, reduceDecimals } from './convertNumber';
 
 describe('convertNumber', () => {
   it('using various number formatting', () => {
-    expect(convertNumber('1234', { commas: null, decimals: null, format: null })).toBe('1234');
-    expect(convertNumber('1234', { commas: true, decimals: null, format: null })).toBe('1,234');
-    expect(convertNumber('1234', { commas: true, decimals: 2, format: null })).toBe('1,234.00');
-    expect(convertNumber('1234', { commas: true, decimals: 2, format: { type: 'CURRENCY', symbol: '$' } })).toBe(
-      '$1,234.00'
-    );
-    expect(convertNumber('1234.5678', { commas: true, decimals: 2, format: null })).toBe('1,234.57');
-    expect(convertNumber('1234.5678', { commas: null, decimals: 5, format: null })).toBe('1234.56780');
+    // expect(convertNumber('1234', { commas: null, decimals: null, format: null })).toBe('1234');
+    // expect(convertNumber('1234', { commas: true, decimals: null, format: null })).toBe('1,234');
+    // expect(convertNumber('1234', { commas: true, decimals: 2, format: null })).toBe('1,234.00');
+    // expect(convertNumber('1234', { commas: true, decimals: 2, format: { type: 'CURRENCY', symbol: '$' } })).toBe(
+    //   '$1,234.00'
+    // );
+    // expect(convertNumber('1234.5678', { commas: true, decimals: 2, format: null })).toBe('1,234.57');
+    // expect(convertNumber('1234.5678', { commas: null, decimals: 5, format: null })).toBe('1234.56780');
+    // expect(
+    //   convertNumber('0.01234', { commas: null, decimals: null, format: { type: 'PERCENTAGE', symbol: null } })
+    // ).toBe('1.234%');
+    // expect(
+    //   convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
+    // ).toBe('1.23123222e+8');
+    // expect(
+    //   convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
+    // ).toBe('1.23e+8');
+    // expect(
+    //   convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    // ).toBe('1e-7');
+    // expect(
+    //   convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    // ).toBe('1.23456789e+8');
     expect(
-      convertNumber('0.01234', { commas: null, decimals: null, format: { type: 'PERCENTAGE', symbol: null } })
-    ).toBe('1.234%');
-    expect(
-      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
-    ).toBe('1.23123222e+8');
-    expect(
-      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
-    ).toBe('1.23e+8');
-    expect(
-      convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    ).toBe('1e-7');
-    expect(
-      convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    ).toBe('1.23456789e+8');
+      convertNumber('100200100.1234', { commas: null, decimals: null, format: { type: 'CURRENCY', symbol: '$' } })
+    ).toBe('$100,200,100.12');
   });
 
   it('reduceDecimals', () => {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { convertNumber, reduceDecimals } from './convertNumber';
 
 describe('convertNumber', () => {
-  it('shows a normal number with no formatting', () => {
+  it('using various number formatting', () => {
     expect(convertNumber('1234', { commas: null, decimals: null, format: null })).toBe('1234');
     expect(convertNumber('1234', { commas: true, decimals: null, format: null })).toBe('1,234');
     expect(convertNumber('1234', { commas: true, decimals: 2, format: null })).toBe('1,234.00');
@@ -14,6 +14,15 @@ describe('convertNumber', () => {
     expect(
       convertNumber('0.01234', { commas: null, decimals: null, format: { type: 'PERCENTAGE', symbol: null } })
     ).toBe('1.234%');
+    expect(
+      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
+    ).toBe('1.23123222e+8');
+    expect(
+      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
+    ).toBe('1.23e+8');
+    expect(
+      convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1e-7');
   });
 
   it('reduceDecimals', () => {
@@ -31,7 +40,7 @@ describe('convertNumber', () => {
         decimals: null,
         format: { type: 'CURRENCY', symbol: '$' },
       })
-    ).toEqual({ number: '$1234.568', currentFractionDigits: 3 });
+    ).toEqual({ number: '$1,234.568', currentFractionDigits: 3 });
     expect(
       reduceDecimals(
         '$1234.5678',
@@ -43,6 +52,6 @@ describe('convertNumber', () => {
         },
         2
       )
-    ).toEqual({ number: '$1234.57', currentFractionDigits: 2 });
+    ).toEqual({ number: '$1,234.57', currentFractionDigits: 2 });
   });
 });

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -13,9 +13,10 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
   let options: BigNumber.Format = { decimalSeparator: '.', groupSeparator: ',' };
   const isCurrency = format.format?.type === 'CURRENCY';
   const isScientific = format.format?.type === 'EXPONENTIAL';
+  const isPercent = format.format?.type === 'PERCENTAGE';
 
   // set commas
-  if (!isScientific && (format.commas || (format.commas === null && isCurrency))) {
+  if (!isScientific && !isPercent && (format.commas || (format.commas === null && isCurrency))) {
     options.groupSize = 3;
   }
 
@@ -57,18 +58,18 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
 
 // Reduces the number of decimals (used by rendering to show a fractional number in a smaller-width cell)
 export const reduceDecimals = (
+  number: string,
   current: string,
-  original: string,
   format: JsNumber,
   currentFractionDigits?: number
 ): { number: string; currentFractionDigits: number } | undefined => {
   // this only works if there is a fractional part
-  if (original.includes('.')) {
+  if (number.includes('.')) {
     if (currentFractionDigits === undefined) {
-      const split = original.split('.');
+      const split = number.split('.');
       currentFractionDigits = split[1].length - 1;
     }
-    const updated = convertNumber(original, format, currentFractionDigits);
+    const updated = convertNumber(number, format, currentFractionDigits);
     if (updated !== current) {
       return { number: updated, currentFractionDigits };
     }

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -20,14 +20,12 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
     options.groupSize = 3;
   }
 
-  if (currentFractionDigits) {
-    options.fractionGroupSize = currentFractionDigits;
-  } else if (format.decimals !== null) {
-    options.fractionGroupSize = format.decimals;
-  } else if (isCurrency) {
-    options.fractionGroupSize = 2;
-  } else {
-    options.fractionGroupSize = undefined;
+  if (currentFractionDigits === undefined) {
+    if (format.decimals !== null) {
+      currentFractionDigits = format.decimals;
+    } else if (isCurrency) {
+      currentFractionDigits = 2;
+    }
   }
 
   if (format.format?.type === 'CURRENCY') {
@@ -50,8 +48,6 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
 
   if (currentFractionDigits !== undefined) {
     return number.toFormat(currentFractionDigits, options) + suffix;
-  } else if (format.decimals !== null) {
-    return number.toFormat(format.decimals, options) + suffix;
   }
   return number.toFormat(options) + suffix;
 };

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -12,13 +12,16 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
   }
 
   let options: BigNumber.Format = { decimalSeparator: '.', groupSeparator: ',' };
-  if (format.commas) {
+  const isCurrency = format.format?.type === 'CURRENCY';
+  if (format.commas || (format.commas === null && isCurrency)) {
     options.groupSize = 3;
   }
   if (currentFractionDigits) {
     options.fractionGroupSize = currentFractionDigits;
   } else if (format.decimals !== null) {
     options.fractionGroupSize = format.decimals;
+  } else if (isCurrency) {
+    options.fractionGroupSize = 2;
   } else {
     options.fractionGroupSize = undefined;
   }

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -4,7 +4,6 @@ import { BigNumber } from 'bignumber.js';
 // Converts a number to a string with the given cell formatting
 export const convertNumber = (n: string, format: JsNumber, currentFractionDigits?: number): string => {
   let number = new BigNumber(n);
-
   let suffix = '';
   if (format.format?.type === 'PERCENTAGE') {
     number = number.times(100);
@@ -13,9 +12,13 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
 
   let options: BigNumber.Format = { decimalSeparator: '.', groupSeparator: ',' };
   const isCurrency = format.format?.type === 'CURRENCY';
-  if (format.commas || (format.commas === null && isCurrency)) {
+  const isScientific = format.format?.type === 'EXPONENTIAL';
+
+  // set commas
+  if (!isScientific && (format.commas || (format.commas === null && isCurrency))) {
     options.groupSize = 3;
   }
+
   if (currentFractionDigits) {
     options.fractionGroupSize = currentFractionDigits;
   } else if (format.decimals !== null) {
@@ -25,11 +28,22 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
   } else {
     options.fractionGroupSize = undefined;
   }
+
   if (format.format?.type === 'CURRENCY') {
     if (format.format.symbol) {
       options.prefix = format.format.symbol;
     } else {
       throw new Error('Expected format.symbol to be defined in convertNumber.ts');
+    }
+  }
+
+  if (isScientific) {
+    if (currentFractionDigits !== undefined) {
+      return number.toExponential(currentFractionDigits);
+    } else if (format.decimals !== null) {
+      return number.toExponential(format.decimals);
+    } else {
+      return number.toExponential();
     }
   }
 

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -64,14 +64,24 @@ export const reduceDecimals = (
   currentFractionDigits?: number
 ): { number: string; currentFractionDigits: number } | undefined => {
   // this only works if there is a fractional part
-  if (number.includes('.')) {
+  if (format.format?.type === 'EXPONENTIAL') {
     if (currentFractionDigits === undefined) {
-      const split = number.split('.');
-      currentFractionDigits = split[1].length - 1;
+      currentFractionDigits = number.length - (number[0] === '-' ? 3 : 2);
     }
     const updated = convertNumber(number, format, currentFractionDigits);
     if (updated !== current) {
       return { number: updated, currentFractionDigits };
+    }
+  } else {
+    if (number.includes('.')) {
+      if (currentFractionDigits === undefined) {
+        const split = number.split('.');
+        currentFractionDigits = split[1].length - 1;
+      }
+      const updated = convertNumber(number, format, currentFractionDigits);
+      if (updated !== current) {
+        return { number: updated, currentFractionDigits };
+      }
     }
   }
 };

--- a/quadratic-core/src/controller/operations/cell_value.rs
+++ b/quadratic-core/src/controller/operations/cell_value.rs
@@ -2,7 +2,7 @@ use super::operation::Operation;
 use crate::{
     cell_values::CellValues,
     controller::GridController,
-    grid::{formatting::CellFmtArray, NumericDecimals, NumericFormat, NumericFormatKind},
+    grid::{formatting::CellFmtArray, NumericFormat, NumericFormatKind},
     selection::Selection,
     CellValue, RunLengthEncoding, SheetPos, SheetRect,
 };
@@ -43,18 +43,11 @@ impl GridController {
                     attr: CellFmtArray::NumericCommas(RunLengthEncoding::repeat(Some(true), 1)),
                 });
             }
-            // only change decimal places if decimals have not been set
-            if let Some(sheet) = self.try_sheet(sheet_pos.sheet_id) {
-                if sheet
-                    .get_formatting_value::<NumericDecimals>(sheet_pos.into())
-                    .is_none()
-                {
-                    ops.push(Operation::SetCellFormats {
-                        sheet_rect,
-                        attr: CellFmtArray::NumericDecimals(RunLengthEncoding::repeat(Some(2), 1)),
-                    });
-                }
-            }
+
+            // We no longer automatically set numeric decimals for
+            // currency; instead, we handle changes in currency decimal
+            // length by using 2 if currency is set by default.
+
             CellValue::Number(number)
         } else if let Some(bool) = CellValue::unpack_boolean(value) {
             bool

--- a/quadratic-core/src/controller/operations/formatting.rs
+++ b/quadratic-core/src/controller/operations/formatting.rs
@@ -15,27 +15,16 @@ impl GridController {
         sheet_rect: &SheetRect,
         symbol: Option<String>,
     ) -> Vec<Operation> {
-        vec![
-            Operation::SetCellFormats {
-                sheet_rect: *sheet_rect,
-                attr: CellFmtArray::NumericFormat(RunLengthEncoding::repeat(
-                    Some(NumericFormat {
-                        kind: NumericFormatKind::Currency,
-                        symbol,
-                    }),
-                    sheet_rect.len(),
-                )),
-            },
-            // todo: this should not set the decimals
-            // default for currency should be 2 but we should not actually change it
-            Operation::SetCellFormats {
-                sheet_rect: *sheet_rect,
-                attr: CellFmtArray::NumericDecimals(RunLengthEncoding::repeat(
-                    Some(2),
-                    sheet_rect.len(),
-                )),
-            },
-        ]
+        vec![Operation::SetCellFormats {
+            sheet_rect: *sheet_rect,
+            attr: CellFmtArray::NumericFormat(RunLengthEncoding::repeat(
+                Some(NumericFormat {
+                    kind: NumericFormatKind::Currency,
+                    symbol,
+                }),
+                sheet_rect.len(),
+            )),
+        }]
     }
 
     /// Sets NumericFormat and NumericDecimals to None
@@ -77,10 +66,9 @@ impl GridController {
         let Some(sheet) = self.try_sheet(source.sheet_id) else {
             return vec![];
         };
-        let is_percentage =
-            sheet.cell_numeric_format_kind(source.into()) == Some(NumericFormatKind::Percentage);
+        let kind = sheet.cell_numeric_format_kind(source.into());
         let source_decimals = sheet
-            .calculate_decimal_places(source.into(), is_percentage)
+            .calculate_decimal_places(source.into(), kind)
             .unwrap_or(0);
         let new_precision = i16::max(0, source_decimals + (delta as i16));
         vec![Operation::SetCellFormats {

--- a/quadratic-core/src/controller/user_actions/cells.rs
+++ b/quadratic-core/src/controller/user_actions/cells.rs
@@ -192,7 +192,7 @@ mod test {
                 symbol: Some("$".into())
             })
         );
-        assert_eq!(get_cell_numeric_decimals(&gc), Some(2));
+        assert_eq!(get_cell_numeric_decimals(&gc), None);
 
         // number
         gc.set_cell_value(sheet_pos, "1.22".into(), None);
@@ -200,7 +200,7 @@ mod test {
             get_cell_value(&gc),
             CellValue::Number(BigDecimal::from_str("1.22").unwrap())
         );
-        assert_eq!(get_cell_numeric_decimals(&gc), Some(2));
+        assert_eq!(get_cell_numeric_decimals(&gc), None);
 
         // percentage
         gc.set_cell_value(sheet_pos, "10.55%".into(), None);
@@ -215,7 +215,7 @@ mod test {
                 symbol: None
             })
         );
-        assert_eq!(get_cell_numeric_decimals(&gc), Some(2));
+        assert_eq!(get_cell_numeric_decimals(&gc), None);
 
         // array
         gc.set_cell_value(sheet_pos, "[1,2,3]".into(), None);

--- a/quadratic-core/src/controller/user_actions/formats.rs
+++ b/quadratic-core/src/controller/user_actions/formats.rs
@@ -241,11 +241,8 @@ impl GridController {
             return Err("Sheet not found".into());
         };
         let source = selection.source();
-        let is_percentage =
-            sheet.cell_numeric_format_kind(source) == Some(NumericFormatKind::Percentage);
-        let source_decimals = sheet
-            .calculate_decimal_places(source, is_percentage)
-            .unwrap_or(0);
+        let kind = sheet.cell_numeric_format_kind(source);
+        let source_decimals = sheet.calculate_decimal_places(source, kind).unwrap_or(0);
         let new_precision = i16::max(0, source_decimals + (delta as i16));
         let formats = Formats::repeat(
             FormatUpdate {

--- a/quadratic-core/src/formulas/functions/mathematics.rs
+++ b/quadratic-core/src/formulas/functions/mathematics.rs
@@ -481,6 +481,7 @@ mod tests {
     fn test_floor_math_and_ceiling_math() {
         let g = Grid::new();
         let test_inputs = &[3.5, 2.5, 0.0, -2.5, -3.5];
+        #[allow(clippy::type_complexity)]
         let test_cases: &[([i64; 5], fn(f64) -> String)] = &[
             ([4, 3, 0, -2, -3], |n| format!("CEILING.MATH({n})")),
             ([4, 3, 0, -3, -4], |n| format!("CEILING.MATH({n},, -1)")),

--- a/quadratic-core/src/grid/js_types.rs
+++ b/quadratic-core/src/grid/js_types.rs
@@ -30,7 +30,6 @@ impl JsNumber {
     #[cfg(test)]
     pub fn dollars() -> Self {
         JsNumber {
-            decimals: Some(2),
             format: Some(NumericFormat {
                 kind: crate::grid::NumericFormatKind::Currency,
                 symbol: Some("$".to_string()),

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -355,6 +355,10 @@ impl Sheet {
         if let Some(value) = self.display_value(pos) {
             match value {
                 CellValue::Number(n) => {
+                    if kind == NumericFormatKind::Exponential {
+                        return Some(n.to_string().len() as i16 - 1);
+                    }
+
                     let exponent = n.as_bigint_and_exponent().1;
                     let max_decimals = 9;
                     let mut decimals = n
@@ -515,6 +519,15 @@ mod test {
             NumericFormatKind::Currency,
             Some(2),
         );
+
+        assert_decimal_places_for_number(
+            &mut sheet,
+            3,
+            2,
+            "91234567891",
+            NumericFormatKind::Exponential,
+            Some(10),
+        )
     }
 
     #[test]

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -244,13 +244,14 @@ impl Sheet {
         A::column_data_ref(column).get(pos.y)
     }
 
-    pub fn cell_numeric_format_kind(&self, pos: Pos) -> Option<NumericFormatKind> {
-        let column = self.get_column(pos.x)?;
-        if let Some(format) = column.numeric_format.get(pos.y) {
-            Some(format.kind)
-        } else {
-            None
+    /// Returns the type of number (defaulting to NumericFormatKind::Number) for a cell.
+    pub fn cell_numeric_format_kind(&self, pos: Pos) -> NumericFormatKind {
+        if let Some(column) = self.get_column(pos.x) {
+            if let Some(format) = column.numeric_format.get(pos.y) {
+                return format.kind;
+            }
         }
+        NumericFormatKind::Number
     }
 
     /// Returns a summary of formatting in a region.
@@ -339,10 +340,15 @@ impl Sheet {
     }
 
     /// get or calculate decimal places for a cell
-    pub fn calculate_decimal_places(&self, pos: Pos, is_percentage: bool) -> Option<i16> {
+    pub fn calculate_decimal_places(&self, pos: Pos, kind: NumericFormatKind) -> Option<i16> {
         // first check if numeric_decimals already exists for this cell
         if let Some(decimals) = self.format_cell(pos.x, pos.y, true).numeric_decimals {
             return Some(decimals);
+        }
+
+        // if currency, then use the default 2 decimal places
+        if kind == NumericFormatKind::Currency {
+            return Some(2);
         }
 
         // otherwise check value to see if it has a decimal and use that length
@@ -357,7 +363,7 @@ impl Sheet {
                         .as_bigint_and_exponent()
                         .1 as i16;
 
-                    if is_percentage {
+                    if kind == NumericFormatKind::Percentage {
                         decimals -= 2;
                     }
 
@@ -448,12 +454,12 @@ mod test {
         x: i64,
         y: i64,
         value: &str,
-        is_percentage: bool,
+        kind: NumericFormatKind,
         expected: Option<i16>,
     ) {
         let pos = Pos { x, y };
         let _ = sheet.set_cell_value(pos, CellValue::Number(BigDecimal::from_str(value).unwrap()));
-        assert_eq!(sheet.calculate_decimal_places(pos, is_percentage), expected);
+        assert_eq!(sheet.calculate_decimal_places(pos, kind), expected);
     }
 
     #[test]
@@ -462,16 +468,53 @@ mod test {
         let mut sheet = Sheet::new(SheetId::new(), String::from(""), String::from(""));
 
         // validate simple decimal places
-        assert_decimal_places_for_number(&mut sheet, 1, 2, "12.23", false, Some(2));
+        assert_decimal_places_for_number(
+            &mut sheet,
+            1,
+            2,
+            "12.23",
+            NumericFormatKind::Number,
+            Some(2),
+        );
 
         // validate percentage
-        assert_decimal_places_for_number(&mut sheet, 2, 2, "0.23", true, Some(0));
+        assert_decimal_places_for_number(
+            &mut sheet,
+            2,
+            2,
+            "0.23",
+            NumericFormatKind::Percentage,
+            Some(0),
+        );
 
         // validate rounding
-        assert_decimal_places_for_number(&mut sheet, 3, 2, "9.1234567891", false, Some(9));
+        assert_decimal_places_for_number(
+            &mut sheet,
+            3,
+            2,
+            "9.1234567891",
+            NumericFormatKind::Number,
+            Some(9),
+        );
 
         // validate percentage rounding
-        assert_decimal_places_for_number(&mut sheet, 3, 2, "9.1234567891", true, Some(7));
+        assert_decimal_places_for_number(
+            &mut sheet,
+            3,
+            2,
+            "9.1234567891",
+            NumericFormatKind::Percentage,
+            Some(7),
+        );
+
+        assert_decimal_places_for_number(
+            &mut sheet,
+            3,
+            2,
+            "9.1234567891",
+            NumericFormatKind::Currency,
+            Some(2),
+        );
     }
 
     #[test]
@@ -492,7 +535,7 @@ mod test {
             ),
         );
         assert_eq!(
-            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, false),
+            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, NumericFormatKind::Number),
             Some(2)
         );
 
@@ -505,7 +548,15 @@ mod test {
             false,
         );
         assert_eq!(
-            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, false),
+            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, NumericFormatKind::Number),
+            Some(3)
+        );
+        assert_eq!(
+            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, NumericFormatKind::Percentage),
+            Some(3)
+        );
+        assert_eq!(
+            sheet.calculate_decimal_places(Pos { x: 3, y: 3 }, NumericFormatKind::Currency),
             Some(3)
         );
     }
@@ -521,7 +572,7 @@ mod test {
         );
 
         assert_eq!(
-            sheet.calculate_decimal_places(Pos { x: 1, y: 2 }, false),
+            sheet.calculate_decimal_places(Pos { x: 1, y: 2 }, NumericFormatKind::Number),
             None
         );
     }
@@ -538,7 +589,7 @@ mod test {
 
         // expect a single decimal place
         assert_eq!(
-            sheet.calculate_decimal_places(Pos { x: 1, y: 2 }, false),
+            sheet.calculate_decimal_places(Pos { x: 1, y: 2 }, NumericFormatKind::Number),
             Some(1)
         );
     }
@@ -558,7 +609,7 @@ mod test {
 
         assert_eq!(
             sheet.cell_numeric_format_kind(Pos { x: 0, y: 0 }),
-            Some(NumericFormatKind::Percentage)
+            NumericFormatKind::Percentage
         );
     }
 
@@ -665,27 +716,6 @@ mod test {
         let value = sheet.get_formatting_value::<Bold>((2, 1).into());
 
         assert_eq!(value, Some(true));
-    }
-
-    // TODO(ddimaria): use the code below numeric format kinds are in place
-    #[ignore]
-    #[test]
-    #[parallel]
-    fn test_cell_numeric_format_kinds() {
-        let (grid, sheet_id, _) = test_setup_basic();
-        let sheet = grid.sheet(sheet_id).clone();
-
-        let format_kind = sheet.cell_numeric_format_kind((2, 1).into());
-        assert_eq!(format_kind, Some(NumericFormatKind::Currency));
-
-        let format_kind = sheet.cell_numeric_format_kind((3, 1).into());
-        assert_eq!(format_kind, Some(NumericFormatKind::Percentage));
-
-        let format_kind = sheet.cell_numeric_format_kind((4, 1).into());
-        assert_eq!(format_kind, Some(NumericFormatKind::Exponential));
-
-        let format_kind = sheet.cell_numeric_format_kind((5, 1).into());
-        assert_eq!(format_kind, Some(NumericFormatKind::Number));
     }
 
     #[test]

--- a/quadratic-core/src/values/cellvalue.rs
+++ b/quadratic-core/src/values/cellvalue.rs
@@ -8,10 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::{Duration, Instant, IsBlank};
 use crate::{
     controller::operations::operation::Operation,
-    grid::{
-        formatting::CellFmtArray, CodeCellLanguage, NumericDecimals, NumericFormat,
-        NumericFormatKind, Sheet,
-    },
+    grid::{formatting::CellFmtArray, CodeCellLanguage, NumericFormat, NumericFormatKind, Sheet},
     CodeResult, Pos, RunError, RunLengthEncoding, SheetRect,
 };
 
@@ -497,17 +494,9 @@ impl CellValue {
                         )),
                     });
 
-                    // only change decimals if it hasn't already been set
-                    if sheet.get_formatting_value::<NumericDecimals>(pos).is_none() {
-                        sheet.set_formatting_value::<NumericDecimals>(pos, Some(2));
-                        ops.push(Operation::SetCellFormats {
-                            sheet_rect,
-                            attr: CellFmtArray::NumericDecimals(RunLengthEncoding::repeat(
-                                Some(2),
-                                1,
-                            )),
-                        });
-                    }
+                    // We no longer automatically set numeric decimals for
+                    // currency; instead, we handle changes in currency decimal
+                    // length by using 2 if currency is set by default.
 
                     CellValue::Number(number)
                 } else if let Ok(number) = BigDecimal::from_str(value) {


### PR DESCRIPTION
Fixes #1633 

- [x] moved default number formatting to TS (we no longer set decimals to 2 when creating a currency, but leave it None)
- [x] fixed scientific notation display