### PR TITLE
fix: number formatting bugs

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -45,57 +45,57 @@ const fontSize = 14;
 
 export class CellLabel {
   private cellsLabels: CellsLabels;
-  position = new Point();
+  private position = new Point();
 
   visible = true;
 
-  text: string;
+  private text: string;
   private originalText: string;
 
-  private displayedText?: string;
   number?: JsNumber;
 
   // created in updateFontName()
-  fontName!: string;
+  private fontName!: string;
 
-  fontSize: number;
-  tint?: number;
-  maxWidth?: number;
-  roundPixels?: boolean;
+  private fontSize: number;
+  private tint?: number;
+  private maxWidth?: number;
+  private roundPixels?: boolean;
   location: Coordinate;
   AABB: Rectangle;
 
   clipLeft?: number;
   clipRight?: number;
 
-  cellClipLeft?: number;
-  cellClipRight?: number;
-  cellClipTop?: number;
-  cellClipBottom?: number;
+  private cellClipLeft?: number;
+  private cellClipRight?: number;
+  private cellClipTop?: number;
+  private cellClipBottom?: number;
 
-  nextLeftWidth?: number;
-  nextRightWidth?: number;
+  private nextLeftWidth?: number;
+  private nextRightWidth?: number;
 
   // used by ContainerBitmapText rendering
-  chars: CharRenderData[] = [];
-  horizontalAlignOffsets: number[] = [];
+  private chars: CharRenderData[] = [];
+  private horizontalAlignOffsets: number[] = [];
 
-  align: CellAlign | 'justify';
-  verticalAlign: CellVerticalAlign;
-  wrap: CellWrap;
+  private align: CellAlign | 'justify';
+  private verticalAlign: CellVerticalAlign;
+  private wrap: CellWrap;
 
-  letterSpacing: number;
-  bold: boolean;
-  italic: boolean;
+  private letterSpacing: number;
+  private bold: boolean;
+  private italic: boolean;
 
-  textWidth = 0;
+  private textWidth = 0;
   textHeight = 0;
   unwrappedTextWidth = 0;
 
-  overflowRight?: number;
-  overflowLeft?: number;
+  overflowRight = 0;
+  overflowLeft = 0;
 
-  dirtyText = true;
+  private actualLeft: number;
+  private actualRight: number;
 
   private getText(cell: JsRenderCell) {
     switch (cell?.special) {
@@ -141,6 +141,9 @@ export class CellLabel {
     this.location = { x: Number(cell.x), y: Number(cell.y) };
     this.AABB = screenRectangle;
 
+    this.actualLeft = this.AABB.left;
+    this.actualRight = this.AABB.right;
+
     this.bold = !!cell?.bold;
     this.italic = !!cell?.italic || isError || isChart;
     this.updateFontName();
@@ -150,20 +153,13 @@ export class CellLabel {
     this.updateCellLimits();
   }
 
-  clear = () => {
-    this.dirtyText = true;
-    this.chars = [];
-    this.horizontalAlignOffsets = [];
-  };
-
-  updateFontName = () => {
+  private updateFontName = () => {
     const bold = this.bold ? 'Bold' : '';
     const italic = this.italic ? 'Italic' : '';
     this.fontName = `OpenSans${bold || italic ? '-' : ''}${bold}${italic}`;
-    this.clear();
   };
 
-  updateCellLimits = () => {
+  private updateCellLimits = () => {
     this.cellClipLeft = this.wrap === 'clip' && this.align !== 'left' ? this.AABB.left : undefined;
     this.cellClipRight = this.wrap === 'clip' && this.align !== 'right' ? this.AABB.right : undefined;
     this.cellClipTop = this.AABB.top;
@@ -171,57 +167,47 @@ export class CellLabel {
     this.maxWidth = this.wrap === 'wrap' ? this.AABB.width - CELL_TEXT_MARGIN_LEFT * 3 : undefined;
   };
 
-  changeBold = (bold?: boolean) => {
-    this.bold = !!bold;
-    this.updateFontName();
-  };
-
-  changeItalic = (italic?: boolean) => {
-    this.italic = !!italic;
-    this.updateFontName();
-  };
-
-  changeAlign = (align?: CellAlign) => {
-    this.align = align ?? 'left';
-    this.calculatePosition();
-    this.clear();
-  };
-
-  changeVerticalAlign = (verticalAlign?: CellVerticalAlign) => {
-    this.verticalAlign = verticalAlign ?? 'top';
-    this.calculatePosition();
-  };
-
-  changeTextColor = (color?: string) => {
-    this.tint = color ? convertColorStringToTint(color) : undefined;
-    this.dirtyText = true;
-  };
-
-  checkLeftClip = (nextLeft: number): boolean => {
-    if (this.overflowLeft && this.AABB.left - this.overflowLeft < nextLeft) {
+  checkLeftClip = (nextLeft: number, labelMeshes: LabelMeshes): boolean => {
+    if (this.AABB.left - this.overflowLeft < nextLeft) {
       const nextLeftWidth = this.AABB.right - nextLeft;
       if (this.nextLeftWidth !== nextLeftWidth) {
         this.nextLeftWidth = nextLeftWidth;
+        if (this.number !== undefined && this.checkNumberClip()) this.updateText(labelMeshes);
         return true;
       }
     } else if (this.nextLeftWidth !== undefined) {
       this.nextLeftWidth = undefined;
+      if (this.number !== undefined && this.checkNumberClip()) this.updateText(labelMeshes);
       return true;
     }
     return false;
   };
 
-  checkRightClip = (nextRight: number): boolean => {
-    if (this.overflowRight && this.AABB.right + this.overflowRight > nextRight) {
+  checkRightClip = (nextRight: number, labelMeshes: LabelMeshes): boolean => {
+    if (this.AABB.right + this.overflowRight > nextRight) {
       const nextRightWidth = nextRight - this.AABB.left;
       if (this.nextRightWidth !== nextRightWidth) {
         this.nextRightWidth = nextRightWidth;
+        if (this.number !== undefined && this.checkNumberClip()) this.updateText(labelMeshes);
         return true;
       }
     } else if (this.nextRightWidth !== undefined) {
       this.nextRightWidth = undefined;
+      if (this.number !== undefined && this.checkNumberClip()) this.updateText(labelMeshes);
       return true;
     }
+    return false;
+  };
+
+  checkNumberClip = (): boolean => {
+    if (this.number === undefined) return false;
+
+    const clipLeft = Math.max(this.cellClipLeft ?? -Infinity, this.AABB.right - (this.nextLeftWidth ?? Infinity));
+    if (this.actualLeft < clipLeft + CELL_TEXT_MARGIN_LEFT * 3) return true;
+
+    const clipRight = Math.min(this.cellClipRight ?? Infinity, this.AABB.left + (this.nextRightWidth ?? Infinity));
+    if (this.actualRight > clipRight - CELL_TEXT_MARGIN_LEFT * 3) return true;
+
     return false;
   };
 
@@ -232,25 +218,27 @@ export class CellLabel {
     this.overflowRight = 0;
     let alignment = this.align ?? 'left';
     if (alignment === 'right') {
-      const actualLeft = this.AABB.right - this.textWidth - OPEN_SANS_FIX.x * 2;
-      if (actualLeft < this.AABB.left) {
-        this.overflowLeft = this.AABB.left - actualLeft;
+      this.actualLeft = this.AABB.right - this.textWidth;
+      this.actualRight = this.actualLeft + this.textWidth;
+      if (this.actualLeft < this.AABB.left) {
+        this.overflowLeft = this.AABB.left - this.actualLeft;
       }
-      this.position = new Point(actualLeft, this.AABB.top);
+      this.position = new Point(this.actualLeft, this.AABB.top);
     } else if (alignment === 'center') {
-      const actualLeft = this.AABB.left + (this.AABB.width - this.textWidth) / 2 - OPEN_SANS_FIX.x;
-      const actualRight = actualLeft + this.textWidth;
-      if (actualLeft < this.AABB.left) {
-        this.overflowLeft = this.AABB.left - actualLeft;
+      this.actualLeft = this.AABB.left + (this.AABB.width - this.textWidth) / 2;
+      this.actualRight = this.actualLeft + this.textWidth;
+      if (this.actualLeft < this.AABB.left) {
+        this.overflowLeft = this.AABB.left - this.actualLeft;
       }
-      if (actualRight > this.AABB.right) {
-        this.overflowRight = actualRight - this.AABB.right;
+      if (this.actualRight > this.AABB.right) {
+        this.overflowRight = this.actualRight - this.AABB.right;
       }
-      this.position = new Point(actualLeft, this.AABB.top);
+      this.position = new Point(this.actualLeft, this.AABB.top);
     } else if (alignment === 'left') {
-      const actualRight = this.AABB.left + this.textWidth;
-      if (actualRight > this.AABB.right) {
-        this.overflowRight = actualRight - this.AABB.right;
+      this.actualLeft = this.AABB.left;
+      this.actualRight = this.AABB.left + this.textWidth;
+      if (this.actualRight > this.AABB.right) {
+        this.overflowRight = this.actualRight - this.AABB.right;
       }
       this.position = new Point(this.AABB.left, this.AABB.top);
     }
@@ -264,18 +252,48 @@ export class CellLabel {
     }
   };
 
+  public updateText = (labelMeshes: LabelMeshes): void => {
+    if (!this.visible) return;
+
+    const processedText = this.processText(labelMeshes, this.text);
+    if (!processedText) return;
+
+    this.chars = processedText.chars;
+    this.textWidth = processedText.textWidth;
+    this.textHeight = processedText.textHeight;
+    this.unwrappedTextWidth = processedText.unwrappedTextWidth;
+    this.horizontalAlignOffsets = processedText.horizontalAlignOffsets;
+
+    this.calculatePosition();
+
+    // replaces numbers with pound signs when the number overflows
+    if (this.checkNumberClip()) {
+      const clippedNumber = this.getClippedNumber(this.originalText, this.text, this.number);
+      const processedNumberText = this.processText(labelMeshes, clippedNumber);
+      if (!processedNumberText) return;
+
+      this.chars = processedNumberText.chars;
+      this.textWidth = processedNumberText.textWidth;
+      this.textHeight = processedText.textHeight;
+      this.horizontalAlignOffsets = processedNumberText.horizontalAlignOffsets;
+
+      this.calculatePosition();
+    }
+  };
+
   /** Calculates the text glyphs and positions */
-  public updateText = (labelMeshes: LabelMeshes, originalText = this.text): void => {
+  public processText = (labelMeshes: LabelMeshes, originalText: string) => {
     if (!this.visible) return;
 
     const data = this.cellsLabels.bitmapFonts[this.fontName];
     if (!data) throw new Error(`Expected BitmapFont ${this.fontName} to be defined in CellLabel.updateText`);
+
     const pos = new Point();
-    this.chars = [];
+    const chars = [];
     const lineWidths: number[] = [];
     const lineSpaces: number[] = [];
-    const text = originalText.replace(/(?:\r\n|\r)/g, '\n') || ' ';
-    const charsInput = splitTextToCharacters(text);
+    const displayText = originalText.replace(/(?:\r\n|\r)/g, '\n') || ' ';
+    const charsInput = splitTextToCharacters(displayText);
     const scale = this.fontSize / data.size;
     const maxWidth = this.maxWidth;
     let prevCharCode = null;
@@ -325,17 +343,17 @@ export class CellLabel {
         prevSpaces: spaceCount,
         position: new Point(pos.x + charData.xOffset + this.letterSpacing / 2, pos.y + charData.yOffset),
       };
-      this.chars.push(charRenderData);
-      pos.x += charData.xAdvance + this.letterSpacing;
+      chars.push(charRenderData);
+      pos.x += Math.max(charData.xAdvance, charData.frame.width) + this.letterSpacing;
       prevCharCode = charCode;
       if (maxWidth !== undefined && pos.x - maxWidth / scale > 0.001) {
         const start = lastBreakPos === -1 ? i - spacesRemoved : 1 + lastBreakPos - spacesRemoved;
         const count = lastBreakPos === -1 ? 1 : 1 + i - lastBreakPos;
-        removeItems(this.chars, start, count);
+        removeItems(chars, start, count);
 
         lastBreakWidth = lastBreakPos === -1 ? lastLineWidth : lastBreakWidth;
         lineWidths.push(lastBreakWidth);
-        lineSpaces.push(this.chars.length > 0 ? this.chars[this.chars.length - 1].prevSpaces : 0);
+        lineSpaces.push(chars.length > 0 ? chars[chars.length - 1].prevSpaces : 0);
         maxLineWidth = Math.max(maxLineWidth, lastBreakWidth);
 
         i = lastBreakPos === -1 ? i - 1 : lastBreakPos;
@@ -347,7 +365,7 @@ export class CellLabel {
         prevCharCode = null;
         spaceCount = 0;
       } else {
-        lastLineWidth = charRenderData.position.x + Math.max(charData.xAdvance, charData.origWidth);
+        lastLineWidth = charRenderData.position.x + Math.max(charData.xAdvance, charData.frame.width);
         textHeight = Math.max(textHeight, charRenderData.position.y + charData.textureHeight);
       }
     }
@@ -361,9 +379,6 @@ export class CellLabel {
       lineSpaces.push(-1);
       maxLineWidth = Math.max(maxLineWidth, lastLineWidth);
     }
-
-    this.textWidth = maxLineWidth * scale;
-    this.textHeight = Math.max(textHeight * scale, CELL_HEIGHT);
 
     // calculate the unwrapped text width, content can be multi-line due to \n or \r
     let curUnwrappedTextWidth = 0;
@@ -381,13 +396,13 @@ export class CellLabel {
       if (prevCharCode && charData.kerning[prevCharCode]) {
         curUnwrappedTextWidth += charData.kerning[prevCharCode];
       }
-      curUnwrappedTextWidth += charData.xAdvance + this.letterSpacing;
+      curUnwrappedTextWidth += Math.max(charData.xAdvance, charData.frame.width) + this.letterSpacing;
       maxUnwrappedTextWidth = Math.max(maxUnwrappedTextWidth, curUnwrappedTextWidth);
       prevCharCode = charCode;
     }
-    this.unwrappedTextWidth = (maxUnwrappedTextWidth + 3 * CELL_TEXT_MARGIN_LEFT) * scale;
+    const unwrappedTextWidth = (maxUnwrappedTextWidth + 3 * CELL_TEXT_MARGIN_LEFT) * scale;
 
-    this.horizontalAlignOffsets = [];
+    const horizontalAlignOffsets = [];
     for (let i = 0; i <= line; i++) {
       let alignOffset = 0;
       if (this.align === 'right') {
@@ -397,66 +412,52 @@ export class CellLabel {
       } else if (this.align === 'justify') {
         alignOffset = lineSpaces[i] < 0 ? 0 : (maxLineWidth - lineWidths[i]) / lineSpaces[i];
       }
-      this.horizontalAlignOffsets.push(alignOffset);
+      horizontalAlignOffsets.push(alignOffset);
     }
-    this.displayedText = text;
-    this.calculatePosition();
-    this.dirtyText = false;
+
+    return {
+      chars,
+      textWidth: maxLineWidth * scale + OPEN_SANS_FIX.x * 2,
+      textHeight: Math.max(textHeight * scale, CELL_HEIGHT),
+      unwrappedTextWidth,
+      displayText,
+      horizontalAlignOffsets,
+    };
   };
 
-  // replaces numbers with pound signs when the number overflows
-  private showPoundLabels = (labelMeshes: LabelMeshes): Bounds => {
+  // This attempts to reduce the decimal precision to ensure the number fits
+  // within the cell. If it doesn't, it shows the pounds
+  private getClippedNumber = (originalText: string, text: string, number: JsNumber | undefined): string => {
+    if (number === undefined) return text;
+
+    let digits: number | undefined = undefined;
+    let infinityProtection = 0;
+    do {
+      const result = reduceDecimals(originalText, text, number, digits);
+      // we cannot reduce decimals anymore, so we show pound characters
+      if (!result) return this.getPoundText();
+
+      digits = result.currentFractionDigits - 1;
+      text = result.number;
+    } while (this.textWidth > this.AABB.width && digits >= 0 && infinityProtection++ < 1000);
+
+    // we were not able to reduce the number to fit the cell, so we show pound characters
+    if (digits < 0) return this.getPoundText();
+
+    return text;
+  };
+
+  private getPoundText = () => {
     const data = this.cellsLabels.bitmapFonts[this.fontName];
     if (!data) throw new Error(`Expected BitmapFont ${this.fontName} to be defined in CellLabel.updateText`);
 
-    if (this.dirtyText) this.updateText(labelMeshes);
-
     const scale = this.fontSize / data.size;
-    const color = this.tint ? convertTintToArray(this.tint) : undefined;
-
-    // keep track of the min/max x/y values for the viewRectangle
-    const bounds = new Bounds();
-
     const charCode = extractCharCode('#');
     const charData = data.chars[charCode];
-    const labelMeshId = labelMeshes.add(this.fontName, fontSize, charData.textureUid, !!this.tint);
-    const labelMesh = labelMeshes.get(labelMeshId);
-    const textureFrame = charData.frame;
-    const textureUvs = charData.uvs;
-    const buffer = labelMesh.getBuffer();
-
-    let x = 0;
-    const charWidth = charData.xAdvance * scale + this.letterSpacing;
-    const count = Math.floor(this.AABB.width / charWidth);
-    const textWidth = charWidth * count;
-
-    const actualLeft = this.AABB.left + (this.AABB.width - textWidth) / 2 - OPEN_SANS_FIX.x;
-    const actualRight = actualLeft + textWidth;
-    if (actualLeft < this.AABB.left) {
-      this.overflowLeft = this.AABB.left - actualLeft;
-    }
-    if (actualRight > this.AABB.right) {
-      this.overflowRight = actualRight - this.AABB.right;
-    }
-    this.position = new Point(actualLeft, this.AABB.top);
-
-    this.cellClipLeft = this.AABB.left;
-    this.cellClipRight = this.AABB.right;
-    this.cellClipTop = this.AABB.top;
-    this.cellClipBottom = this.AABB.bottom;
-    this.maxWidth = undefined;
-
-    for (let i = 0; i < count; i++) {
-      const xPos = this.position.x + x * scale + OPEN_SANS_FIX.x;
-      const yPos = this.position.y + OPEN_SANS_FIX.y + charData.yOffset * scale;
-      this.insertBuffers({ buffer, bounds, xPos, yPos, textureFrame, textureUvs, scale, color });
-      x += charData.xAdvance + this.letterSpacing;
-    }
-
-    // this removes extra characters from the mesh after a clip
-    buffer.reduceSize(6 * (this.chars.length - count));
-
-    return bounds;
+    const charWidth = Math.max(charData.xAdvance, charData.frame.width) * scale + this.letterSpacing;
+    const count = Math.floor((this.AABB.width - CELL_TEXT_MARGIN_LEFT * 3) / charWidth);
+    const text = '#'.repeat(count);
+    return text;
   };
 
   private insertBuffers = (options: {
@@ -532,40 +533,8 @@ export class CellLabel {
     const data = this.cellsLabels.bitmapFonts[this.fontName];
     if (!data) throw new Error('Expected BitmapFont to be defined in CellLabel.updateLabelMesh');
 
-    if (this.dirtyText) this.updateText(labelMeshes);
-
     const scale = this.fontSize / data.size;
     const color = this.tint ? convertTintToArray(this.tint) : undefined;
-
-    // This attempts to reduce the decimal precision to ensure the number fits
-    // within the cell. If it doesn't, it shows the pounds
-    const clip =
-      this.cellClipLeft !== undefined ||
-      this.cellClipRight !== undefined ||
-      this.nextLeftWidth !== undefined ||
-      this.nextRightWidth !== undefined;
-    if (this.number && this.displayedText && clip) {
-      let digits: number | undefined = undefined;
-      let text = this.text;
-      let infinityProtection = 0;
-      do {
-        const result = reduceDecimals(this.originalText, this.text, this.number, digits);
-
-        // we cannot reduce decimals anymore, so we show pound characters
-        if (!result) {
-          return this.showPoundLabels(labelMeshes);
-        }
-        digits = result.currentFractionDigits - 1;
-
-        text = result.number;
-        this.updateText(labelMeshes, text);
-      } while (this.textWidth > this.AABB.width && digits >= 0 && infinityProtection++ < 1000);
-
-      // we were not able to reduce the number to fit the cell, so we show pound characters
-      if (digits < 0) {
-        return this.showPoundLabels(labelMeshes);
-      }
-    }
 
     const bounds = new Bounds();
     for (let i = 0; i < this.chars.length; i++) {
@@ -597,7 +566,6 @@ export class CellLabel {
         this.insertBuffers({ buffer, bounds, xPos, yPos, textureFrame, textureUvs, scale, color });
       }
     }
-    this.clear();
     return bounds;
   };
 

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -108,7 +108,7 @@ export class CellLabel {
       default:
         if (cell.value !== undefined && cell.number) {
           this.number = cell.number;
-          return convertNumber(cell.value, cell.number);
+          return convertNumber(cell.value, cell.number).toUpperCase();
         } else {
           return cell?.value;
         }
@@ -164,8 +164,8 @@ export class CellLabel {
   };
 
   updateCellLimits = () => {
-    this.cellClipLeft = this.wrap !== 'overflow' && this.align !== 'left' ? this.AABB.left : undefined;
-    this.cellClipRight = this.wrap !== 'overflow' && this.align !== 'right' ? this.AABB.right : undefined;
+    this.cellClipLeft = this.wrap === 'clip' && this.align !== 'left' ? this.AABB.left : undefined;
+    this.cellClipRight = this.wrap === 'clip' && this.align !== 'right' ? this.AABB.right : undefined;
     this.cellClipTop = this.AABB.top;
     this.cellClipBottom = this.AABB.bottom;
     this.maxWidth = this.wrap === 'wrap' ? this.AABB.width - CELL_TEXT_MARGIN_LEFT * 3 : undefined;
@@ -539,7 +539,12 @@ export class CellLabel {
 
     // This attempts to reduce the decimal precision to ensure the number fits
     // within the cell. If it doesn't, it shows the pounds
-    if (this.number && this.textWidth > this.AABB.width && this.displayedText) {
+    const clip =
+      this.cellClipLeft !== undefined ||
+      this.cellClipRight !== undefined ||
+      this.nextLeftWidth !== undefined ||
+      this.nextRightWidth !== undefined;
+    if (this.number && this.displayedText && clip) {
       let digits: number | undefined = undefined;
       let text = this.text;
       let infinityProtection = 0;
@@ -561,8 +566,8 @@ export class CellLabel {
         return this.showPoundLabels(labelMeshes);
       }
     }
-    const bounds = new Bounds();
 
+    const bounds = new Bounds();
     for (let i = 0; i < this.chars.length; i++) {
       const char = this.chars[i];
       let horizontalOffset =

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
@@ -172,7 +172,10 @@ export class CellsTextHash {
       return true;
     } else if (this.dirtyBuffers) {
       if (debugShowHashUpdates) console.log(`[CellsTextHash] updating buffers ${this.hashX}, ${this.hashY}`);
-      queueMicrotask(() => this.updateBuffers());
+      queueMicrotask(() => {
+        this.updateText();
+        this.updateBuffers();
+      });
       if (!visibleOrNeighbor) {
         this.unload();
       }

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
@@ -46,7 +46,7 @@ export class CellsTextHash {
   // todo: not sure if this is still used as I ran into issues with only rendering buffers:
 
   // update text
-  dirtyText = false;
+  dirtyText = true;
 
   // rebuild only buffers
   dirtyBuffers = true;
@@ -156,6 +156,7 @@ export class CellsTextHash {
       if (visibleOrNeighbor) {
         queueMicrotask(() => this.updateBuffers());
       } else {
+        this.dirtyBuffers = true;
         this.unload();
       }
       return true;
@@ -165,6 +166,7 @@ export class CellsTextHash {
       if (visibleOrNeighbor) {
         queueMicrotask(() => this.updateBuffers());
       } else {
+        this.dirtyBuffers = true;
         this.unload();
       }
       return true;
@@ -182,9 +184,12 @@ export class CellsTextHash {
   };
 
   private updateText = () => {
-    if (!this.loaded) return;
+    if (!this.loaded || this.dirty) {
+      return;
+    }
 
     this.dirtyText = false;
+
     this.labelMeshes.clear();
     this.labels.forEach((child) => child.updateText(this.labelMeshes));
     this.overflowClip();
@@ -256,11 +261,11 @@ export class CellsTextHash {
       }
       const neighborLabel = currentHash.getLabel(column, row);
       if (neighborLabel) {
-        const clipRightResult = neighborLabel.checkRightClip(label.AABB.left);
+        const clipRightResult = neighborLabel.checkRightClip(label.AABB.left, this.labelMeshes);
         if (clipRightResult && currentHash !== this) {
           currentHash.dirtyBuffers = true;
         }
-        label.checkLeftClip(neighborLabel.AABB.right);
+        label.checkLeftClip(neighborLabel.AABB.right, this.labelMeshes);
         break;
       }
       column--;
@@ -276,11 +281,11 @@ export class CellsTextHash {
       }
       const neighborLabel = currentHash.getLabel(column, row);
       if (neighborLabel) {
-        const clipLeftResult = neighborLabel.checkLeftClip(label.AABB.right);
+        const clipLeftResult = neighborLabel.checkLeftClip(label.AABB.right, this.labelMeshes);
         if (clipLeftResult && currentHash !== this) {
           currentHash.dirtyBuffers = true;
         }
-        label.checkRightClip(neighborLabel.AABB.left);
+        label.checkRightClip(neighborLabel.AABB.left, this.labelMeshes);
         return;
       }
       column++;

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { convertNumber, reduceDecimals } from './convertNumber';
 
 describe('convertNumber', () => {
@@ -16,16 +16,16 @@ describe('convertNumber', () => {
     ).toBe('1.234%');
     expect(
       convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: null })
-    ).toBe('1.23123222e+8');
-    expect(
-      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 2 })
     ).toBe('1.23e+8');
     expect(
-      convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    ).toBe('1e-7');
+      convertNumber('123456789', { commas: null, decimals: 1, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1.2e+8');
     expect(
-      convertNumber('123456789', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
-    ).toBe('1.23456789e+8');
+      convertNumber('123123222', { format: { type: 'EXPONENTIAL', symbol: null }, commas: null, decimals: 5 })
+    ).toBe('1.23123e+8');
+    expect(
+      convertNumber('0.0000001', { commas: null, decimals: null, format: { type: 'EXPONENTIAL', symbol: null } })
+    ).toBe('1.00e-7');
     expect(
       convertNumber('100200100.1234', { commas: null, decimals: null, format: { type: 'CURRENCY', symbol: '$' } })
     ).toBe('$100,200,100.12');

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -42,7 +42,7 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
     } else if (format.decimals !== null) {
       return number.toExponential(format.decimals);
     } else {
-      return number.toExponential();
+      return number.toExponential(2);
     }
   }
 

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/convertNumber.ts
@@ -38,7 +38,6 @@ export const convertNumber = (n: string, format: JsNumber, currentFractionDigits
 
   if (isScientific) {
     if (currentFractionDigits !== undefined) {
-      // we need to remove trailing zeros for format.decimals === null
       return number.toExponential(currentFractionDigits);
     } else {
       return number.toExponential(2);


### PR DESCRIPTION
- decimal places for scientific notation is now 2 by default, can be changed
- number will should pound labels only if Overflow is set to clip or there is content in the next cell