### PR TITLE
fix: typing text into a cell inline is wrongly interpreted as a formula

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
@@ -71,7 +71,7 @@ class InlineEditorHandler {
     this.cursorIsMoving = false;
     this.x = this.y = this.width = this.height = 0;
     this.location = undefined;
-    this.formula = false;
+    this.formula = undefined;
     this.formatSummary = undefined;
     this.temporaryBold = undefined;
     this.temporaryItalic = undefined;


### PR DESCRIPTION
closes #1698 