### PR TITLE
Remove nonsense digits for `f64 -> BigDecimal`

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -20,7 +20,7 @@ import { CellsLabels } from './CellsLabels';
 import { LabelMeshEntry } from './LabelMeshEntry';
 import { LabelMeshes } from './LabelMeshes';
 import { extractCharCode, splitTextToCharacters } from './bitmapTextUtils';
-import { convertNumber, getFractionDigits, reduceDecimals } from './convertNumber';
+import { convertNumber, reduceDecimals } from './convertNumber';
 
 interface CharRenderData {
   charData: RenderBitmapChar;
@@ -108,13 +108,6 @@ export class CellLabel {
       default:
         if (cell.value !== undefined && cell.number) {
           this.number = cell.number;
-          if (cell.language) {
-            // fraction digits in number, max 16 (f64 precision)
-            const numberFractionDigits = Math.min(getFractionDigits(cell.value, cell.number), 16);
-            // display fraction digits in number, default 9
-            const displayFractionDigits = Math.min(this.number.decimals ?? 9, numberFractionDigits);
-            this.number.decimals = displayFractionDigits;
-          }
           return convertNumber(cell.value, cell.number).toUpperCase();
         } else {
           return cell?.value;

--- a/quadratic-core/src/formulas/functions/mathematics.rs
+++ b/quadratic-core/src/formulas/functions/mathematics.rs
@@ -609,8 +609,10 @@ mod tests {
         #[parallel]
         fn proptest_int_mod_invariant(n in -100.0..100.0_f64, d in -100.0..100.0_f64) {
             let g = Grid::new();
-            let should_equal_n = eval(&g, &format!("INT({n} / {d}) * {d} + MOD({n}, {d})")).coerce_nonblank::<f64>().unwrap();
-            assert!((should_equal_n - n).abs() < 0.01);
+            crate::util::assert_f64_approx_eq(
+                n,
+                &eval_to_string(&g, &format!("INT({n} / {d}) * {d} + MOD({n}, {d})")),
+            );
         }
     }
 

--- a/quadratic-core/src/formulas/functions/trigonometry.rs
+++ b/quadratic-core/src/formulas/functions/trigonometry.rs
@@ -153,8 +153,8 @@ mod tests {
     fn test_formula_radian_degree_conversion() {
         let g = Grid::new();
 
-        assert_eq!("-4", eval_to_string(&g, "RADIANS(-720) / PI()"));
-        assert_eq!("-720", eval_to_string(&g, "DEGREES(-PI() * 4)"));
+        crate::util::assert_f64_approx_eq(-4.0, &eval_to_string(&g, "RADIANS(-720) / PI()"));
+        crate::util::assert_f64_approx_eq(-720.0, &eval_to_string(&g, "DEGREES(-PI() * 4)"));
     }
 
     #[test]

--- a/quadratic-core/src/values/convert.rs
+++ b/quadratic-core/src/values/convert.rs
@@ -6,6 +6,8 @@ use crate::{CodeResult, CodeResultExt, RunErrorMsg, Span, Spanned, Unspan};
 
 const CURRENCY_PREFIXES: &[char] = &['$', '¥', '£', '€'];
 
+const F64_DECIMAL_PRECISION: u64 = 16; // just enough to not lose information
+
 /*
  * CONVERSIONS (specific type -> Value)
  */
@@ -39,7 +41,11 @@ impl From<&str> for CellValue {
 impl From<f64> for CellValue {
     fn from(value: f64) -> Self {
         match BigDecimal::try_from(value) {
-            Ok(n) => CellValue::Number(n.with_prec(16)), // just enough to not lose information
+            Ok(n) => CellValue::Number(if n.digits() > F64_DECIMAL_PRECISION {
+                n.with_prec(F64_DECIMAL_PRECISION)
+            } else {
+                n
+            }),
             // TODO: add span information
             Err(_) => CellValue::Error(Box::new(RunErrorMsg::NaN.without_span())),
         }

--- a/quadratic-core/src/values/convert.rs
+++ b/quadratic-core/src/values/convert.rs
@@ -39,7 +39,7 @@ impl From<&str> for CellValue {
 impl From<f64> for CellValue {
     fn from(value: f64) -> Self {
         match BigDecimal::try_from(value) {
-            Ok(n) => CellValue::Number(n),
+            Ok(n) => CellValue::Number(n.with_prec(16)), // just enough to not lose information
             // TODO: add span information
             Err(_) => CellValue::Error(Box::new(RunErrorMsg::NaN.without_span())),
         }


### PR DESCRIPTION
This should provide another layer of protection against #1678

Thank you @AyushAgrawal-A2 for pushing for this! I didn't realize the extra digits were coming from Rust.
