### PR TITLE
fix: button on onboarding banner

### DIFF
--- a/quadratic-client/src/dashboard/components/OnboardingBanner.tsx
+++ b/quadratic-client/src/dashboard/components/OnboardingBanner.tsx
@@ -100,7 +100,7 @@ export function OnboardingBanner() {
             </Button>
           </div>
           <p>Or bring your own data:</p>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Button variant="outline" asChild>
               <Link
                 to={newApiFileToLink}


### PR DESCRIPTION
Buttons don't wrap and look weird on more narrow screens

Before:

![CleanShot 2024-08-22 at 11 38 55@2x](https://github.com/user-attachments/assets/957182b1-db63-4254-a27d-a4b320dc2de0)

After:

![CleanShot 2024-08-22 at 11 43 32@2x](https://github.com/user-attachments/assets/6ad68532-b184-4318-b72a-0d143086eff6)
