### PR TITLE
Fix console.log bug in JS

### DIFF
--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
@@ -79,7 +79,7 @@ export function prepareJavascriptCode(
     '\n })();' +
     'if (results instanceof OffscreenCanvas) results = await results.convertToBlob();' +
     `self.postMessage({ type: "results", results, console: javascriptConsole.output()${
-      withLineNumbers ? `, lineNumber: ${LINE_NUMBER_VAR} - 1` : ''
+      withLineNumbers ? `, lineNumber: Math.max(${LINE_NUMBER_VAR} - 1, 0)` : ''
     } });` +
     `} catch (e) { const error = e.message; const stack = e.stack; self.postMessage({ type: "error", error, stack, console: javascriptConsole.output() }); }` +
     '})();';

--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/runner/generatedJavascriptForEditor.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/runner/generatedJavascriptForEditor.ts
@@ -181,9 +181,9 @@ function convertNullToUndefined(
 
 function lineNumber(): number | undefined {
   try {
-    throw new Error()
+    throw new Error();
   } catch (e: any) {
-    const stackLines = e.stack.split("\\n");
+    const stackLines = e.stack.split('\\n');
     const match = stackLines[3].match(/:(\\d+):(\\d+)/);
     if (match) {
       return match[1];
@@ -313,4 +313,5 @@ export const relCells = (deltaX0: number, deltaY0: number, deltaX1: number, delt
   return getCells(deltaX0 + p.x, deltaY0 + p.y, deltaX1 + p.x, deltaY1 + p.y);
 };
 
-export const rc = relCell;`;
+export const rc = relCell;
+`;

--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/runner/javascriptLibrary.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/runner/javascriptLibrary.ts
@@ -180,9 +180,9 @@ function convertNullToUndefined(
 
 function lineNumber(): number | undefined {
   try {
-    throw new Error()
+    throw new Error();
   } catch (e: any) {
-    const stackLines = e.stack.split("\\n");
+    const stackLines = e.stack.split('\\n');
     const match = stackLines[3].match(/:(\\d+):(\\d+)/);
     if (match) {
       return match[1];


### PR DESCRIPTION
Properly handles a console.log where there is no return statement. 

Sample code in code editor:
```js
console.log(1)
```

Cause: the return lineNumber was -1, which caused rust to panic when unpacking because it expected an u32.