### PR TITLE
fix: navigate to connection from error state

### DIFF
--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanel.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanel.tsx
@@ -23,6 +23,7 @@ export const CodeEditorPanel = memo((props: Props) => {
   const { isAuthenticated } = useRootRouteLoaderData();
   const {
     userMakingRequest: { teamPermissions },
+    team: { uuid: teamUuid },
   } = useFileRouteLoaderData();
   const { editorRef } = useCodeEditor();
   const editorInteractionState = useRecoilValue(editorInteractionStateAtom);
@@ -42,6 +43,7 @@ export const CodeEditorPanel = memo((props: Props) => {
   const schemaBrowser =
     isAuthenticated && connectionInfo !== undefined && teamPermissions?.includes('TEAM_EDIT') ? (
       <ConnectionSchemaBrowser
+        teamUuid={teamUuid}
         type={connectionInfo.kind}
         uuid={connectionInfo.id}
         TableQueryAction={TableQueryAction}

--- a/quadratic-client/src/dashboard/components/NewFileDialog.tsx
+++ b/quadratic-client/src/dashboard/components/NewFileDialog.tsx
@@ -235,6 +235,7 @@ function SchemaBrowser({
       type={connectionType}
       uuid={connectionUuid}
       TableQueryAction={TableQueryAction}
+      teamUuid={teamUuid}
     />
   );
 }

--- a/quadratic-client/src/shared/components/connections/ConnectionDetails.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionDetails.tsx
@@ -28,6 +28,7 @@ export const ConnectionDetails = ({
       </ConnectionHeader>
 
       <ConnectionSchemaBrowser
+        teamUuid={teamUuid}
         selfContained={true}
         TableQueryAction={TableQueryAction}
         uuid={connectionUuid}

--- a/quadratic-client/src/shared/components/connections/ConnectionSchemaBrowser.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionSchemaBrowser.tsx
@@ -15,10 +15,12 @@ import { Link } from 'react-router-dom';
 export const ConnectionSchemaBrowser = ({
   TableQueryAction,
   selfContained,
+  teamUuid,
   type,
   uuid,
 }: {
   TableQueryAction: React.FC<{ query: string }>;
+  teamUuid: string;
   selfContained?: boolean;
   type?: ConnectionType;
   uuid?: string;
@@ -75,8 +77,9 @@ export const ConnectionSchemaBrowser = ({
             </button>
             . If that doesn’t work,{' '}
             <Link
-              // Enhancement: do the logic to know when to do an in-memory navigation or redirect the document entirely
-              to={ROUTES.TEAM_SHORTCUT.CONNECTIONS}
+              to={ROUTES.TEAM_CONNECTION(teamUuid, uuid, type)}
+              // This has to be hard-reload because we don't use URLs and we don't know the context:
+              // of whether this is in the app or in the dashboard
               reloadDocument={true}
               className="underline hover:text-primary"
             >

--- a/quadratic-client/src/shared/components/connections/Connections.tsx
+++ b/quadratic-client/src/shared/components/connections/Connections.tsx
@@ -30,11 +30,13 @@ export const Connections = ({ connections, connectionsAreLoading, teamUuid, stat
   // Delete it from the url after we store it in local state
   const [searchParams] = useSearchParams();
   const initialConnectionType = searchParams.get('initial-connection-type');
+  const initialConnectionUuid = searchParams.get('initial-connection-uuid');
   useUpdateQueryStringValueWithoutNavigation('initial-connection-type', null);
+  useUpdateQueryStringValueWithoutNavigation('initial-connection-uuid', null);
 
   const [activeConnectionState, setActiveConnectionState] = useState<
     { uuid: string; view: 'edit' | 'details' } | undefined
-  >();
+  >(initialConnectionUuid ? { uuid: initialConnectionUuid, view: 'edit' } : undefined);
   const [activeConnectionType, setActiveConnectionType] = useState<ConnectionType | undefined>(
     initialConnectionType === 'MYSQL' || initialConnectionType === 'POSTGRES' ? initialConnectionType : undefined
   );

--- a/quadratic-client/src/shared/constants/routes.ts
+++ b/quadratic-client/src/shared/constants/routes.ts
@@ -25,6 +25,8 @@ export const ROUTES = {
   TEAM_CONNECTIONS: (teamUuid: string) => `/teams/${teamUuid}/connections`,
   TEAM_CONNECTION_CREATE: (teamUuid: string, connectionType: ConnectionType) =>
     `/teams/${teamUuid}/connections?initial-connection-type=${connectionType}`,
+  TEAM_CONNECTION: (teamUuid: string, connectionUuid: string, connectionType: ConnectionType) =>
+    `/teams/${teamUuid}/connections?initial-connection-uuid=${connectionUuid}&initial-connection-type=${connectionType}`,
   TEAM_FILES: (teamUuid: string) => `/teams/${teamUuid}`,
   TEAM_FILES_PRIVATE: (teamUuid: string) => `/teams/${teamUuid}/files/private`,
   TEAM_MEMBERS: (teamUuid: string) => `/teams/${teamUuid}/members`,


### PR DESCRIPTION
Today when you open a connection that won't load you get an error state that tells you to go check your connection details but the link is broken. It doesn't take you to the connection you're looking at, but rather the generic connection list.

This fixes this problem so clicking on it takes you to the details of the connection you were looking at

![CleanShot 2024-08-23 at 13 46 52@2x](https://github.com/user-attachments/assets/4f9427e8-5219-4dda-9a54-816c4de7e964)

Note: the navigation is less-than-ideal because it refreshes the whole page. This is caused because we don't use URLs to make these navigations because this component is used in multiple places (in-app and in-dashboard) so it's hard to know which context we're navigating in. This problem would have to be considered in a separate a PR. At minimum this fixes the error state so it actually takes you to the connection details you're having a problem with (albeit in a less-than-ideal flow)