### PR TITLE
fix: javaScript charts not anchored to their cell when resizing columns

### DIFF
--- a/quadratic-client/src/app/gridGL/cells/CellsSheets.ts
+++ b/quadratic-client/src/app/gridGL/cells/CellsSheets.ts
@@ -154,6 +154,11 @@ export class CellsSheets extends Container<CellsSheet> {
     cellsSheet?.adjustOffsets();
   }
 
+  adjustCellsImages(sheetId: string): void {
+    const cellsSheet = this.getById(sheetId);
+    cellsSheet?.cellsImages.reposition(sheetId);
+  }
+
   showLabel(x: number, y: number, sheetId: string, show: boolean) {
     const cellsSheet = this.getById(sheetId);
     cellsSheet?.showLabel(x, y, show);

--- a/quadratic-client/src/app/gridGL/cells/cellsImages/CellsImages.ts
+++ b/quadratic-client/src/app/gridGL/cells/cellsImages/CellsImages.ts
@@ -26,6 +26,7 @@ export class CellsImages extends Container<CellsImage> {
     if (this.cellsSheet.sheetId === sheetId) {
       this.children.forEach((sprite) => sprite.reposition());
     }
+    pixiApp.cellImages.dirtyBorders = true;
   };
 
   cheapCull(bounds: Rectangle) {

--- a/quadratic-client/src/app/gridGL/pixiApp/PixiApp.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/PixiApp.ts
@@ -23,6 +23,7 @@ import { Cursor } from '../UI/Cursor';
 import { GridLines } from '../UI/GridLines';
 import { HtmlPlaceholders } from '../UI/HtmlPlaceholders';
 import { UIMultiPlayerCursor } from '../UI/UIMultiplayerCursor';
+import { UIValidations } from '../UI/UIValidations';
 import { BoxCells } from '../UI/boxCells';
 import { GridHeadings } from '../UI/gridHeadings/GridHeadings';
 import { CellsSheets } from '../cells/CellsSheets';
@@ -32,7 +33,6 @@ import { Update } from './Update';
 import { Viewport } from './Viewport';
 import './pixiApp.css';
 import { urlParams } from './urlParams/urlParams';
-import { UIValidations } from '../UI/UIValidations';
 
 utils.skipHello();
 
@@ -328,6 +328,7 @@ export class PixiApp {
   adjustHeadings(options: { sheetId: string; delta: number; row?: number; column?: number }): void {
     this.cellsSheets.adjustHeadings(options);
     this.cellsSheets.adjustOffsetsBorders(options.sheetId);
+    this.cellsSheets.adjustCellsImages(options.sheetId);
     htmlCellsHandler.updateOffsets([sheets.sheet.id]);
     if (sheets.sheet.id === options.sheetId) {
       this.gridLines.dirty = true;

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
@@ -10,6 +10,7 @@
  */
 
 import { debugShowHashUpdates, debugShowLoadingHashes } from '@/app/debugFlags';
+import { DROPDOWN_PADDING, DROPDOWN_SIZE } from '@/app/gridGL/cells/cellsLabel/drawSpecial';
 import { sheetHashHeight, sheetHashWidth } from '@/app/gridGL/cells/CellsTypes';
 import { intersects } from '@/app/gridGL/helpers/intersects';
 import { Coordinate } from '@/app/gridGL/types/size';
@@ -19,10 +20,9 @@ import { renderClient } from '../renderClient';
 import { renderCore } from '../renderCore';
 import { CellLabel } from './CellLabel';
 import { CellsLabels } from './CellsLabels';
-import { LabelMeshes } from './LabelMeshes';
-import { CellsTextHashSpecial } from './CellsTextHashSpecial';
-import { DROPDOWN_PADDING, DROPDOWN_SIZE } from '@/app/gridGL/cells/cellsLabel/drawSpecial';
 import { CellsTextHashContent } from './CellsTextHashContent';
+import { CellsTextHashSpecial } from './CellsTextHashSpecial';
+import { LabelMeshes } from './LabelMeshes';
 
 // Draw hashed regions of cell glyphs (the text + text formatting)
 export class CellsTextHash {
@@ -450,7 +450,7 @@ export class CellsTextHash {
 
   getCellsContentMaxWidth = async (column: number): Promise<number> => {
     const columnsMax = await this.getColumnContentMaxWidths();
-    return columnsMax.get(column) ?? this.cellsLabels.getCellOffsets(column, 0).width;
+    return columnsMax.get(column) ?? 0;
   };
 
   getColumnContentMaxWidths = async (): Promise<Map<number, number>> => {
@@ -465,7 +465,7 @@ export class CellsTextHash {
 
   getCellsContentMaxHeight = async (row: number): Promise<number> => {
     const rowsMax = await this.getRowContentMaxHeights();
-    return rowsMax.get(row) ?? this.cellsLabels.getCellOffsets(0, row).height;
+    return rowsMax.get(row) ?? 0;
   };
 
   getRowContentMaxHeights = async (): Promise<Map<number, number>> => {


### PR DESCRIPTION
closes #1777