### PR TITLE
feat: team file list avatars (& misc. improvements)

### DIFF
--- a/quadratic-client/src/dashboard/components/FilesListItem.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListItem.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/shared/shadcn/ui/dropdown-menu';
 import { Separator } from '@/shared/shadcn/ui/separator';
 import { cn } from '@/shared/shadcn/utils';
+import { timeAgo } from '@/shared/utils/timeAgo';
 import { DotsVerticalIcon, FileIcon } from '@radix-ui/react-icons';
 import mixpanel from 'mixpanel-browser';
 import { useEffect, useRef, useState } from 'react';
@@ -204,7 +205,16 @@ export function FilesListItemUserFile({
             actions={
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Btn variant="ghost" size="icon" className="flex-shrink-0 hover:bg-background">
+                  <Btn
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      viewPreferences.layout === Layout.Grid
+                        ? 'absolute right-2 top-2 text-muted-foreground'
+                        : 'flex-shrink-0',
+                      'hover:border hover:bg-background hover:text-foreground hover:shadow-sm data-[state=open]:border data-[state=open]:bg-background data-[state=open]:text-foreground data-[state=open]:shadow-sm'
+                    )}
+                  >
                     <DotsVerticalIcon className="h-4 w-4" />
                   </Btn>
                 </DropdownMenuTrigger>
@@ -383,33 +393,4 @@ function ListItemView({
       <div className="flex-grow">{children}</div>
     </div>
   );
-}
-
-// Vanilla js time formatter. Adapted from:
-// https://blog.webdevsimplified.com/2020-07/relative-time-format/
-const formatter = new Intl.RelativeTimeFormat(undefined, {
-  numeric: 'auto',
-  style: 'narrow',
-});
-const DIVISIONS: { amount: number; name: Intl.RelativeTimeFormatUnit }[] = [
-  { amount: 60, name: 'seconds' },
-  { amount: 60, name: 'minutes' },
-  { amount: 24, name: 'hours' },
-  { amount: 7, name: 'days' },
-  { amount: 4.34524, name: 'weeks' },
-  { amount: 12, name: 'months' },
-  { amount: Number.POSITIVE_INFINITY, name: 'years' },
-];
-export function timeAgo(dateString: string) {
-  const date: Date = new Date(dateString);
-
-  let duration = (date.getTime() - new Date().getTime()) / 1000;
-
-  for (let i = 0; i < DIVISIONS.length; i++) {
-    const division = DIVISIONS[i];
-    if (Math.abs(duration) < division.amount) {
-      return formatter.format(Math.round(duration), division.name);
-    }
-    duration /= division.amount;
-  }
 }

--- a/quadratic-client/src/dashboard/components/FilesListItem.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListItem.tsx
@@ -245,7 +245,7 @@ export function FilesListItemUserFile({
                             });
                           }}
                         >
-                          Move to private files
+                          Move to my files
                         </DropdownMenuItem>
                       )}
                       {isTeamPrivateFilesRoute && (

--- a/quadratic-client/src/dashboard/components/FilesListViewControlsDropdown.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListViewControlsDropdown.tsx
@@ -32,7 +32,7 @@ export enum Order {
 }
 
 const sortLabelsByValue = {
-  [Sort.Updated]: 'Last updated',
+  [Sort.Updated]: 'Last modified',
   [Sort.Created]: 'Date created',
   [Sort.Alphabetical]: 'Alphabetical',
 };

--- a/quadratic-client/src/routes/teams.$teamUuid.index.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.index.tsx
@@ -13,7 +13,6 @@ import { Link } from 'react-router-dom';
 
 export const Component = () => {
   const {
-    userMakingRequest: { id: userMakingRequestId },
     activeTeam: {
       team: { uuid: teamUuid },
       files,
@@ -64,7 +63,7 @@ export const Component = () => {
       <FilesList
         files={files.map(({ file, userMakingRequest }) => {
           // Don't include the creator if it's the person logged in
-          const creator = userMakingRequestId !== file.creatorId ? usersById[file.creatorId] : undefined;
+          const creator = usersById[file.creatorId];
           return {
             name: file.name,
             createdDate: file.createdDate,

--- a/quadratic-client/src/shared/shadcn/ui/tooltip.tsx
+++ b/quadratic-client/src/shared/shadcn/ui/tooltip.tsx
@@ -38,9 +38,11 @@ const TooltipPopover = ({ label, children }: { label: string; children: React.Re
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent>
-          <p>{label}</p>
-        </TooltipContent>
+        <TooltipPrimitive.Portal>
+          <TooltipContent>
+            <p>{label}</p>
+          </TooltipContent>
+        </TooltipPrimitive.Portal>
       </Tooltip>
     </TooltipProvider>
   );


### PR DESCRIPTION
<img src=https://github.com/user-attachments/assets/d3ce9f33-e5d2-40f1-8e31-fdd82b1e685d width=500 />

### Fixes 

- For grid view, avatars are moved to far right with the secondary actions triggered moved to top right
  - Everything stays the same on list view (avatar/secondary actions on the far right)
- Avatars always show on team list view, even if they are your files.
- Dates older than 24hrs switch from relative ("2h ago") to showing the date (Aug 24, 2024)
- Fixes a bug where tooltips could display behind other content
- Changes sort order label from "Last updated" to "Last modified" to match the file's meta which says "Modified ___ ago"

