### PR TITLE
fix: stacktrace for JS coderun in safari

### DIFF
--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/worker/javascript/javascriptCompile.ts
@@ -39,7 +39,7 @@ export function javascriptAddLineNumberVars(transform: JavascriptTransformedCode
   let s = '';
   for (let i = 0; i < list.length; i++) {
     if (list[i].includes('return')) {
-      s += `try { throw new Error() } catch (e) { const stackLines = e.stack.split("\\n"); const match = stackLines[1].match(/:(\\d+):(\\d+)/); if (match) { ${LINE_NUMBER_VAR} = match[1];} }`;
+      s += `try { throw new Error() } catch (e) { const stackLines = e.stack.split("\\n"); let lineNumber; for (let i = 0; i < stackLines.length; i++) { const match = stackLines[i].match(/:(\\d+):(\\d+)/); if (match) { lineNumber = match[1]; break; } } if (lineNumber) { ${LINE_NUMBER_VAR} = lineNumber; } }`;
     }
     s += list[i] + '\n';
   }


### PR DESCRIPTION
Fixes JS code run in safari
![image](https://github.com/user-attachments/assets/56666d95-ff3a-4bc2-b7b1-09c4a03f09b0)
