### PR TITLE
fix: click to select on command dialog

### DIFF
--- a/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
@@ -194,7 +194,15 @@ function CommandItemWrapper({
   uuid?: string;
 }) {
   return (
-    <CommandItem disabled={disabled} onSelect={onSelect} value={name + (uuid ? uuid : '')}>
+    <CommandItem
+      disabled={disabled}
+      onSelect={onSelect}
+      value={name + (uuid ? uuid : '')}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
       <div className="mr-4">{icon}</div>
       <div className="flex flex-col">
         <span className="flex items-center">

--- a/quadratic-client/src/app/ui/menus/CommandPalette/CommandPaletteListItem.tsx
+++ b/quadratic-client/src/app/ui/menus/CommandPalette/CommandPaletteListItem.tsx
@@ -53,6 +53,10 @@ export const CommandPaletteListItem = (props: CommandPaletteListItemProps) => {
         closeCommandPalette();
         action();
       }}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       disabled={disabled}
     >
       <div className={`mr-2 flex h-5 w-5 items-center text-muted-foreground`}>{icon ? icon : null}</div>

--- a/quadratic-client/src/app/ui/menus/GoTo/GoTo.tsx
+++ b/quadratic-client/src/app/ui/menus/GoTo/GoTo.tsx
@@ -80,7 +80,14 @@ export const GoTo = () => {
         omitIcon={true}
       />
       <CommandList className="p-2">
-        <CommandItem onSelect={onSelect} className="flex items-center justify-between">
+        <CommandItem
+          onSelect={onSelect}
+          className="flex items-center justify-between"
+          onPointerDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
           Go to {coordinates.length === 1 ? 'cell' : 'range'}:{' '}
           {coordinates.map(({ x, y }) => `(${x}, ${y})`).join(', ')}
           <ArrowForward className="text-muted-foreground" />


### PR DESCRIPTION
closes #1815

fixes: https://quadratichq.slack.com/archives/C06Q34HGV8A/p1724851083994249

Affected items - Code cell menu, Goto menu and command pallete
- clicking on command option should execute that option
- clicking on empty space should close command dialog and focus grid