### PR TITLE
feat: when users have 0 teams, make them create one

### DIFF
--- a/quadratic-client/src/router.tsx
+++ b/quadratic-client/src/router.tsx
@@ -70,6 +70,9 @@ export const router = createBrowserRouter(
             />
           </Route>
 
+          {/* Routes accessible outside the root dashboard */}
+          <Route path={ROUTES.TEAM_ONBOARDING} lazy={() => import('./routes/team-onboarding')} />
+
           {/* Dashboard UI routes */}
           <Route path="/" id={ROUTE_LOADER_IDS.DASHBOARD} lazy={() => import('./routes/_dashboard')}>
             <Route
@@ -88,15 +91,13 @@ export const router = createBrowserRouter(
               shouldRevalidate={dontRevalidateDialogs}
             />
 
-            <Route path="teams">
-              <Route path="create" lazy={() => import('./routes/teams.create')} />
-              <Route path=":teamUuid" lazy={() => import('./routes/teams.$teamUuid')}>
-                <Route index lazy={() => import('./routes/teams.$teamUuid.index')} />
-                <Route path="files/private" lazy={() => import('./routes/teams.$teamUuid.files.private')} />
-                <Route path="members" lazy={() => import('./routes/teams.$teamUuid.members')} />
-                <Route path="settings" lazy={() => import('./routes/teams.$teamUuid.settings')} />
-                <Route path="connections" lazy={() => import('./routes/teams.$teamUuid.connections')} />
-              </Route>
+            <Route path={ROUTES.TEAMS_CREATE} lazy={() => import('./routes/teams.create')} />
+            <Route path="teams/:teamUuid" lazy={() => import('./routes/teams.$teamUuid')}>
+              <Route index lazy={() => import('./routes/teams.$teamUuid.index')} />
+              <Route path="files/private" lazy={() => import('./routes/teams.$teamUuid.files.private')} />
+              <Route path="members" lazy={() => import('./routes/teams.$teamUuid.members')} />
+              <Route path="settings" lazy={() => import('./routes/teams.$teamUuid.settings')} />
+              <Route path="connections" lazy={() => import('./routes/teams.$teamUuid.connections')} />
             </Route>
           </Route>
         </Route>

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -23,7 +23,6 @@ import {
   ShouldRevalidateFunctionArgs,
   isRouteErrorResponse,
   redirect,
-  redirectDocument,
   useLocation,
   useNavigation,
   useRevalidator,
@@ -89,10 +88,9 @@ export const loader = async ({ params, request }: LoaderFunctionArgs): Promise<L
   } else if (teams.length > 0) {
     initialActiveTeamUuid = teams[0].team.uuid;
 
-    // 4) there's no teams in the API, so create one and send the user to it
+    // 4) there's no teams in the API, send them to create one
   } else if (teams.length === 0) {
-    const newTeam = await apiClient.teams.create({ name: 'My Team' });
-    return redirectDocument(ROUTES.TEAM(newTeam.uuid));
+    return redirect(ROUTES.TEAM_ONBOARDING);
   }
 
   // This should never happen, but if it does, we'll log it to sentry

--- a/quadratic-client/src/routes/team-onboarding.tsx
+++ b/quadratic-client/src/routes/team-onboarding.tsx
@@ -1,0 +1,17 @@
+import { CreateTeamForm } from '@/routes/teams.create';
+import { Type } from '@/shared/components/Type';
+
+export const Component = () => {
+  return (
+    <div className="m-auto mt-8 max-w-lg rounded border border-border p-8 shadow-lg">
+      <img src="/logo192.png" width="32" height="32" alt="Quadratic logo" className="mb-6" />
+      <Type as="h1" className="text-xl font-medium">
+        Create a team
+      </Type>
+      <Type className="mb-6 text-muted-foreground">
+        A team is your collaborative space for working with other people.
+      </Type>
+      <CreateTeamForm />
+    </div>
+  );
+};

--- a/quadratic-client/src/routes/teams.create.tsx
+++ b/quadratic-client/src/routes/teams.create.tsx
@@ -20,40 +20,28 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ActionFunctionArgs, redirect, useFetcher, useLocation, useNavigate, useParams } from 'react-router-dom';
 import z from 'zod';
-type ActionData = {
-  name: string;
-  picture?: string;
-};
+
+const CreateTeamFormSchema = z.object({
+  name: TeamSchema.shape.name,
+});
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const data: ActionData = await request.json();
+  const data = await request.json();
 
-  const { uuid } = await apiClient.teams.create(data);
-  if (uuid) {
-    // const checkoutSessionUrl = await apiClient.teams.billing.getCheckoutSessionUrl(uuid);
+  try {
+    const body = CreateTeamFormSchema.parse(data);
+    const { uuid } = await apiClient.teams.create(body);
     return redirect(ROUTES.TEAM(uuid));
-  } else {
+  } catch (e) {
     return { ok: false };
   }
 };
-
-const FormSchema = z.object({
-  name: TeamSchema.shape.name,
-});
 
 export const Component = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { teamUuid } = useParams() as { teamUuid: string };
   const [open, setOpen] = useState(true);
-  const { addGlobalSnackbar } = useGlobalSnackbar();
-  const fetcher = useFetcher();
-  const form = useForm<z.infer<typeof FormSchema>>({
-    resolver: zodResolver(FormSchema),
-    defaultValues: {
-      name: '',
-    },
-  });
 
   // Open by default. When it closes, close it immediately then navigate.
   useEffect(() => {
@@ -66,6 +54,31 @@ export const Component = () => {
     }
   }, [open, navigate, teamUuid, location.key]);
 
+  const onClose = () => setOpen(false);
+
+  return open ? (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a team</DialogTitle>
+          <DialogDescription>A team is your collaborative space for working with other people.</DialogDescription>
+        </DialogHeader>
+        <CreateTeamForm onCancel={onClose} />
+      </DialogContent>
+    </Dialog>
+  ) : null;
+};
+
+export const CreateTeamForm = ({ onCancel }: { onCancel?: () => void }) => {
+  const { addGlobalSnackbar } = useGlobalSnackbar();
+  const fetcher = useFetcher();
+  const form = useForm<z.infer<typeof CreateTeamFormSchema>>({
+    resolver: zodResolver(CreateTeamFormSchema),
+    defaultValues: {
+      name: '',
+    },
+  });
+
   // Show some UI if the team creation failed
   useEffect(() => {
     if (fetcher.state === 'idle' && fetcher.data && fetcher.data.ok === false) {
@@ -73,50 +86,40 @@ export const Component = () => {
     }
   }, [fetcher, addGlobalSnackbar]);
 
-  const onSubmit = async (data: z.infer<typeof FormSchema>) => {
-    fetcher.submit(data, { method: 'POST', encType: 'application/json' });
+  const onSubmit = async (data: z.infer<typeof CreateTeamFormSchema>) => {
+    fetcher.submit(data, { action: '/teams/create', method: 'POST', encType: 'application/json' });
   };
-
-  const onClose = () => setOpen(false);
 
   const disabled = fetcher.state !== 'idle';
 
-  return open ? (
-    <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Create a team</DialogTitle>
-          <DialogDescription>Teams are a collaborative space for working with other people.</DialogDescription>
-        </DialogHeader>
-        <div>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Team name</FormLabel>
-                    <FormControl>
-                      <Input {...field} autoFocus autoComplete="off" disabled={disabled} />
-                    </FormControl>
-                    <FormDescription>You can always change this later</FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className="flex items-center justify-end gap-2">
-                <Button type="button" variant="outline" onClick={onClose} disabled={disabled}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="default" disabled={disabled}>
-                  {fetcher.state !== 'idle' && <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />} Create team
-                </Button>
-              </div>
-            </form>
-          </Form>
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Team name</FormLabel>
+              <FormControl>
+                <Input {...field} autoFocus autoComplete="off" disabled={disabled} />
+              </FormControl>
+              <FormDescription>You can always change this later</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex items-center justify-end gap-2">
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel} disabled={disabled}>
+              Cancel
+            </Button>
+          )}
+          <Button type="submit" variant="default" disabled={disabled}>
+            {fetcher.state !== 'idle' && <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />} Create team
+          </Button>
         </div>
-      </DialogContent>
-    </Dialog>
-  ) : null;
+      </form>
+    </Form>
+  );
 };

--- a/quadratic-client/src/shared/constants/routes.ts
+++ b/quadratic-client/src/shared/constants/routes.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
     (state ? `&state=${btoa(JSON.stringify({ insertAndRunCodeInNewSheet: state }))}` : ''),
   TEAMS: `/teams`,
   TEAMS_CREATE: `/teams/create`,
+  TEAM_ONBOARDING: `/team-onboarding`,
   TEAM: (teamUuid: string) => `/teams/${teamUuid}`,
   TEAM_CONNECTIONS: (teamUuid: string) => `/teams/${teamUuid}/connections`,
   TEAM_CONNECTION_CREATE: (teamUuid: string, connectionType: ConnectionType) =>


### PR DESCRIPTION
- [ ] Ask company name
- [ ] Can you code or not?


When users try to access `/` but they have 0 teams, this navigates them to a special page (`team-onboarding`) where they can create a new team by giving it a name.

Generally this will be hit by new users to the app, but would also apply to users who are part of a team and leave it (then have 0 teams).

![CleanShot 2024-08-29 at 11 48 13@2x](https://github.com/user-attachments/assets/2f388e7f-c735-4d28-8bf6-cd1ce32f2cc6)

It uses the same form component we use when the user clicks "new team" in the dashboard.

![CleanShot 2024-08-29 at 11 51 40@2x](https://github.com/user-attachments/assets/fc0a1b2f-9012-4546-b98a-21f654d5a41e)
