### PR TITLE
fix: remove discord link

### DIFF
--- a/quadratic-client/src/app/ui/menus/FeedbackMenu/FeedbackMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/FeedbackMenu/FeedbackMenu.tsx
@@ -1,7 +1,7 @@
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { apiClient } from '@/shared/api/apiClient';
 import { useGlobalSnackbar } from '@/shared/components/GlobalSnackbarProvider';
-import { BUG_REPORT_URL, DISCORD, TWITTER } from '@/shared/constants/urls';
+import { CONTACT_URL } from '@/shared/constants/urls';
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
 import { Button } from '@/shared/shadcn/ui/button';
 import {
@@ -66,19 +66,12 @@ export const FeedbackMenu = () => {
         <DialogHeader>
           <DialogTitle>Provide feedback</DialogTitle>
           <DialogDescription>
-            Or reach out to us on{' '}
-            <a href={BUG_REPORT_URL} target="_blank" rel="noreferrer" className="underline hover:text-primary">
-              GitHub
+            Or{' '}
+            <a href={CONTACT_URL} target="_blank" rel="noreferrer" className="underline hover:text-primary">
+              contact us by some other form
             </a>
-            ,{' '}
-            <a href={TWITTER} target="_blank" rel="noreferrer" className="underline hover:text-primary">
-              Twitter
-            </a>
-            , or{' '}
-            <a href={DISCORD} target="_blank" rel="noreferrer" className="underline hover:text-primary">
-              Discord
-            </a>
-            .
+            {', '}
+            we would love to hear from you!
           </DialogDescription>
         </DialogHeader>
         <form

--- a/quadratic-client/src/shared/constants/urls.ts
+++ b/quadratic-client/src/shared/constants/urls.ts
@@ -11,7 +11,6 @@ export const DOCUMENTATION_CONNECTIONS_IP_LIST_URL = `${DOCUMENTATION_CONNECTION
 export const DOCUMENTATION_BROWSER_COMPATIBILITY_URL = `${DOCUMENTATION_URL}/spreadsheet/browser-compatibility`;
 export const TRUST_CENTER = 'https://trust.quadratichq.com';
 export const BUG_REPORT_URL = 'https://github.com/quadratichq/quadratic/issues';
-export const DISCORD = 'https://discord.gg/quadratic';
 export const TWITTER = 'https://twitter.com/quadratichq';
 export const CONTACT_URL = 'https://quadratichq.com/contact';
 export const WEBSITE_CONNECTIONS = 'https://www.quadratichq.com/connections';


### PR DESCRIPTION
Provide the generic contact link on the marketing website, so future contact changes don't require a re-deploy of the app (this is what we do generally in the app).

Before:

![CleanShot 2024-08-29 at 12 06 28@2x](https://github.com/user-attachments/assets/d10773a7-04fc-4ae7-9eac-ba1432441d7a)

After:

![CleanShot 2024-08-29 at 12 06 33@2x](https://github.com/user-attachments/assets/332b598c-0240-4b0d-9fc4-8cf7e6d850da)
