### PR TITLE
Revert "Use upstream ts-rs"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,10 +4862,10 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts-rs"
-version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44017f9f875786e543595076374b9ef7d13465a518dd93d6ccdbf5b432dde8c"
+version = "7.0.0"
+source = "git+https://github.com/quadratichq/ts-rs/?rev=812c1a8#812c1a8b5ff3128916426e95e228f51430eb02cc"
 dependencies = [
+ "smallvec",
  "thiserror",
  "ts-rs-macros",
  "uuid",
@@ -4867,10 +4873,10 @@ dependencies = [
 
 [[package]]
 name = "ts-rs-macros"
-version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88cc88fd23b5a04528f3a8436024f20010a16ec18eb23c164b1242f65860130"
+version = "7.0.0"
+source = "git+https://github.com/quadratichq/ts-rs/?rev=812c1a8#812c1a8b5ff3128916426e95e228f51430eb02cc"
 dependencies = [
+ "Inflector",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.72",

--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -67,9 +67,9 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # JS dependencies that break the WASI build (which we need for benchmarks)
 js-sys = { version = "0.3.60", optional = true }
 serde-wasm-bindgen = { version = "0.6.0", optional = true }
-ts-rs = { version = "9.0.1", optional = true, features = [
+ts-rs = { git = "https://github.com/quadratichq/ts-rs/", rev = "812c1a8", optional = true, features = [
     "uuid-impl",
-    "no-serde-warnings",
+    "smallvec-impl",
 ] }
 wasm-bindgen = { version = "0.2.87", optional = true }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }


### PR DESCRIPTION
This reverts commit 4f614366e137f5de539282a90abda76528d16821.

Still using quadratichq/ts-rs (which is identical to the old HactarCE/ts-rs)