### PR TITLE
fix: rendering bug due to slow viewport buffer update

### DIFF
--- a/quadratic-core/src/controller/send_render.rs
+++ b/quadratic-core/src/controller/send_render.rs
@@ -14,7 +14,7 @@ use super::{
 };
 
 impl GridController {
-    fn send_render_cells_from_hash(&self, sheet_id: SheetId, modified: HashSet<Pos>) {
+    pub fn send_render_cells_from_hash(&self, sheet_id: SheetId, modified: &HashSet<Pos>) {
         // send the modified cells to the render web worker
         modified.iter().for_each(|modified| {
             if let Some(sheet) = self.try_sheet(sheet_id) {
@@ -56,7 +56,7 @@ impl GridController {
                 });
             }
         }
-        self.send_render_cells_from_hash(sheet_rect.sheet_id, modified);
+        self.send_render_cells_from_hash(sheet_rect.sheet_id, &modified);
     }
 
     /// Sends the modified cell sheets to the render web worker based on a
@@ -84,7 +84,7 @@ impl GridController {
                 }
             }
         }
-        self.send_render_cells_from_hash(selection.sheet_id, modified);
+        self.send_render_cells_from_hash(selection.sheet_id, &modified);
     }
 
     pub fn send_render_borders(&self, sheet_id: SheetId) {

--- a/quadratic-core/src/controller/viewport.rs
+++ b/quadratic-core/src/controller/viewport.rs
@@ -111,6 +111,12 @@ impl GridController {
                         .dirty_hashes
                         .insert(viewport_sheet_id, remaining_hashes);
                 }
+            } else {
+                for (&sheet_id, dirty_hashes) in transaction.dirty_hashes.iter_mut() {
+                    self.send_render_cells_from_hash(sheet_id, dirty_hashes);
+                    dirty_hashes.clear();
+                }
+                transaction.dirty_hashes.clear()
             }
         }
     }


### PR DESCRIPTION
fixes qa-wolf issue : https://quadratichq.slack.com/archives/C06Q34HGV8A/p1726598848314919

Bugs is happening because the transaction is over before render worker initialises the viewport buffer
The change in this PR is to send all dirty hashes if viewport buffer is not available.

A better fix is to have a constant viewport buffer b/w core and render worker, so that viewport information is always available to core.