### PR TITLE
Change Sheet saves input (for non-formula inline editor)

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
@@ -148,7 +148,7 @@ class InlineEditorHandler {
       }
       inlineEditorFormula.cursorMoved();
     } else {
-      this.close(0, 0, true);
+      this.close(0, 0, false, true);
     }
   };
 
@@ -368,7 +368,7 @@ class InlineEditorHandler {
   // Close editor. It saves the value if cancel = false. It also moves the
   // cursor by (deltaX, deltaY).
   // @returns whether the editor closed successfully
-  close = async (deltaX = 0, deltaY = 0, cancel: boolean): Promise<boolean> => {
+  close = async (deltaX = 0, deltaY = 0, cancel: boolean, skipChangeSheet = false): Promise<boolean> => {
     if (!this.open) return true;
     if (!this.location) {
       throw new Error('Expected location to be defined in InlineEditorHandler');
@@ -381,7 +381,9 @@ class InlineEditorHandler {
 
     if (!cancel) {
       // Ensure we're on the right sheet so we can show the change
-      sheets.current = this.location.sheetId;
+      if (!skipChangeSheet) {
+        sheets.current = this.location.sheetId;
+      }
 
       if (this.formula) {
         const updatedValue = inlineEditorFormula.closeParentheses();
@@ -419,7 +421,9 @@ class InlineEditorHandler {
             value.trim(),
             sheets.getCursorPosition()
           );
-          events.emit('hoverCell');
+          if (!skipChangeSheet) {
+            events.emit('hoverCell');
+          }
         }
       }
     }

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
@@ -412,6 +412,10 @@ class InlineEditorHandler {
         const validationError = await this.validateInput();
         if (validationError) {
           events.emit('hoverCell', { x: this.location.x, y: this.location.y, validationId: validationError, value });
+          // need to change the sheet back to the original sheet if there's a validation error
+          if (skipChangeSheet) {
+            sheets.current = location.sheetId;
+          }
           return false;
         } else {
           quadraticCore.setCellValue(


### PR DESCRIPTION
If you are editing a non-formula and change sheets, it properly saves the input before switching sheets. This fixes an annoying bug.