### PR TITLE
Fix hovering top-bar menu triggers canvas events

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -102,6 +102,12 @@ export class Pointer {
   };
 
   private pointerMove = (e: InteractionEvent): void => {
+    if (e.data.originalEvent.target) {
+      const target = e.data.originalEvent.target as HTMLElement;
+      if (target.tagName !== 'CANVAS') {
+        return;
+      }
+    }
     if (this.isMoreThanOneTouch(e) || this.isOverCodeEditor(e)) return;
     const world = pixiApp.viewport.toWorld(e.data.global);
     const event = e.data.originalEvent as PointerEvent;

--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -102,14 +102,11 @@ export class Pointer {
   };
 
   private pointerMove = (e: InteractionEvent): void => {
-    // if the top menu is open, skip checking pointerMove
-    const target = e.data.originalEvent.target as HTMLElement;
-    if (target) {
-      const contextMenu = document.querySelector('.top-bar-menubar');
-      if (contextMenu?.contains(target)) {
-        return;
-      }
-    }
+    // ignore pointerMove if the target is a child of an element with class pointer-move-stop-propagation
+    const target = e.data.originalEvent.target as HTMLElement | null;
+    const isWithinPointerMoveIgnore = !!target?.closest('.pointer-move-ignore');
+    if (isWithinPointerMoveIgnore) return;
+
     if (this.isMoreThanOneTouch(e) || this.isOverCodeEditor(e)) return;
     const world = pixiApp.viewport.toWorld(e.data.global);
     const event = e.data.originalEvent as PointerEvent;

--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -102,9 +102,11 @@ export class Pointer {
   };
 
   private pointerMove = (e: InteractionEvent): void => {
-    if (e.data.originalEvent.target) {
-      const target = e.data.originalEvent.target as HTMLElement;
-      if (target.tagName !== 'CANVAS') {
+    // if the top menu is open, skip checking pointerMove
+    const target = e.data.originalEvent.target as HTMLElement;
+    if (target) {
+      const contextMenu = document.querySelector('.top-bar-menubar');
+      if (contextMenu?.contains(target)) {
         return;
       }
     }

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/EditMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/EditMenubarMenu.tsx
@@ -6,7 +6,7 @@ export const EditMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Edit</MenubarTrigger>
-      <MenubarContent className="top-bar-menubar">
+      <MenubarContent className="pointer-move-ignore">
         <MenubarItemAction action={Action.Undo} actionArgs={undefined} />
         <MenubarItemAction action={Action.Redo} actionArgs={undefined} />
 

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/EditMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/EditMenubarMenu.tsx
@@ -6,7 +6,7 @@ export const EditMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Edit</MenubarTrigger>
-      <MenubarContent>
+      <MenubarContent className="top-bar-menubar">
         <MenubarItemAction action={Action.Undo} actionArgs={undefined} />
         <MenubarItemAction action={Action.Redo} actionArgs={undefined} />
 

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FileMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FileMenubarMenu.tsx
@@ -31,7 +31,7 @@ export const FileMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>File</MenubarTrigger>
-      <MenubarContent>
+      <MenubarContent className="top-bar-menubar">
         {createNewFileAction.isAvailable(isAvailableArgs) && (
           <MenubarItem onClick={() => createNewFileAction.run({ setEditorInteractionState })}>
             <DraftIcon /> {createNewFileAction.label}

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FileMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FileMenubarMenu.tsx
@@ -31,7 +31,7 @@ export const FileMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>File</MenubarTrigger>
-      <MenubarContent className="top-bar-menubar">
+      <MenubarContent className="pointer-move-ignore">
         {createNewFileAction.isAvailable(isAvailableArgs) && (
           <MenubarItem onClick={() => createNewFileAction.run({ setEditorInteractionState })}>
             <DraftIcon /> {createNewFileAction.label}

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FormatMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FormatMenubarMenu.tsx
@@ -27,7 +27,7 @@ export const FormatMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Format</MenubarTrigger>
-      <MenubarContent>
+      <MenubarContent className="top-bar-menubar">
         <MenubarSub>
           <MenubarSubTrigger>
             <Number123Icon /> Number

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FormatMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/FormatMenubarMenu.tsx
@@ -27,7 +27,7 @@ export const FormatMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Format</MenubarTrigger>
-      <MenubarContent className="top-bar-menubar">
+      <MenubarContent className="pointer-move-ignore">
         <MenubarSub>
           <MenubarSubTrigger>
             <Number123Icon /> Number

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/HelpMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/HelpMenubarMenu.tsx
@@ -6,7 +6,7 @@ export const HelpMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Help</MenubarTrigger>
-      <MenubarContent>
+      <MenubarContent className="top-bar-menubar">
         <MenubarItemAction action={Action.HelpDocs} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpFeedback} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpContactUs} actionArgs={undefined} />

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/HelpMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/HelpMenubarMenu.tsx
@@ -6,7 +6,7 @@ export const HelpMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Help</MenubarTrigger>
-      <MenubarContent className="top-bar-menubar">
+      <MenubarContent className="pointer-move-ignore">
         <MenubarItemAction action={Action.HelpDocs} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpFeedback} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpContactUs} actionArgs={undefined} />

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/InsertMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/InsertMenubarMenu.tsx
@@ -22,7 +22,7 @@ export const InsertMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Insert</MenubarTrigger>
-      <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()}>
+      <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()} className="top-bar-menubar">
         <MenubarSub>
           <MenubarSubTrigger>
             <CodeIcon /> Code

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/InsertMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/InsertMenubarMenu.tsx
@@ -22,7 +22,7 @@ export const InsertMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>Insert</MenubarTrigger>
-      <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()} className="top-bar-menubar">
+      <MenubarContent onCloseAutoFocus={(e) => e.preventDefault()} className="pointer-move-ignore">
         <MenubarSub>
           <MenubarSubTrigger>
             <CodeIcon /> Code

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/ViewMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/ViewMenubarMenu.tsx
@@ -27,7 +27,7 @@ export const ViewMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>View</MenubarTrigger>
-      <MenubarContent>
+      <MenubarContent className="top-bar-menubar">
         <MenubarItem
           onClick={() => {
             settings.setShowHeadings(!settings.showHeadings);

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/ViewMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarFileMenu/ViewMenubarMenu.tsx
@@ -27,7 +27,7 @@ export const ViewMenubarMenu = () => {
   return (
     <MenubarMenu>
       <MenubarTrigger>View</MenubarTrigger>
-      <MenubarContent className="top-bar-menubar">
+      <MenubarContent className="pointer-move-ignore">
         <MenubarItem
           onClick={() => {
             settings.setShowHeadings(!settings.showHeadings);


### PR DESCRIPTION
This fixes a subtle bug where the viewport receives pointermove events even when it is hovering over the top menu. 