### PR TITLE
Fixes bug with drag position when dragging sheet (in prod)

### DIFF
--- a/quadratic-client/src/app/ui/menus/SheetBar/SheetBar.tsx
+++ b/quadratic-client/src/app/ui/menus/SheetBar/SheetBar.tsx
@@ -170,6 +170,7 @@ export const SheetBar = (): JSX.Element => {
       const tab = event.currentTarget;
       if (tab) {
         const rect = tab.getBoundingClientRect();
+        rect.x -= sheetTabs.offsetLeft;
         const originalOrderIndex = getOrderIndex(sheet.order);
         down.current = {
           tab,


### PR DESCRIPTION
This fixes a minor bug where the drag point for the sheet tab was wrong (which was caused by the addition of the left navigation bar).

Current prod:


https://github.com/user-attachments/assets/64065c29-61c2-4e19-b7a4-07e0b664a230


