### PR TITLE
added ctrl+; for time now; fixed bug with inserting while editor is open

### DIFF
--- a/quadratic-client/.vscode/settings.json
+++ b/quadratic-client/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "ayush",
     "shadcn",
     "szhsin"
   ]

--- a/quadratic-client/src/app/actions/actions.ts
+++ b/quadratic-client/src/app/actions/actions.ts
@@ -132,6 +132,7 @@ export enum Action {
   RemoveInsertedCells = 'remove_inserted_cells',
   TriggerCell = 'trigger_cell',
   InsertToday = 'insert_today',
+  InsertTodayTime = 'insert_today_time',
   InsertColumnLeft = 'insert_column_left',
   InsertColumnRight = 'insert_column_right',
   InsertRowAbove = 'insert_row_above',

--- a/quadratic-client/src/app/actions/insertActionsSpec.ts
+++ b/quadratic-client/src/app/actions/insertActionsSpec.ts
@@ -30,6 +30,7 @@ type InsertActionSpec = Pick<
   | Action.InsertCellReference
   | Action.RemoveInsertedCells
   | Action.InsertToday
+  | Action.InsertTodayTime
 >;
 
 export const insertActionsSpec: InsertActionSpec = {
@@ -249,6 +250,17 @@ export const insertActionsSpec: InsertActionSpec = {
       const today = new Date();
       const formattedDate = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()}`;
       quadraticCore.setCellValue(sheet.id, cursor.cursorPosition.x, cursor.cursorPosition.y, formattedDate);
+    },
+  },
+  [Action.InsertTodayTime]: {
+    label: "Insert today's time",
+    Icon: FormatDateTimeIcon,
+    run: () => {
+      const sheet = sheets.sheet;
+      const cursor = sheet.cursor;
+      const today = new Date();
+      const formattedTime = `${today.getHours()}:${today.getMinutes()}:${today.getSeconds()}`;
+      quadraticCore.setCellValue(sheet.id, cursor.cursorPosition.x, cursor.cursorPosition.y, formattedTime);
     },
   },
 };

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
@@ -14,7 +14,6 @@ import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
 import { matchShortcut } from '@/app/helpers/keyboardShortcuts.js';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
-import { inlineEditorEvents } from './inlineEditorEvents';
 
 class InlineEditorKeyboard {
   escapeBackspacePressed = false;
@@ -326,7 +325,11 @@ class InlineEditorKeyboard {
       const today = new Date();
       // todo: this should be based on locale (maybe?)
       const formattedDate = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()}`;
-      inlineEditorEvents.emit('replaceText', formattedDate, false);
+      inlineEditorMonaco.insertTextAtCursor(formattedDate);
+    } else if (matchShortcut(Action.InsertTodayTime, e)) {
+      const today = new Date();
+      const formattedTime = `${today.getHours()}:${today.getMinutes()}:${today.getSeconds()}`;
+      inlineEditorMonaco.insertTextAtCursor(formattedTime);
     }
 
     // Fallback for all other keys (used to end cursorIsMoving and return

--- a/quadratic-client/src/app/gridGL/interaction/keyboard/useKeyboard.ts
+++ b/quadratic-client/src/app/gridGL/interaction/keyboard/useKeyboard.ts
@@ -54,6 +54,12 @@ export const useKeyboard = (): {
       const today = new Date();
       const formattedDate = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()}`;
       quadraticCore.setCellValue(sheet.id, cursor.cursorPosition.x, cursor.cursorPosition.y, formattedDate);
+    } else if (matchShortcut(Action.InsertTodayTime, event)) {
+      const sheet = sheets.sheet;
+      const cursor = sheet.cursor;
+      const today = new Date();
+      const formattedTime = `${today.getHours()}:${today.getMinutes()}:${today.getSeconds()}`;
+      quadraticCore.setCellValue(sheet.id, cursor.cursorPosition.x, cursor.cursorPosition.y, formattedTime);
     }
 
     // Prevent these commands if "command" key is being pressed

--- a/quadratic-client/src/app/keyboard/defaults.ts
+++ b/quadratic-client/src/app/keyboard/defaults.ts
@@ -346,10 +346,11 @@ export const defaultShortcuts: ActionShortcut = {
     windows: [[Keys.Space]],
   },
   [Action.InsertToday]: {
-    mac: [
-      [MacModifiers.Ctrl, Keys.Semicolon],
-      [MacModifiers.Cmd, Keys.Semicolon],
-    ],
+    mac: [[MacModifiers.Cmd, Keys.Semicolon]],
     windows: [[WindowsModifiers.Ctrl, Keys.Semicolon]],
+  },
+  [Action.InsertTodayTime]: {
+    mac: [[MacModifiers.Ctrl, Keys.Semicolon]],
+    windows: [[WindowsModifiers.Ctrl, WindowsModifiers.Shift, Keys.Semicolon]],
   },
 };

--- a/quadratic-client/src/app/ui/menus/CommandPalette/commands/Edit.tsx
+++ b/quadratic-client/src/app/ui/menus/CommandPalette/commands/Edit.tsx
@@ -19,6 +19,7 @@ const data: CommandGroup = {
     Action.FindInCurrentSheet,
     Action.FindInAllSheets,
     Action.InsertToday,
+    Action.InsertTodayTime,
     {
       label: 'Copy selection as PNG',
       isAvailable: () => fullClipboardSupport(),


### PR DESCRIPTION
- [x] ctrl+; (mac) and ctrl+shift+; (windows) inserts time
- [x] fixed bug with insertion date/time when inline editor replaced instead of inserted 