### PR TITLE
feat: show logged in user context

### DIFF
--- a/quadratic-client/src/dashboard/components/Empty.tsx
+++ b/quadratic-client/src/dashboard/components/Empty.tsx
@@ -43,7 +43,7 @@ export function Empty({
       {showLoggedInUser && loggedInUser && (
         <div className="mx-auto mt-12 max-w-96 border-t border-border pt-2">
           <div className="mx-auto flex items-center gap-2 rounded-md pt-2 text-left text-sm">
-            <Avatar src={loggedInUser.picture} alt="Avatar for" className="flex-shrink-0">
+            <Avatar src={loggedInUser.picture} alt={`Avatar for ${loggedInUser.name}`} className="flex-shrink-0">
               {loggedInUser.name}
             </Avatar>
             <div className="flex flex-col justify-start truncate">

--- a/quadratic-client/src/dashboard/components/Empty.tsx
+++ b/quadratic-client/src/dashboard/components/Empty.tsx
@@ -1,7 +1,12 @@
+import { useRootRouteLoaderData } from '@/routes/_root';
+import { Avatar } from '@/shared/components/Avatar';
 import { TYPE } from '@/shared/constants/appConstants';
+import { ROUTES } from '@/shared/constants/routes';
+import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
 import { StopwatchIcon } from '@radix-ui/react-icons';
 import { ReactNode } from 'react';
+import { useSubmit } from 'react-router-dom';
 
 export function Empty({
   title,
@@ -10,6 +15,7 @@ export function Empty({
   Icon,
   severity,
   className,
+  showLoggedInUser,
 }: {
   title: String;
   description: ReactNode;
@@ -17,7 +23,11 @@ export function Empty({
   Icon: typeof StopwatchIcon;
   severity?: 'error';
   className?: string;
+  showLoggedInUser?: boolean;
 }) {
+  const { loggedInUser } = useRootRouteLoaderData();
+  const submit = useSubmit();
+
   return (
     <div className={cn(`max-w mx-auto my-10 max-w-md px-2 text-center`, className)}>
       <div
@@ -30,6 +40,27 @@ export function Empty({
       <div className={`text-sm text-muted-foreground`}>{description}</div>
 
       {actions && <div className={`mt-8`}>{actions}</div>}
+      {showLoggedInUser && loggedInUser && (
+        <div className="mx-auto mt-12 max-w-96 border-t border-border pt-2">
+          <div className="mx-auto flex items-center gap-2 rounded-md pt-2 text-left text-sm">
+            <Avatar src={loggedInUser.picture} alt="Avatar for" className="flex-shrink-0">
+              {loggedInUser.name}
+            </Avatar>
+            <div className="flex flex-col justify-start truncate">
+              {loggedInUser.name}
+              <span className="text-xs text-muted-foreground">{loggedInUser.email}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-auto"
+              onClick={() => submit('', { method: 'POST', action: ROUTES.LOGOUT })}
+            >
+              Logout
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -281,6 +281,7 @@ export const ErrorBoundary = () => {
           description="Reach out to the team owner for permission to access this team."
           Icon={InfoCircledIcon}
           actions={actions}
+          showLoggedInUser
         />
       );
     if (error.status === 404 || error.status === 400)
@@ -290,6 +291,7 @@ export const ErrorBoundary = () => {
           description="This team may have been deleted, moved, or made unavailable. Try reaching out to the team owner."
           Icon={ExclamationTriangleIcon}
           actions={actions}
+          showLoggedInUser
         />
       );
   }
@@ -307,6 +309,7 @@ export const ErrorBoundary = () => {
         </Button>
       }
       severity="error"
+      showLoggedInUser
     />
   );
 };

--- a/quadratic-client/src/routes/file.$uuid.tsx
+++ b/quadratic-client/src/routes/file.$uuid.tsx
@@ -159,7 +159,15 @@ export const ErrorBoundary = () => {
       title = 'Failed to load file';
       description = 'There was an error retrieving and loading this file.';
     }
-    return <Empty title={title} description={description} Icon={ExclamationTriangleIcon} actions={actions} />;
+    return (
+      <Empty
+        title={title}
+        description={description}
+        Icon={ExclamationTriangleIcon}
+        actions={actions}
+        showLoggedInUser
+      />
+    );
   }
 
   // If we reach here, it's an error we don't know how to handle.
@@ -172,6 +180,7 @@ export const ErrorBoundary = () => {
       Icon={ExclamationTriangleIcon}
       actions={actions}
       severity="error"
+      showLoggedInUser
     />
   );
 };


### PR DESCRIPTION
On the dashboard or in the app, there are times you can hit a route that results in a screen where something went wrong.

Today it's not always clear that you might be hitting that error based on who you're logged in as.

For example, I go to `/teams/team-id-1` and it says "You can't access this team" and I think "I should be able to, that's weird..."

But the reality is that I can't access that team because I'm not logged in as the user I think I am when I hit that screen.

So this PR makes it a lot easier to infer why you might be hitting these screens, as it will show you you're currently logged in status (if you're logged in — if you're not logged in, e.g. an anon user, it won't show this).

Examples:

**You don't have permission to see team**

![CleanShot 2024-10-17 at 13 42 37@2x](https://github.com/user-attachments/assets/795472f3-442c-4743-83ce-b018fb56ec4e)

**Team not found**

![CleanShot 2024-10-17 at 13 42 29@2x](https://github.com/user-attachments/assets/4b45f6f5-c263-46a8-b5b1-d9b760531ba4)

**Unexpected error**

![CleanShot 2024-10-17 at 13 44 32@2x](https://github.com/user-attachments/assets/9c8f1f23-a5a7-41ce-94c0-8880244c7ef8)



