### PR TITLE
fix: optimistic UI when changing user role

### DIFF
--- a/quadratic-client/src/shared/components/ShareDialog.tsx
+++ b/quadratic-client/src/shared/components/ShareDialog.tsx
@@ -648,6 +648,13 @@ function ManageUser({
   let activeRole = user.role;
   let error = undefined;
 
+  // If the user's role is being updated, show the optimistic value
+  if (fetcherUpdate.state !== 'idle' && isJsonObject(fetcherUpdate.json)) {
+    activeRole = fetcherUpdate.json.role as (typeof roles)[0];
+  } else if (fetcherUpdate.data && !fetcherUpdate.data.ok) {
+    error = 'Failed to update. Try again.';
+  }
+
   const label = useMemo(() => getRoleLabel(activeRole), [activeRole]);
 
   // If user is being deleted, hide them
@@ -656,13 +663,6 @@ function ManageUser({
     // If there was a failure to delete, show an error
   } else if (fetcherDelete.data && !fetcherDelete.data.ok) {
     error = 'Failed to delete. Try again.';
-  }
-
-  // If the user's role is being updated, show the optimistic value
-  if (fetcherUpdate.state !== 'idle' && isJsonObject(fetcherUpdate.json)) {
-    activeRole = fetcherUpdate.json.role as (typeof roles)[0];
-  } else if (fetcherUpdate.data && !fetcherUpdate.data.ok) {
-    error = 'Failed to update. Try again.';
   }
 
   return (


### PR DESCRIPTION
When changing a user's role on a team, the UI updates immediately (while the change goes over the network).


https://github.com/user-attachments/assets/eea09ccd-6678-4dc0-8a24-f385e88e26f7

