### PR TITLE
Search dialog triggers when manually changing sheets

### DIFF
--- a/quadratic-client/src/app/ui/components/Search.tsx
+++ b/quadratic-client/src/app/ui/components/Search.tsx
@@ -15,7 +15,7 @@ import {
 import { Input } from '@/shared/shadcn/ui/input';
 import { Popover, PopoverAnchor, PopoverContent } from '@/shared/shadcn/ui/popover';
 import { ChevronLeftIcon, ChevronRightIcon, Cross2Icon, DotsHorizontalIcon } from '@radix-ui/react-icons';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 const findInSheetActionSpec = defaultActionSpec[Action.FindInCurrentSheet];
@@ -36,23 +36,26 @@ export function Search() {
 
   const placeholder = !searchOptions.sheet_id ? findInSheetsActionSpec.label : findInSheetActionSpec.label;
 
-  const onChange = async (search: string, updatedSearchOptions = searchOptions) => {
-    if (search.length > 0) {
-      const found = await quadraticCore.search(search, updatedSearchOptions);
-      if (found.length) {
-        setResults(found);
-        setCurrent(0);
-        moveCursor(found[0]);
-        events.emit(
-          'search',
-          found.map((found) => ({ x: Number(found.x), y: Number(found.y), sheetId: found.sheet_id.id }), 0)
-        );
-        return;
+  const onChange = useCallback(
+    async (search: string, updatedSearchOptions = searchOptions) => {
+      if (search.length > 0) {
+        const found = await quadraticCore.search(search, updatedSearchOptions);
+        if (found.length) {
+          setResults(found);
+          setCurrent(0);
+          moveCursor(found[0]);
+          events.emit(
+            'search',
+            found.map((found) => ({ x: Number(found.x), y: Number(found.y), sheetId: found.sheet_id.id }), 0)
+          );
+          return;
+        }
       }
-    }
-    setResults([]);
-    events.emit('search');
-  };
+      setResults([]);
+      events.emit('search');
+    },
+    [searchOptions]
+  );
 
   const moveCursor = (pos: SheetPos) => {
     if (sheets.sheet.id !== pos.sheet_id.id) {
@@ -109,22 +112,21 @@ export function Search() {
 
   useEffect(() => {
     const changeSheet = () => {
-      if (!showSearch) {
+      if (!showSearch || !searchOptions.sheet_id) {
         return;
       }
-      setSearchOptions((prev) => {
-        if (prev.sheet_id) {
-          return { ...prev, sheet_id: sheets.sheet.id };
-        } else {
-          return prev;
-        }
-      });
+      const newSearchOptions = { ...searchOptions };
+      if (searchOptions.sheet_id) {
+        newSearchOptions.sheet_id = sheets.sheet.id;
+      }
+      setSearchOptions(newSearchOptions);
+      onChange((inputRef.current as HTMLInputElement).value, newSearchOptions);
     };
     events.on('changeSheet', changeSheet);
     return () => {
       events.off('changeSheet', changeSheet);
     };
-  }, [showSearch]);
+  }, [showSearch, searchOptions, onChange]);
 
   useEffect(() => {
     if (!showSearch) {


### PR DESCRIPTION
closes #1989

When searching on one sheet, if you manually change sheets, then the search dialog will search that sheet with the same options. When searching all sheets, then the behavior is the same as before.