### PR TITLE
feat: dashboard design tweaks

### DIFF
--- a/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
+++ b/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
@@ -1,10 +1,7 @@
-import { colors } from '@/app/theme/colors';
 import { newFileDialogAtom } from '@/dashboard/atoms/newFileDialogAtom';
 import { TeamSwitcher } from '@/dashboard/components/TeamSwitcher';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
-import { useRootRouteLoaderData } from '@/routes/_root';
 import { getActionFileMove } from '@/routes/api.files.$uuid';
-import { Avatar } from '@/shared/components/Avatar';
 import {
   AddIcon,
   DatabaseIcon,
@@ -35,7 +32,6 @@ import { useSetRecoilState } from 'recoil';
  */
 export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
   const [, setSearchParams] = useSearchParams();
-  const { loggedInUser: user } = useRootRouteLoaderData();
   const {
     userMakingRequest: { id: ownerUserId },
     eduStatus,
@@ -49,11 +45,11 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
   const classNameIcons = `mx-0.5 text-muted-foreground`;
 
   return (
-    <nav className={`flex h-full flex-col gap-4 overflow-auto`}>
-      <div className="sticky top-0 z-10 flex flex-col bg-background px-4 pt-4">
+    <nav className={`flex h-full flex-col gap-4 overflow-auto bg-accent`}>
+      <div className="sticky top-0 z-10 flex flex-col bg-accent px-3 pt-3">
         <TeamSwitcher appIsLoading={isLoading} />
       </div>
-      <div className={`flex flex-col px-4`}>
+      <div className={`flex flex-col px-3`}>
         <Type
           as="h3"
           variant="overline"
@@ -129,7 +125,7 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
           </SidebarNavLink>
         </div>
       </div>
-      <div className="mt-auto flex flex-col gap-1 bg-background px-4 pb-2">
+      <div className="mt-auto flex flex-col gap-1 bg-accent px-3 pb-2">
         {eduStatus === 'ENROLLED' && (
           <SidebarNavLink
             to={`./?${SEARCH_PARAMS.DIALOG.KEY}=${SEARCH_PARAMS.DIALOG.VALUES.EDUCATION}`}
@@ -154,22 +150,6 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
         <SidebarNavLink to="/labs">
           <LabsIcon className={classNameIcons} />
           Labs
-        </SidebarNavLink>
-        <SidebarNavLink to={ROUTES.ACCOUNT}>
-          <Avatar
-            src={user?.picture}
-            alt={user?.name}
-            style={{
-              backgroundColor: colors.quadraticSecondary,
-            }}
-          >
-            {user?.name}
-          </Avatar>
-
-          <div className={`flex flex-col overflow-hidden`}>
-            {user?.name || 'You'}
-            {user?.email && <p className={`truncate ${TYPE.caption} text-muted-foreground`}>{user?.email}</p>}
-          </div>
         </SidebarNavLink>
       </div>
     </nav>
@@ -256,8 +236,8 @@ function SidebarNavLink({
     : {};
 
   const classes = cn(
-    isActive && !isLogo && 'bg-muted',
-    !isLogo && 'hover:bg-accent',
+    isActive && !isLogo && 'bg-border font-medium',
+    !isLogo && 'hover:bg-border',
     isDraggingOver && 'bg-primary text-primary-foreground',
     TYPE.body2,
     `relative flex items-center gap-2 p-2 no-underline rounded`,

--- a/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
+++ b/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
@@ -1,7 +1,9 @@
 import { newFileDialogAtom } from '@/dashboard/atoms/newFileDialogAtom';
 import { TeamSwitcher } from '@/dashboard/components/TeamSwitcher';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
+import { useRootRouteLoaderData } from '@/routes/_root';
 import { getActionFileMove } from '@/routes/api.files.$uuid';
+import { Avatar } from '@/shared/components/Avatar';
 import {
   AddIcon,
   DatabaseIcon,
@@ -32,6 +34,7 @@ import { useSetRecoilState } from 'recoil';
  */
 export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
   const [, setSearchParams] = useSearchParams();
+  const { loggedInUser: user } = useRootRouteLoaderData();
   const {
     userMakingRequest: { id: ownerUserId },
     eduStatus,
@@ -151,6 +154,16 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
           <LabsIcon className={classNameIcons} />
           Labs
         </SidebarNavLink>
+        <SidebarNavLink to="/account">
+          <Avatar src={user?.picture} alt={user?.name}>
+            {user?.name}
+          </Avatar>
+
+          <div className={`flex flex-col overflow-hidden text-left`}>
+            {user?.name || 'You'}
+            {user?.email && <p className={`truncate ${TYPE.caption} text-muted-foreground`}>{user?.email}</p>}
+          </div>
+        </SidebarNavLink>
       </div>
     </nav>
   );
@@ -164,7 +177,7 @@ function SidebarNavLinkCreateButton({ children, isPrivate }: { children: ReactNo
         <Button
           variant="ghost"
           size="icon-sm"
-          className="absolute right-2 top-1 ml-auto opacity-30 hover:opacity-100"
+          className="absolute right-2 top-1 ml-auto !bg-transparent opacity-30 hover:opacity-100"
           onClick={() => setNewFileDialogState({ show: true, isPrivate })}
         >
           <AddIcon />
@@ -174,6 +187,12 @@ function SidebarNavLinkCreateButton({ children, isPrivate }: { children: ReactNo
     </Tooltip>
   );
 }
+
+export const sidebarItemClasses = {
+  base: `dark:hover:brightness-125 hover:brightness-95 hover:saturate-150 dark:hover:saturate-100 bg-accent relative flex items-center gap-2 p-2 no-underline rounded`,
+  active: `bg-accent dark:brightness-125 brightness-95 saturate-150 dark:saturate-100`,
+  dragging: `bg-primary text-primary-foreground`,
+};
 
 function SidebarNavLink({
   to,
@@ -236,11 +255,10 @@ function SidebarNavLink({
     : {};
 
   const classes = cn(
-    isActive && !isLogo && 'bg-border font-medium',
-    !isLogo && 'hover:bg-border',
-    isDraggingOver && 'bg-primary text-primary-foreground',
+    sidebarItemClasses.base,
+    isActive && sidebarItemClasses.active,
+    isDraggingOver && sidebarItemClasses.dragging,
     TYPE.body2,
-    `relative flex items-center gap-2 p-2 no-underline rounded`,
     className
   );
 

--- a/quadratic-client/src/dashboard/components/TeamSwitcher.tsx
+++ b/quadratic-client/src/dashboard/components/TeamSwitcher.tsx
@@ -1,10 +1,8 @@
+import { sidebarItemClasses } from '@/dashboard/components/DashboardSidebar';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
-import { useRootRouteLoaderData } from '@/routes/_root';
 import { TeamAction } from '@/routes/teams.$teamUuid';
-import { Avatar } from '@/shared/components/Avatar';
-import { AccountIcon, AddIcon, ArrowDropDownIcon, CheckIcon, LogoutIcon, RefreshIcon } from '@/shared/components/Icons';
+import { AddIcon, ArrowDropDownIcon, CheckIcon, RefreshIcon } from '@/shared/components/Icons';
 import { Type } from '@/shared/components/Type';
-import { TYPE } from '@/shared/constants/appConstants';
 import { ROUTES } from '@/shared/constants/routes';
 import {
   DropdownMenu,
@@ -13,17 +11,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/shared/shadcn/ui/dropdown-menu';
+import { cn } from '@/shared/shadcn/utils';
 import { isJsonObject } from '@/shared/utils/isJsonObject';
 import { ReactNode } from 'react';
-import { Link, useFetcher, useNavigate, useSubmit } from 'react-router-dom';
+import { Link, useFetcher, useNavigate } from 'react-router-dom';
 
 type Props = {
   appIsLoading: boolean;
 };
 
 export function TeamSwitcher({ appIsLoading }: Props) {
-  const submit = useSubmit();
-  const { loggedInUser } = useRootRouteLoaderData();
   const { teams } = useDashboardRouteLoaderData();
   const {
     activeTeam: {
@@ -40,20 +37,13 @@ export function TeamSwitcher({ appIsLoading }: Props) {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="group flex items-center justify-between gap-2 rounded p-2 text-left hover:bg-border focus:outline-none ">
-        <Avatar src={loggedInUser?.picture} alt={loggedInUser?.name}>
-          {loggedInUser?.name}
-        </Avatar>
-
-        <div className={`flex flex-grow flex-col overflow-hidden`}>
-          <span className="truncate text-sm font-semibold">{optimisticActiveTeamName}</span>
-          {loggedInUser?.email && (
-            <span className={`truncate ${TYPE.caption} text-muted-foreground`}>{loggedInUser?.email}</span>
-          )}
+      <DropdownMenuTrigger className={cn(`gap-2 py-1 text-sm font-semibold`, sidebarItemClasses.base)}>
+        <div className="mx-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded bg-foreground capitalize text-background">
+          {activeTeamName.slice(0, 1)}
         </div>
-
-        <div className="relative flex items-center pr-1">
-          <ArrowDropDownIcon className="text-muted-foreground group-hover:text-foreground" />
+        <div className="select-none truncate">{optimisticActiveTeamName}</div>
+        <div className="relative ml-auto mr-0.5 flex items-center">
+          <ArrowDropDownIcon />
           <RefreshIcon
             className={`absolute left-0 top-0 ml-auto animate-spin bg-accent text-primary transition-opacity ${
               appIsLoading ? '' : ' opacity-0'
@@ -61,7 +51,7 @@ export function TeamSwitcher({ appIsLoading }: Props) {
           />
         </div>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-72">
+      <DropdownMenuContent className="min-w-72" align="start" alignOffset={-4}>
         {teams.map(({ team: { uuid, name }, users }) => {
           const isActive = activeTeamUuid === uuid;
           return (
@@ -82,20 +72,27 @@ export function TeamSwitcher({ appIsLoading }: Props) {
                   {isPaid ? <DotFilledIcon className="text-success" /> : <DotIcon className="text-warning" />}
                 </IconWrapper> */}
 
-                <IconWrapper>{isActive && <CheckIcon />}</IconWrapper>
+                <IconWrapper
+                  className={cn(
+                    'h-5 w-5 rounded border border-border capitalize',
+                    isActive && 'border-foreground bg-foreground text-background'
+                  )}
+                >
+                  {name.slice(0, 1)}
+                </IconWrapper>
                 <div className="flex flex-col">
                   <div>{name}</div>
                   <Type variant="caption">
                     {users} member{users === 1 ? '' : 's'}
                   </Type>
                 </div>
-                {/* <div className="ml-auto flex h-6 w-6 items-center justify-center">
-                  {isActive && <CheckCircledIcon />}
-                </div> */}
+                <div className="ml-auto flex h-6 w-6 items-center justify-center">{isActive && <CheckIcon />}</div>
               </Link>
             </DropdownMenuItem>
           );
         })}
+
+        <DropdownMenuSeparator />
 
         <DropdownMenuItem
           className="flex gap-3 text-muted-foreground"
@@ -108,34 +105,11 @@ export function TeamSwitcher({ appIsLoading }: Props) {
           </IconWrapper>
           Create team
         </DropdownMenuItem>
-
-        <DropdownMenuSeparator />
-
-        <DropdownMenuItem asChild>
-          <Link to={ROUTES.ACCOUNT} className="flex gap-3 text-muted-foreground">
-            <IconWrapper>
-              <AccountIcon />
-            </IconWrapper>
-            My account
-          </Link>
-        </DropdownMenuItem>
-
-        <DropdownMenuItem
-          className="flex gap-3 text-muted-foreground"
-          onClick={() => {
-            submit('', { method: 'POST', action: ROUTES.LOGOUT });
-          }}
-        >
-          <IconWrapper>
-            <LogoutIcon />
-          </IconWrapper>
-          Log out
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
 }
 
-function IconWrapper({ children }: { children: ReactNode }) {
-  return <div className="flex h-6 w-6 items-center justify-center">{children}</div>;
+function IconWrapper({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn('flex h-6 w-6 items-center justify-center', className)}>{children}</div>;
 }

--- a/quadratic-client/src/dashboard/components/TeamSwitcher.tsx
+++ b/quadratic-client/src/dashboard/components/TeamSwitcher.tsx
@@ -1,15 +1,15 @@
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { TeamAction } from '@/routes/teams.$teamUuid';
-import { AddIcon, ArrowDropDownIcon, CheckIcon, LogoutIcon, RefreshIcon } from '@/shared/components/Icons';
+import { Avatar } from '@/shared/components/Avatar';
+import { AccountIcon, AddIcon, ArrowDropDownIcon, CheckIcon, LogoutIcon, RefreshIcon } from '@/shared/components/Icons';
 import { Type } from '@/shared/components/Type';
+import { TYPE } from '@/shared/constants/appConstants';
 import { ROUTES } from '@/shared/constants/routes';
-import { Button } from '@/shared/shadcn/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/shared/shadcn/ui/dropdown-menu';
@@ -40,22 +40,28 @@ export function TeamSwitcher({ appIsLoading }: Props) {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" className="flex justify-between px-3 font-semibold">
-          <div className="select-none truncate">{optimisticActiveTeamName}</div>
-          <div className="relative flex items-center">
-            <ArrowDropDownIcon />
-            <RefreshIcon
-              className={`absolute left-0 top-0 ml-auto animate-spin bg-background text-primary transition-opacity ${
-                appIsLoading ? '' : ' opacity-0'
-              }`}
-            />
-          </div>
-        </Button>
+      <DropdownMenuTrigger className="group flex items-center justify-between gap-2 rounded p-2 text-left hover:bg-border focus:outline-none ">
+        <Avatar src={loggedInUser?.picture} alt={loggedInUser?.name}>
+          {loggedInUser?.name}
+        </Avatar>
+
+        <div className={`flex flex-grow flex-col overflow-hidden`}>
+          <span className="truncate text-sm font-semibold">{optimisticActiveTeamName}</span>
+          {loggedInUser?.email && (
+            <span className={`truncate ${TYPE.caption} text-muted-foreground`}>{loggedInUser?.email}</span>
+          )}
+        </div>
+
+        <div className="relative flex items-center pr-1">
+          <ArrowDropDownIcon className="text-muted-foreground group-hover:text-foreground" />
+          <RefreshIcon
+            className={`absolute left-0 top-0 ml-auto animate-spin bg-accent text-primary transition-opacity ${
+              appIsLoading ? '' : ' opacity-0'
+            }`}
+          />
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-72">
-        <DropdownMenuLabel className="text-xs text-muted-foreground">{loggedInUser?.email}</DropdownMenuLabel>
-
         {teams.map(({ team: { uuid, name }, users }) => {
           const isActive = activeTeamUuid === uuid;
           return (
@@ -91,8 +97,6 @@ export function TeamSwitcher({ appIsLoading }: Props) {
           );
         })}
 
-        <DropdownMenuSeparator />
-
         <DropdownMenuItem
           className="flex gap-3 text-muted-foreground"
           onClick={() => {
@@ -103,6 +107,17 @@ export function TeamSwitcher({ appIsLoading }: Props) {
             <AddIcon />
           </IconWrapper>
           Create team
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem asChild>
+          <Link to={ROUTES.ACCOUNT} className="flex gap-3 text-muted-foreground">
+            <IconWrapper>
+              <AccountIcon />
+            </IconWrapper>
+            My account
+          </Link>
         </DropdownMenuItem>
 
         <DropdownMenuItem

--- a/quadratic-client/src/shared/components/Icons.tsx
+++ b/quadratic-client/src/shared/components/Icons.tsx
@@ -32,6 +32,10 @@ const Icon = (props: BaseIconProps) => {
 type IconProps = Omit<BaseIconProps, 'children'>;
 export type IconComponent = React.FC<IconProps>;
 
+export const AccountIcon: IconComponent = (props) => {
+  return <Icon {...props}>account_circle</Icon>;
+};
+
 export const AddIcon: IconComponent = (props) => {
   return <Icon {...props}>add</Icon>;
 };


### PR DESCRIPTION
- Make the dashboard background color the same as when you're in the app
- Tweak the team switcher to be purely about the current team (account stuff stays in the bottom)

<img width=300 src=https://github.com/user-attachments/assets/7c64aa8c-88cc-4e50-8ab7-f2f1d5e28f31 >

<img width=300 src=https://github.com/user-attachments/assets/4dbcdec8-b8da-44ac-8ef0-f855c124a71a >
