### PR TITLE
fix: support theming in app bar

### DIFF
--- a/quadratic-client/src/shared/hooks/useThemeAppearanceMode.tsx
+++ b/quadratic-client/src/shared/hooks/useThemeAppearanceMode.tsx
@@ -1,5 +1,6 @@
 import { useFeatureFlag } from '@/shared/hooks/useFeatureFlag';
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
+import { getCSSVariableAsHexColor } from '@/shared/utils/colors';
 import { useEffect } from 'react';
 
 const DEFAULT_APPEARANCE_MODE = 'light';
@@ -51,6 +52,20 @@ export const ThemeAppearanceModeEffects = () => {
     return () => {
       userPrefesDarkMode.removeEventListener('change', handleMatch);
     };
+  }, [appearanceMode, userPrefesDarkMode]);
+
+  useEffect(() => {
+    const metaTag = document.querySelector('meta[name="theme-color"]');
+    const hexColor = getCSSVariableAsHexColor('background');
+
+    if (metaTag) {
+      metaTag.setAttribute('content', hexColor);
+    } else {
+      const meta = document.createElement('meta');
+      meta.name = 'theme-color';
+      meta.content = hexColor;
+      document.head.appendChild(meta);
+    }
   }, [appearanceMode, userPrefesDarkMode]);
 
   return null;

--- a/quadratic-client/src/shared/utils/colors.ts
+++ b/quadratic-client/src/shared/utils/colors.ts
@@ -1,0 +1,15 @@
+import Color from 'color';
+
+export function getCSSVariableAsHexColor(cssVariableName: string) {
+  if (cssVariableName.startsWith('--')) {
+    console.warn(
+      '`getCSSVariableTint` expects a CSS variable name without the `--` prefix. Are you sure you meant: `%s`',
+      cssVariableName
+    );
+  }
+
+  const hslColorString = getComputedStyle(document.documentElement).getPropertyValue(`--${cssVariableName}`).trim();
+  const parsed = Color.hsl(hslColorString.split(' ').map(parseFloat));
+  const out = parsed.hex();
+  return out;
+}


### PR DESCRIPTION
When you add install Quadratic as a standalone app, for example using Chrome:

![CleanShot 2024-10-30 at 15 08 22@2x](https://github.com/user-attachments/assets/4e0664a5-6742-458b-9cf0-b376280bd6cf)

It gets its own app bar. This needs to adjust to the theme color when the theme changes. This adds a `<meta>` tag that browsers use as a cue for this, so when you change it in the UI, the browser will update the app bar color too.


https://github.com/user-attachments/assets/10c3e6fd-9c57-44e1-8812-3243cad0aca9


