### PR TITLE
fix: all v1_4 code cell are imported as formula

### DIFF
--- a/quadratic-core/src/grid/file/v1_4/file.rs
+++ b/quadratic-core/src/grid/file/v1_4/file.rs
@@ -33,8 +33,11 @@ fn upgrade_column(sheet: &v1_4::Sheet, x: &i64, column: &v1_4::Column) -> (i64, 
             if cell_ref.column == column.id {
                 let pos = cell_ref_to_pos(sheet, cell_ref);
                 let language = Some(
-                    serde_json::from_str::<CodeCellLanguage>(&code_cell_value.language)
-                        .unwrap_or(CodeCellLanguage::Formula),
+                    serde_json::from_str::<CodeCellLanguage>(&format!(
+                        "{:?}",
+                        code_cell_value.language
+                    ))
+                    .unwrap_or(CodeCellLanguage::Formula),
                 );
                 // let language = match code_cell_value.language.to_lowercase().as_str() {
                 //     "python" => Some(v1_5::CodeCellLanguage::Python),


### PR DESCRIPTION
fixes import of this charts example:

![image](https://github.com/user-attachments/assets/b8ab82ef-7507-4f4d-878c-fa53253492a5)


![image](https://github.com/user-attachments/assets/8ba899ad-81c4-4350-a911-aead06e278be)
