### PR TITLE
Change code editor shortcut language from "Return to sheet" to "Output to sheet" and add missing space in AI security "Learn more dialogue" 

### DIFF
--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -201,7 +201,7 @@ export const AIUserMessageFormDisclaimer = () => {
     <p className="py-0.5 text-center text-xs text-muted-foreground">
       Some sheet data is sent to the AI model.
       <a href={AI_SECURITY} target="_blank" rel="noreferrer" className="underline hover:text-foreground">
-        Learn more.
+        {' '}Learn more.
       </a>
     </p>
   );

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -199,9 +199,9 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
 export const AIUserMessageFormDisclaimer = () => {
   return (
     <p className="py-0.5 text-center text-xs text-muted-foreground">
-      Some sheet data is sent to the AI model.
+      Some sheet data is sent to the AI model.{' '}
       <a href={AI_SECURITY} target="_blank" rel="noreferrer" className="underline hover:text-foreground">
-        {' '}Learn more.
+        Learn more.
       </a>
     </p>
   );

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEmptyState.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEmptyState.tsx
@@ -69,7 +69,7 @@ export function CodeEditorEmptyState({ editorInst }: CodeEditorEmptyStateProps) 
       },
     },
     {
-      label: 'Return to sheet',
+      label: 'Output to sheet',
       Icon: SheetComeFromIcon,
       onClick: () => {
         if (codeCell.id === 'Javascript') fillWithSnippet(SNIPPET_JS_RETURN);


### PR DESCRIPTION
Two tiny one word changes 

Change 1: @davidfig thought this meant he was returning to the sheet as in closing the editor and returning to the sheet

Change 2: Adds a space in the AI panel where there currently is missing one, see attached image

![CleanShot 2024-11-12 at 08 42 55@2x](https://github.com/user-attachments/assets/0d3f51d5-ad21-47b9-900a-a7d2f8d0fbb7)
![CleanShot 2024-11-12 at 08 42 41@2x](https://github.com/user-attachments/assets/b3debad4-0ec2-45da-b8d6-9f77d261f64f)



