### PR TITLE
feat: add mixpanel events for AI

### DIFF
--- a/quadratic-client/src/app/ai/components/SelectAIModelMenu.tsx
+++ b/quadratic-client/src/app/ai/components/SelectAIModelMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/shared/shadcn/ui/dropdown-menu';
 import { cn } from '@/shared/shadcn/utils';
 import { CaretDownIcon } from '@radix-ui/react-icons';
+import mixpanel from 'mixpanel-browser';
 import { MODEL_OPTIONS } from 'quadratic-shared/AI_MODELS';
 import { useMemo } from 'react';
 
@@ -49,7 +50,10 @@ export function SelectAIModelMenu({ loading, textAreaRef }: SelectAIModelMenuPro
             <DropdownMenuCheckboxItem
               key={enabledModel}
               checked={selectedMode === enabledModel}
-              onCheckedChange={() => setSelectedModel(enabledModel)}
+              onCheckedChange={() => {
+                mixpanel.track('[AI].model.change', { model: enabledModel });
+                setSelectedModel(enabledModel);
+              }}
             >
               <div className="flex w-full items-center justify-between text-xs">
                 <span className="pr-4">{displayName}</span>

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -199,7 +199,7 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
 export const AIUserMessageFormDisclaimer = () => {
   return (
     <p className="py-0.5 text-center text-xs text-muted-foreground">
-      Some sheet data is sent to the AI model.
+      Some sheet data is sent to the AI model.{' '}
       <a href={AI_SECURITY} target="_blank" rel="noreferrer" className="underline hover:text-foreground">
         Learn more.
       </a>

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -1,6 +1,7 @@
 import { sheets } from '@/app/grid/controller/Sheets';
 import { useSubmitAIAnalystPrompt } from '@/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt';
 import { CodeIcon, InsertChartIcon, TableIcon } from '@/shared/components/Icons';
+import mixpanel from 'mixpanel-browser';
 
 const examples = [
   {
@@ -32,12 +33,13 @@ export function AIAnalystExamplePrompts() {
         <button
           key={title}
           className="flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-accent"
-          onClick={() =>
+          onClick={() => {
+            mixpanel.track('[AIAnalyst].submitExamplePrompt', { title });
             submitPrompt({
               userPrompt: prompt,
               context: { sheets: [], currentSheet: sheets.sheet.name, selection: undefined },
-            })
-          }
+            });
+          }}
         >
           {icon}
 

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
@@ -4,6 +4,7 @@ import { matchShortcut } from '@/app/helpers/keyboardShortcuts';
 import { AIUserMessageForm, AIUserMessageFormWrapperProps } from '@/app/ui/components/AIUserMessageForm';
 import { defaultAIAnalystContext } from '@/app/ui/menus/AIAnalyst/const/defaultAIAnalystContext';
 import { useSubmitAIAnalystPrompt } from '@/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt';
+import mixpanel from 'mixpanel-browser';
 import { Context } from 'quadratic-shared/typesAndSchemasAI';
 import { forwardRef, useState } from 'react';
 import { useRecoilCallback, useRecoilState, useRecoilValue } from 'recoil';
@@ -36,7 +37,10 @@ export const AIAnalystUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((
       abortController={abortController}
       loading={loading}
       setLoading={setLoading}
-      submitPrompt={(prompt) => submitPrompt({ userPrompt: prompt, context, messageIndex: props.messageIndex })}
+      submitPrompt={(prompt) => {
+        mixpanel.track('[AIAnalyst].submitPrompt');
+        submitPrompt({ userPrompt: prompt, context, messageIndex: props.messageIndex });
+      }}
       formOnKeyDown={formOnKeyDown}
       ctx={{
         context,

--- a/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm.tsx
@@ -1,6 +1,7 @@
 import { aiAssistantAbortControllerAtom, aiAssistantLoadingAtom } from '@/app/atoms/codeEditorAtom';
 import { AIUserMessageForm, AIUserMessageFormWrapperProps } from '@/app/ui/components/AIUserMessageForm';
 import { useSubmitAIAssistantPrompt } from '@/app/ui/menus/CodeEditor/hooks/useSubmitAIAssistantPrompt';
+import mixpanel from 'mixpanel-browser';
 import { forwardRef } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -16,7 +17,10 @@ export const AIAssistantUserMessageForm = forwardRef<HTMLTextAreaElement, AIUser
         abortController={abortController}
         loading={loading}
         setLoading={setLoading}
-        submitPrompt={(prompt) => submitPrompt({ userPrompt: prompt, messageIndex: props.messageIndex })}
+        submitPrompt={(prompt) => {
+          mixpanel.track('[AIAssistant].submitPrompt');
+          submitPrompt({ userPrompt: prompt, messageIndex: props.messageIndex });
+        }}
       />
     );
   }


### PR DESCRIPTION
4 new events:

- When user submits prompt in AI Analyst context
- When user submits prompt in AI Assistant context
- When user selects one of the zero state example prompts (in AI Analyst context)
- When the user changes the model (in either context)