### PR TITLE
fix: ai tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,5 +92,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/quadratic-api/src/routes/ai/anthropic.ts
+++ b/quadratic-api/src/routes/ai/anthropic.ts
@@ -28,12 +28,12 @@ anthropic_router.post('/anthropic/chat', validateAccessToken, ai_rate_limiter, a
     });
     response.json(result.content);
   } catch (error: any) {
-    if (error.response) {
-      response.status(error.response.status).json(error.response.data);
-      console.log(error.response.status, error.response.data);
+    if (error instanceof Anthropic.APIError) {
+      response.status(error.status ?? 400).json(error.message);
+      console.log(error.status, error.message);
     } else {
-      response.status(400).json(error.message);
-      console.log(error.message);
+      response.status(400).json(error);
+      console.log(error);
     }
   }
 });
@@ -75,14 +75,15 @@ anthropic_router.post(
       }
     } catch (error: any) {
       if (!response.headersSent) {
-        if (error.response) {
-          response.status(error.response.status).json(error.response.data);
-          console.log(error.response.status, error.response.data);
+        if (error instanceof Anthropic.APIError) {
+          response.status(error.status ?? 400).json(error.message);
+          console.log(error.status, error.message);
         } else {
-          response.status(400).json(error.message);
-          console.log(error.message);
+          response.status(400).json(error);
+          console.log(error);
         }
       } else {
+        response.status(500).json('Error occurred after headers were sent');
         console.error('Error occurred after headers were sent:', error);
       }
     }

--- a/quadratic-api/src/routes/ai/bedrock.ts
+++ b/quadratic-api/src/routes/ai/bedrock.ts
@@ -1,4 +1,5 @@
 import { AnthropicBedrock } from '@anthropic-ai/bedrock-sdk';
+import Anthropic from '@anthropic-ai/sdk';
 import { BedrockRuntimeClient, ConverseCommand, ConverseStreamCommand } from '@aws-sdk/client-bedrock-runtime';
 import express from 'express';
 import { MODEL_OPTIONS } from 'quadratic-shared/AI_MODELS';
@@ -125,12 +126,12 @@ bedrock_router.post('/bedrock/anthropic/chat', validateAccessToken, ai_rate_limi
     });
     response.json(result.content);
   } catch (error: any) {
-    if (error.response) {
-      response.status(error.response.status).json(error.response.data);
-      console.log(error.response.status, error.response.data);
+    if (error instanceof Anthropic.APIError) {
+      response.status(error.status ?? 400).json(error.message);
+      console.log(error.status, error.message);
     } else {
-      response.status(400).json(error.message);
-      console.log(error.message);
+      response.status(400).json(error);
+      console.log(error);
     }
   }
 });
@@ -173,12 +174,12 @@ bedrock_router.post(
       }
     } catch (error: any) {
       if (!response.headersSent) {
-        if (error.response) {
-          response.status(error.response.status).json(error.response.data);
-          console.log(error.response.status, error.response.data);
+        if (error instanceof Anthropic.APIError) {
+          response.status(error.status ?? 400).json(error.message);
+          console.log(error.status, error.message);
         } else {
-          response.status(400).json(error.message);
-          console.log(error.message);
+          response.status(400).json(error);
+          console.log(error);
         }
       } else {
         console.error('Error occurred after headers were sent:', error);

--- a/quadratic-api/src/routes/ai/openai.ts
+++ b/quadratic-api/src/routes/ai/openai.ts
@@ -26,12 +26,12 @@ openai_router.post('/openai/chat', validateAccessToken, ai_rate_limiter, async (
     });
     response.json(result.choices[0].message);
   } catch (error: any) {
-    if (error.response) {
-      response.status(error.response.status).json(error.response.data);
-      console.log(error.response.status, error.response.data);
+    if (error instanceof OpenAI.APIError) {
+      response.status(error.status ?? 400).json(error.message);
+      console.log(error.status, error.message);
     } else {
-      response.status(400).json(error.message);
-      console.log(error.message);
+      response.status(400).json(error);
+      console.log(error);
     }
   }
 });
@@ -65,12 +65,12 @@ openai_router.post('/openai/chat/stream', validateAccessToken, ai_rate_limiter, 
     }
   } catch (error: any) {
     if (!response.headersSent) {
-      if (error.response) {
-        response.status(error.response.status).json(error.response.data);
-        console.log(error.response.status, error.response.data);
+      if (error instanceof OpenAI.APIError) {
+        response.status(error.status ?? 400).json(error.message);
+        console.log(error.status, error.message);
       } else {
-        response.status(400).json(error.message);
-        console.log(error.message);
+        response.status(400).json(error);
+        console.log(error);
       }
     } else {
       console.error('Error occurred after headers were sent:', error);

--- a/quadratic-client/src/app/ai/hooks/useAIRequestToAPI.tsx
+++ b/quadratic-client/src/app/ai/hooks/useAIRequestToAPI.tsx
@@ -356,17 +356,16 @@ export function useAIRequestToAPI() {
         });
 
         if (!response.ok) {
+          const data = await response.json();
           const error =
             response.status === 429
               ? 'You have exceeded the maximum number of requests. Please try again later.'
-              : `Looks like there was a problem. Status Code: ${response.status}`;
+              : `Looks like there was a problem. Error: ${data}`;
           setMessages?.((prev) => [
             ...prev.slice(0, -1),
             { role: 'assistant', content: error, contextType: 'userPrompt', model, toolCalls: [] },
           ]);
-          if (response.status !== 429) {
-            console.error(`Error retrieving data from AI API: ${response.status}`);
-          }
+          console.error(`Error retrieving data from AI API. Error: ${data}`);
           return { error: true, content: error, toolCalls: [] };
         }
 

--- a/quadratic-client/src/app/ai/hooks/useCodeCellContextMessages.tsx
+++ b/quadratic-client/src/app/ai/hooks/useCodeCellContextMessages.tsx
@@ -68,6 +68,7 @@ Use any functions that are part of the ${language} library.\n
 A code cell can return only one type of value as specified in the Quadratic documentation.\n
 A code cell cannot display both a chart and return a data frame at the same time.\n
 A code cell cannot display multiple charts at the same time.\n
+Do not use conditional returns in code cells.\n
 Do not use any markdown syntax besides triple backticks for ${language} code blocks.\n
 Do not reply code blocks in plain text, use markdown with triple backticks and language name ${language}.`
 }

--- a/quadratic-client/src/app/ai/hooks/useQuadraticContextMessages.tsx
+++ b/quadratic-client/src/app/ai/hooks/useQuadraticContextMessages.tsx
@@ -26,7 +26,7 @@ ${
     : 'Choose the language of your response based on the context and user prompt.'
 }
 Provide complete code blocks with language syntax highlighting. Don't provide small code snippets of changes.
-Respond in minimum number of words with direct answer. Include a concise explanation of the answer.
+Respond in minimum number of words and include a concise explanation of the actions you are taking. Don't guess the answer itself, just the actions you are taking to respond to the user prompt and what the user can do next.
 `,
         contextType: 'quadraticDocs',
       },

--- a/quadratic-client/src/app/ai/hooks/useToolUseMessages.tsx
+++ b/quadratic-client/src/app/ai/hooks/useToolUseMessages.tsx
@@ -10,7 +10,7 @@ export function useToolUseMessages() {
         content: `Note: This is an internal message for context. Do not quote it in your response.\n\n
 Following are the tools you should use to do actions in the spreadsheet, use them to respond to the user prompt.\n
 
-Include a concise explanation of the actions you are taking to respond to the user prompt.
+Include a concise explanation of the actions you are taking to respond to the user prompt. Never guess the answer itself, just the actions you are taking to respond to the user prompt and what the user can do next.\n
 
 Don't include tool details in your response. Reply in layman's terms what actions you are taking.\n
 

--- a/quadratic-client/src/app/ai/hooks/useVisibleContextMessages.tsx
+++ b/quadratic-client/src/app/ai/hooks/useVisibleContextMessages.tsx
@@ -68,9 +68,10 @@ Add imports to the top of the code cell and do not use any libraries or function
 Use any functions that are part of the code cell language library.\n
 A code cell can return only one type of value as specified in the Quadratic documentation.\n
 A code cell cannot display both a chart and return a data frame at the same time.\n
+Do not use conditional returns in code cells.\n
 A code cell cannot display multiple charts at the same time.\n
 Do not use any markdown syntax besides triple backticks for code cell language code blocks.\n
-Do not reply code blocks in plain text, use markdown with triple backticks and language name code cell language.
+Do not reply code blocks in plain text, use markdown with triple backticks and language name code cell language.\n
 
 ${erroredCodeCells[0].map(({ x, y, language, code_string, std_out, std_err }) => {
   const consoleOutput = {

--- a/quadratic-client/src/app/ai/tools/aiToolsSpec.ts
+++ b/quadratic-client/src/app/ai/tools/aiToolsSpec.ts
@@ -223,6 +223,7 @@ The required location (x,y) for this code cell is one which satisfies the follow
  - If there are multiple tables or data sources being referenced, place the code cell in a location that provides a good balance between proximity to all referenced data and maintaining readability of the currently open sheet.\n
  - Consider the overall layout and organization of the currently open sheet when placing the code cell, ensuring it doesn't disrupt existing data or interfere with other code cells.\n
  - A plot returned by the code cell occupies just one cell, the plot overlay is larger but the code cell is always just one cell.\n
+ - Do not use conditional returns in code cells.\n
  `,
   },
   [AITool.MoveCells]: {

--- a/quadratic-client/src/app/atoms/aiAnalystAtom.ts
+++ b/quadratic-client/src/app/atoms/aiAnalystAtom.ts
@@ -36,11 +36,14 @@ export const aiAnalystAtom = atom<AIAnalystState>({
   effects: [
     async ({ getPromise, setSelf, trigger }) => {
       if (trigger === 'get') {
+        // Determine if we want to override the default showAIAnalyst value on initialization
+        const aiAnalystOpenCount = getAiAnalystOpenCount();
         const isSheetEmpty = sheets.sheet.bounds.type === 'empty';
-        if (isSheetEmpty) {
+        const showAIAnalyst = aiAnalystOpenCount <= 3 ? true : isSheetEmpty;
+        if (showAIAnalyst) {
           setSelf({
             ...defaultAIAnalystState,
-            showAIAnalyst: true,
+            showAIAnalyst,
           });
         }
 
@@ -52,7 +55,7 @@ export const aiAnalystAtom = atom<AIAnalystState>({
             const chats = await aiAnalystOfflineChats.loadChats();
             setSelf({
               ...defaultAIAnalystState,
-              showAIAnalyst: isSheetEmpty,
+              showAIAnalyst,
               chats,
             });
           } catch (error) {
@@ -271,3 +274,14 @@ export const aiAnalystCurrentChatMessagesCountAtom = selector<number>({
   key: 'aiAnalystCurrentChatMessagesCountAtom',
   get: ({ get }) => getPromptMessages(get(aiAnalystCurrentChatAtom).messages).length,
 });
+
+const STORAGE_KEY = 'aiAnalystOpenCount';
+export function getAiAnalystOpenCount() {
+  const count = window.localStorage.getItem(STORAGE_KEY);
+  return count ? parseInt(count) : 0;
+}
+export function incrementAiAnalystOpenCount() {
+  const count = getAiAnalystOpenCount();
+  const newCount = count + 1;
+  window.localStorage.setItem(STORAGE_KEY, newCount.toString());
+}

--- a/quadratic-client/src/app/keyboard/defaults.ts
+++ b/quadratic-client/src/app/keyboard/defaults.ts
@@ -354,7 +354,7 @@ export const defaultShortcuts: ActionShortcut = {
     windows: [[WindowsModifiers.Ctrl, WindowsModifiers.Shift, Keys.Semicolon]],
   },
   [Action.ToggleAIAnalyst]: {
-    mac: [[MacModifiers.Cmd, MacModifiers.Shift, Keys.L]],
-    windows: [[WindowsModifiers.Ctrl, WindowsModifiers.Shift, Keys.L]],
+    mac: [[MacModifiers.Cmd, Keys.K]],
+    windows: [[WindowsModifiers.Ctrl, Keys.K]],
   },
 };

--- a/quadratic-client/src/app/ui/QuadraticSidebar.tsx
+++ b/quadratic-client/src/app/ui/QuadraticSidebar.tsx
@@ -1,7 +1,7 @@
 import { isAvailableBecauseCanEditFile, isAvailableBecauseFileLocationIsAccessibleAndWriteable } from '@/app/actions';
 import { Action } from '@/app/actions/actions';
 import { defaultActionSpec } from '@/app/actions/defaultActionsSpec';
-import { showAIAnalystAtom } from '@/app/atoms/aiAnalystAtom';
+import { incrementAiAnalystOpenCount, showAIAnalystAtom } from '@/app/atoms/aiAnalystAtom';
 import { codeEditorShowCodeEditorAtom } from '@/app/atoms/codeEditorAtom';
 import {
   editorInteractionStateShowCommandPaletteAtom,
@@ -75,7 +75,19 @@ export const QuadraticSidebar = () => {
       <div className="mt-2 flex flex-col items-center gap-1">
         {canEditFile && isAuthenticated && (
           <SidebarTooltip label={toggleAIChat.label} shortcut={keyboardShortcutEnumToDisplay(Action.ToggleAIAnalyst)}>
-            <SidebarToggle pressed={showAIAnalyst} onPressedChange={() => setShowAIAnalyst((prev) => !prev)}>
+            <SidebarToggle
+              pressed={showAIAnalyst}
+              onPressedChange={() => {
+                setShowAIAnalyst((prevShowAiAnalyst) => {
+                  // if it's hidden and therefore being opened by the user, count it!
+                  if (prevShowAiAnalyst === false) {
+                    incrementAiAnalystOpenCount();
+                  }
+
+                  return !prevShowAiAnalyst;
+                });
+              }}
+            >
               <AIIcon />
             </SidebarToggle>
           </SidebarTooltip>

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -56,11 +56,8 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useImperativeHandle(ref, () => textareaRef.current!);
 
-  console.log('AIUserMessageForm', autoFocusRef?.current, textareaRef.current);
-
   // Focus the input when relevant & the tab comes into focus
   useEffect(() => {
-    console.log('AIUserMessageForm useEffect', autoFocusRef?.current, textareaRef.current);
     if (autoFocusRef?.current) {
       textareaRef.current?.focus();
     }

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -14,7 +14,7 @@ import { SetterOrUpdater } from 'recoil';
 
 export type AIUserMessageFormWrapperProps = {
   textareaRef: React.RefObject<HTMLTextAreaElement>;
-  autoFocus?: boolean;
+  autoFocusRef?: React.RefObject<boolean>;
   initialPrompt?: string;
   messageIndex?: number;
 };
@@ -36,7 +36,7 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
   const {
     initialPrompt,
     ctx,
-    autoFocus,
+    autoFocusRef,
     textareaRef: bottomTextareaRef,
     abortController,
     loading,
@@ -58,12 +58,12 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
 
   // Focus the input when relevant & the tab comes into focus
   useEffect(() => {
-    if (autoFocus) {
+    if (autoFocusRef?.current) {
       window.requestAnimationFrame(() => {
         textareaRef.current?.focus();
       });
     }
-  }, [autoFocus, textareaRef]);
+  }, [autoFocusRef, textareaRef]);
 
   useEffect(() => {
     if (loading && initialPrompt !== undefined) {

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -56,12 +56,13 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   useImperativeHandle(ref, () => textareaRef.current!);
 
+  console.log('AIUserMessageForm', autoFocusRef?.current, textareaRef.current);
+
   // Focus the input when relevant & the tab comes into focus
   useEffect(() => {
+    console.log('AIUserMessageForm useEffect', autoFocusRef?.current, textareaRef.current);
     if (autoFocusRef?.current) {
-      window.requestAnimationFrame(() => {
-        textareaRef.current?.focus();
-      });
+      textareaRef.current?.focus();
     }
   }, [autoFocusRef, textareaRef]);
 

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -115,6 +115,7 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
 
             if (event.key === 'Enter' && !(event.ctrlKey || event.shiftKey)) {
               event.preventDefault();
+              if (loading) return;
 
               if (prompt.trim().length === 0) return;
 
@@ -128,6 +129,9 @@ export const AIUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((props: 
                 bottomTextareaRef.current?.focus();
               }
             }
+
+            if (loading) return;
+
             if (formOnKeyDown) {
               formOnKeyDown(event);
             }

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
@@ -28,7 +28,7 @@ export const AIAnalyst = () => {
     } else {
       autoFocusRef.current = true;
     }
-  }, []);
+  }, [showAIAnalyst]);
 
   const handleResize = useCallback(
     (event: MouseEvent) => {
@@ -43,8 +43,6 @@ export const AIAnalyst = () => {
     },
     [setPanelWidth]
   );
-
-  console.log('AIAnalyst', initialLoadRef.current, autoFocusRef.current, showAIAnalyst);
 
   if (!showAIAnalyst || presentationMode) {
     return null;

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
@@ -9,7 +9,7 @@ import { AIAnalystMessages } from '@/app/ui/menus/AIAnalyst/AIAnalystMessages';
 import { AIAnalystUserMessageForm } from '@/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm';
 import { useAIAnalystPanelWidth } from '@/app/ui/menus/AIAnalyst/hooks/useAIAnalystPanelWidth';
 import { cn } from '@/shared/shadcn/utils';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 
 export const AIAnalyst = () => {
@@ -19,6 +19,18 @@ export const AIAnalyst = () => {
   const aiPanelRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { panelWidth, setPanelWidth } = useAIAnalystPanelWidth();
+
+  const initialLoadRef = useRef(true);
+  const autoFocusRef = useRef(false);
+  useEffect(() => {
+    if (showAIAnalyst) {
+      if (initialLoadRef.current) {
+        initialLoadRef.current = false;
+      } else {
+        autoFocusRef.current = true;
+      }
+    }
+  }, [showAIAnalyst]);
 
   const handleResize = useCallback(
     (event: MouseEvent) => {
@@ -67,7 +79,7 @@ export const AIAnalyst = () => {
               <AIAnalystMessages textareaRef={textareaRef} />
 
               <div className="px-2 py-0.5">
-                <AIAnalystUserMessageForm ref={textareaRef} autoFocus={true} textareaRef={textareaRef} />
+                <AIAnalystUserMessageForm ref={textareaRef} autoFocusRef={autoFocusRef} textareaRef={textareaRef} />
                 <AIUserMessageFormDisclaimer />
               </div>
             </>

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
@@ -23,14 +23,12 @@ export const AIAnalyst = () => {
   const initialLoadRef = useRef(true);
   const autoFocusRef = useRef(false);
   useEffect(() => {
-    if (showAIAnalyst) {
-      if (initialLoadRef.current) {
-        initialLoadRef.current = false;
-      } else {
-        autoFocusRef.current = true;
-      }
+    if (initialLoadRef.current) {
+      initialLoadRef.current = false;
+    } else {
+      autoFocusRef.current = true;
     }
-  }, [showAIAnalyst]);
+  }, []);
 
   const handleResize = useCallback(
     (event: MouseEvent) => {

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
@@ -44,6 +44,8 @@ export const AIAnalyst = () => {
     [setPanelWidth]
   );
 
+  console.log('AIAnalyst', initialLoadRef.current, autoFocusRef.current, showAIAnalyst);
+
   if (!showAIAnalyst || presentationMode) {
     return null;
   }

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -61,11 +61,11 @@ function TypewriterHeader() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [startTyping, setStartTyping] = useState(false);
 
-  // Delay starting the effect just a tad — it looks better
+  // Delay starting the effect just a tad — it looks better, especially on initial page load
   useEffect(() => {
     const initialDelay = setTimeout(() => {
       setStartTyping(true);
-    }, 80);
+    }, 50);
 
     return () => clearTimeout(initialDelay);
   }, []);

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -28,7 +28,8 @@ export function AIAnalystExamplePrompts() {
   const { submitPrompt } = useSubmitAIAnalystPrompt();
 
   return (
-    <div className="flex flex-col gap-2 px-2 pt-1">
+    <div className="flex flex-col justify-center gap-2 px-2 pt-1">
+      <h2 className="mb-1 text-center text-lg font-bold">What can I help with?</h2>
       {examples.map(({ title, description, icon, prompt }) => (
         <button
           key={title}

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -2,6 +2,7 @@ import { sheets } from '@/app/grid/controller/Sheets';
 import { useSubmitAIAnalystPrompt } from '@/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt';
 import { CodeIcon, InsertChartIcon, TableIcon } from '@/shared/components/Icons';
 import mixpanel from 'mixpanel-browser';
+import { useEffect, useState } from 'react';
 
 const examples = [
   {
@@ -29,7 +30,7 @@ export function AIAnalystExamplePrompts() {
 
   return (
     <div className="flex flex-col justify-center gap-2 px-2 pt-1">
-      <h2 className="mb-1 text-center text-lg font-bold">What can I help with?</h2>
+      <TypewriterHeader />
       {examples.map(({ title, description, icon, prompt }) => (
         <button
           key={title}
@@ -53,3 +54,40 @@ export function AIAnalystExamplePrompts() {
     </div>
   );
 }
+
+function TypewriterHeader() {
+  const fullText = 'What can I help with?';
+  const [displayText, setDisplayText] = useState('');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [startTyping, setStartTyping] = useState(false);
+
+  // Delay starting the effect just a tad — it looks better
+  useEffect(() => {
+    const initialDelay = setTimeout(() => {
+      setStartTyping(true);
+    }, 80);
+
+    return () => clearTimeout(initialDelay);
+  }, []);
+
+  // Type out each character, adjust the speed as necessary
+  useEffect(() => {
+    if (startTyping && currentIndex < fullText.length) {
+      const timeout = setTimeout(() => {
+        setDisplayText((prevText) => prevText + fullText[currentIndex]);
+        setCurrentIndex((prevIndex) => prevIndex + 1);
+      }, 30);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [currentIndex, startTyping]);
+
+  return (
+    <h2 className="mb-1 flex items-center justify-center text-center text-lg font-bold">
+      {displayText}&nbsp;
+      <span className="relative -top-[1px] h-5/6 w-[2px] animate-pulse bg-primary"></span>
+    </h2>
+  );
+}
+
+export default TypewriterHeader;

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystHeader.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystHeader.tsx
@@ -41,18 +41,6 @@ export function AIAnalystHeader({ textareaRef }: AIAnalystHeaderProps) {
       </span>
 
       <div className="flex items-center gap-2">
-        <TooltipPopover label="Previous chats">
-          <Button
-            variant={showChatHistory ? 'default' : 'ghost'}
-            size="icon-sm"
-            className={cn(!showChatHistory && 'text-muted-foreground hover:text-foreground')}
-            disabled={!showChatHistory && (loading || chatsCount === 0)}
-            onClick={() => setShowChatHistory((prev) => !prev)}
-          >
-            <HistoryIcon />
-          </Button>
-        </TooltipPopover>
-
         <TooltipPopover label="New chat">
           <Button
             variant="ghost"
@@ -70,6 +58,18 @@ export function AIAnalystHeader({ textareaRef }: AIAnalystHeaderProps) {
             }}
           >
             <AddIcon />
+          </Button>
+        </TooltipPopover>
+
+        <TooltipPopover label="Previous chats">
+          <Button
+            variant={showChatHistory ? 'default' : 'ghost'}
+            size="icon-sm"
+            className={cn(!showChatHistory && 'text-muted-foreground hover:text-foreground')}
+            disabled={!showChatHistory && (loading || chatsCount === 0)}
+            onClick={() => setShowChatHistory((prev) => !prev)}
+          >
+            <HistoryIcon />
           </Button>
         </TooltipPopover>
 

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
@@ -34,6 +34,7 @@ export const AIAnalystUserMessageForm = forwardRef<HTMLTextAreaElement, Props>((
   return (
     <AIUserMessageForm
       {...rest}
+      ref={ref}
       abortController={abortController}
       loading={loading}
       setLoading={setLoading}

--- a/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistant.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistant.tsx
@@ -3,15 +3,16 @@ import { AIAssistantMessages } from '@/app/ui/menus/CodeEditor/AIAssistant/AIAss
 import { AIAssistantUserMessageForm } from '@/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm';
 import { useRef } from 'react';
 
-export const AIAssistant = ({ autoFocus }: { autoFocus?: boolean }) => {
+export const AIAssistant = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const autoFocusRef = useRef(true);
 
   return (
     <div className="grid h-full grid-rows-[1fr_auto]">
       <AIAssistantMessages textareaRef={textareaRef} />
 
       <div className="flex h-full flex-col justify-end px-2 py-0.5">
-        <AIAssistantUserMessageForm ref={textareaRef} autoFocus={autoFocus} textareaRef={textareaRef} />
+        <AIAssistantUserMessageForm ref={textareaRef} autoFocusRef={autoFocusRef} textareaRef={textareaRef} />
         <AIUserMessageFormDisclaimer />
       </div>
     </div>

--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelBottom.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelBottom.tsx
@@ -75,7 +75,7 @@ export function CodeEditorPanelBottom({ schemaBrowser, showAIAssistant }: CodeEd
 
       {showAIAssistant && (
         <TabsContent value="ai-assistant" className="m-0 grow overflow-hidden">
-          {!bottomHidden && <AIAssistant autoFocus={true} />}
+          {!bottomHidden && <AIAssistant />}
         </TabsContent>
       )}
 


### PR DESCRIPTION
Fixes for #2077, including:

- [x] Tracks the number of times a user has opened the AI Analyst and cues off that determine whether to show it by default
  - The logic is: if the user has _manually opened_ the AI chat 3 or more times, we cue off whether the sheet is empty or not. Otherwise we always show the AI Analyst open by default.
  - It's worth noting that:
    - The state of whether the AI is open or not is not a user preference and it is therefore lost on a page refresh (this is the same as the code editor, if you have the code editor open and you refresh the page, it's now closed which is the default state)
    - This requires users manually open the AI analyst _at least 3 times_ by themselves, before we will stop showing it by default to them. We don't pay any heed to whether they've ever _closed_ the AI analyst. Only opened it.
- [x] Add "what can I help with?" to empty state
- [x] Move history/new chat button
- [x] Keep focus on grid on initial load @AyushAgrawal-A2 
- [x] Cmd + k to open left side panel
- [x] While a chat response is running, the user can "send" another chat. But it just disappears. This should be prevented until the previous chat finishes.
- [x] Show actual API error to user, instead of a generic status 400.
- [x] Prompt AI to not answer questions in the chat, answer in the sheet. Often gives one answer on the sheet and one in the chat that are different. The one on the sheet is correct and the one in the chat is incorrect.
- [x] Prompt AI to not use a conditional return. Quadratic does not support conditional returns.


![CleanShot 2024-11-20 at 14 41 37](https://github.com/user-attachments/assets/0b31a016-778d-4624-82d0-c0f610a04b0c)

