### PR TITLE
fix: new users sent to empty file

### DIFF
--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -15,6 +15,7 @@ import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons'
 import * as Sentry from '@sentry/react';
 import { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import { useEffect, useRef, useState } from 'react';
+import { isMobile } from 'react-device-detect';
 import {
   Link,
   LoaderFunctionArgs,
@@ -91,10 +92,11 @@ export const loader = async ({ params, request }: LoaderFunctionArgs): Promise<L
   } else if (teams.length > 0) {
     initialActiveTeamUuid = teams[0].team.uuid;
 
-    // 4) there's no teams in the API, so create one, then send the user to a new file
+    // 4) there's no teams in the API, so create one
   } else if (teams.length === 0) {
     const newTeam = await apiClient.teams.create({ name: 'My Team' });
-    return redirect(ROUTES.CREATE_FILE(newTeam.uuid));
+    // Send user to team dashboard if mobile, otherwise to a new file
+    return isMobile ? redirect(ROUTES.TEAM(newTeam.uuid)) : redirect(ROUTES.CREATE_FILE(newTeam.uuid));
   }
 
   // This should never happen, but if it does, we'll log it to sentry

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -91,10 +91,10 @@ export const loader = async ({ params, request }: LoaderFunctionArgs): Promise<L
   } else if (teams.length > 0) {
     initialActiveTeamUuid = teams[0].team.uuid;
 
-    // 4) there's no teams in the API, so create one and send the user to it
+    // 4) there's no teams in the API, so create one, then send the user to a new file
   } else if (teams.length === 0) {
     const newTeam = await apiClient.teams.create({ name: 'My Team' });
-    return redirect(ROUTES.TEAM(newTeam.uuid));
+    return redirect(ROUTES.CREATE_FILE(newTeam.uuid));
   }
 
   // This should never happen, but if it does, we'll log it to sentry


### PR DESCRIPTION
Resolves #2100

When a user lands on the dashboard and has 0 teams, create a new team and then instead of sending them to the homepage for that team, create a new file for them and send them to the file

(Note: most of the time this will be because they are a _new_ user who hasn't been associated with a team yet, but it could also be for existing users who left the last team they were a part of).