### PR TITLE
feat: support duplicating example files from outside the app

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
@@ -80,7 +80,7 @@ export function EmptyGridMessage() {
       </div>
       <h2 className="text-md font-semibold">Import data</h2>
       <p className="text-sm text-muted-foreground">
-        Bring in your own data via a file (CSV, Excel, Parquet) or a connection (Postgres, MySQL, and more).
+        Drag and drop a file (CSV, Excel, Parquet) or use a connection (Postgres, MySQL, and more).
       </p>
       <div className="mt-2 flex w-full flex-col justify-center gap-2">
         <UploadFileButton teamUuid={teamUuid} />

--- a/quadratic-client/src/routes/examples.tsx
+++ b/quadratic-client/src/routes/examples.tsx
@@ -20,7 +20,7 @@ export const Component = () => {
 
   const files: FilesListExampleFile[] = examples.map(({ name, description, thumbnail, url }, i) => ({
     description,
-    href: ROUTES.CREATE_FILE_EXAMPLE(activeTeamUuid, url, true),
+    href: ROUTES.CREATE_FILE_EXAMPLE(activeTeamUuid, url),
     name,
     thumbnail: thumbnail + '?w=800&h=450&fit=crop&auto=format', // 16/9 aspect ratio
   }));

--- a/quadratic-client/src/routes/files.create.tsx
+++ b/quadratic-client/src/routes/files.create.tsx
@@ -1,15 +1,36 @@
 import getActiveTeam from '@/dashboard/shared/getActiveTeam';
 import { apiClient } from '@/shared/api/apiClient';
-import { ROUTES } from '@/shared/constants/routes';
+import { ROUTES, SEARCH_PARAMS } from '@/shared/constants/routes';
 import { LoaderFunctionArgs, redirect } from 'react-router-dom';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
-  const prompt = url.searchParams.get('prompt');
 
+  // Get the active team
   const { teams } = await apiClient.teams.list();
   const { teamUuid } = await getActiveTeam(teams, undefined);
 
-  const redirectUrl = ROUTES.CREATE_FILE(teamUuid, { prompt, private: true });
+  // Ensure the active team is _writeable_. If it's not, redirect them to the dashboard.
+  // (They may have write access to another team, but not the 'active' one.)
+  const team = teams.find(({ team }) => team.uuid === teamUuid);
+  if (!team?.userMakingRequest.teamPermissions.includes('TEAM_EDIT')) {
+    return redirect(
+      `/?${SEARCH_PARAMS.SNACKBAR_MSG.KEY}=${encodeURIComponent('Failed to create file. You can only view this team.')}`
+    );
+  }
+
+  // Are they trying to duplicate an example file? Do that.
+  const example = url.searchParams.get('example');
+  if (example) {
+    return redirect(ROUTES.CREATE_FILE_EXAMPLE(teamUuid, example));
+  }
+
+  // Otherwise, start a new file by redirecting them to the file creation route
+  const redirectUrl = ROUTES.CREATE_FILE(teamUuid, {
+    // Are they creating a new file with a prompt?
+    prompt: url.searchParams.get('prompt'),
+    // Creating via this route is _always_ private
+    private: true,
+  });
   return redirect(redirectUrl);
 };

--- a/quadratic-client/src/routes/teams.$teamUuid.files.create.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.files.create.tsx
@@ -41,7 +41,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       const { uuid, name } = await apiClient.examples.duplicate({
         publicFileUrlInProduction: exampleUrl,
         teamUuid,
-        isPrivate: true,
+        isPrivate,
       });
       mixpanel.track('[Files].newExampleFile', { fileName: name });
       return replace(ROUTES.FILE(uuid));

--- a/quadratic-client/src/routes/teams.$teamUuid.files.create.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.files.create.tsx
@@ -41,7 +41,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       const { uuid, name } = await apiClient.examples.duplicate({
         publicFileUrlInProduction: exampleUrl,
         teamUuid,
-        isPrivate,
+        isPrivate: true,
       });
       mixpanel.track('[Files].newExampleFile', { fileName: name });
       return replace(ROUTES.FILE(uuid));

--- a/quadratic-client/src/shared/components/ShareDialog.tsx
+++ b/quadratic-client/src/shared/components/ShareDialog.tsx
@@ -120,7 +120,7 @@ export function ShareTeamDialog({ data }: { data: ApiTypes['/v0/teams/:uuid.GET.
       )}
 
       {license.status === 'exceeded' && (
-        <div className="relative rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700" role="alert">
+        <div className="relative rounded border border-red-400 bg-red-100 px-4 py-3 text-sm text-red-700" role="alert">
           <div>
             <strong className="font-bold">Over the user limit!</strong>
           </div>
@@ -132,7 +132,7 @@ export function ShareTeamDialog({ data }: { data: ApiTypes['/v0/teams/:uuid.GET.
       )}
 
       {license.status === 'revoked' && (
-        <div className="relative rounded border border-red-400 bg-red-100 px-4 py-3 text-red-700" role="alert">
+        <div className="relative rounded border border-red-400 bg-red-100 px-4 py-3 text-sm text-red-700" role="alert">
           <div>
             <strong className="font-bold">License Revoked!</strong>
           </div>

--- a/quadratic-client/src/shared/constants/routes.ts
+++ b/quadratic-client/src/shared/constants/routes.ts
@@ -34,8 +34,8 @@ export const ROUTES = {
 
     return url.toString();
   },
-  CREATE_FILE_EXAMPLE: (teamUuid: string, publicFileUrlInProduction: string, isPrivate: boolean) =>
-    `/teams/${teamUuid}/files/create?example=${publicFileUrlInProduction}${isPrivate ? '&private' : ''}`,
+  CREATE_FILE_EXAMPLE: (teamUuid: string, publicFileUrlInProduction: string) =>
+    `/teams/${teamUuid}/files/create?example=${publicFileUrlInProduction}&private`,
   TEAMS: `/teams`,
   TEAMS_CREATE: `/teams/create`,
   TEAM: (teamUuid: string) => `/teams/${teamUuid}`,


### PR DESCRIPTION
Fixes #2147 

**To test**

Visit `/files/create?example=<example-file-url-in-prod>`

Example:

https://quadratic-git-duplicate-example-files.vercel.quadratic-preview.com/files/create?example=https://app.quadratichq.com/file/b90a8c28-4573-4073-bfaa-5bf14e808f51

Implemented by: https://github.com/quadratichq/quadratic-website/pull/240