### PR TITLE
feat: remove dependence on mui for spinner

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/codeRunning/CodeRunning.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/codeRunning/CodeRunning.tsx
@@ -3,7 +3,8 @@ import { sheets } from '@/app/grid/controller/Sheets';
 import type { CodeRun } from '@/app/web-workers/CodeRun';
 import { LanguageState } from '@/app/web-workers/languageTypes';
 import { MultiplayerUser } from '@/app/web-workers/multiplayerWebWorker/multiplayerTypes';
-import { CircularProgress } from '@mui/material';
+import { SpinnerIcon } from '@/shared/components/Icons';
+import { cn } from '@/shared/shadcn/utils';
 import { useEffect, useState } from 'react';
 import './CodeRunning.css';
 
@@ -134,14 +135,19 @@ export const CodeRunning = () => {
         .filter((code) => {
           return code.sheetId === sheets.sheet.id;
         })
-        .map((code, index) => (
-          <CircularProgress
-            color={code.color === 'black' ? 'primary' : undefined}
-            size={`${CIRCULAR_PROGRESS_SIZE}px`}
-            key={index}
-            sx={{ position: 'absolute', left: code.left, top: code, color: code.color }}
-          />
-        ))}
+        .map((code, index) => {
+          return (
+            <span
+              className="-translate-x-[2px] -translate-y-[4px] scale-75"
+              style={{ position: 'absolute', left: code.left, top: code.top }}
+            >
+              <SpinnerIcon
+                className={cn(code.color === 'black' && 'text-primary')}
+                style={code.color !== 'black' ? { color: code.color } : {}}
+              />
+            </span>
+          );
+        })}
     </div>
   );
 };

--- a/quadratic-client/src/app/ui/QuadraticSidebar.tsx
+++ b/quadratic-client/src/app/ui/QuadraticSidebar.tsx
@@ -22,13 +22,13 @@ import {
   DatabaseIcon,
   ManageSearch,
   MemoryIcon,
+  SpinnerIcon,
 } from '@/shared/components/Icons';
 import { QuadraticLogo } from '@/shared/components/QuadraticLogo';
 import { ShowAfter } from '@/shared/components/ShowAfter';
 import { Toggle } from '@/shared/shadcn/ui/toggle';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import { CircularProgress } from '@mui/material';
 import mixpanel from 'mixpanel-browser';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -64,7 +64,7 @@ export const QuadraticSidebar = () => {
             {isRunningAsyncAction && (
               <ShowAfter delay={300}>
                 <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center bg-accent group-hover:hidden">
-                  <CircularProgress style={{ width: 18, height: 18 }} />
+                  <SpinnerIcon className="text-primary" />
                 </div>
               </ShowAfter>
             )}

--- a/quadratic-client/src/app/ui/menus/BottomBar/SyncState.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/SyncState.tsx
@@ -4,13 +4,12 @@ import { multiplayer } from '@/app/web-workers/multiplayerWebWorker/multiplayer'
 import { MultiplayerState } from '@/app/web-workers/multiplayerWebWorker/multiplayerClientMessages';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { useGlobalSnackbar } from '@/shared/components/GlobalSnackbarProvider';
-import { CloseIcon } from '@/shared/components/Icons';
+import { CloseIcon, SpinnerIcon } from '@/shared/components/Icons';
 import { ShowAfter } from '@/shared/components/ShowAfter';
 import { DOCUMENTATION_OFFLINE } from '@/shared/constants/urls';
 import { Button } from '@/shared/shadcn/ui/button';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
 import { timeAgo } from '@/shared/utils/timeAgo';
-import { CircularProgress } from '@mui/material';
 import { useEffect, useState } from 'react';
 import BottomBarItem from './BottomBarItem';
 
@@ -85,7 +84,11 @@ export default function SyncState() {
   let icon = null;
   let className = '';
 
-  const loadingIcon = <CircularProgress size="0.5rem" />;
+  const loadingIcon = (
+    <span className="flex scale-75 items-center">
+      <SpinnerIcon className="text-primary" />
+    </span>
+  );
 
   if (syncState === 'connected') {
     message = 'Connected';

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorBody.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorBody.tsx
@@ -27,10 +27,10 @@ import {
 import { QuadraticEditorTheme } from '@/app/ui/menus/CodeEditor/quadraticEditorTheme';
 import { javascriptLibraryForEditor } from '@/app/web-workers/javascriptWebWorker/worker/javascript/runner/generatedJavascriptForEditor';
 import { pyrightWorker, uri } from '@/app/web-workers/pythonLanguageServer/worker';
+import { SpinnerIcon } from '@/shared/components/Icons';
 import useEventListener from '@/shared/hooks/useEventListener';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
 import Editor, { DiffEditor, Monaco } from '@monaco-editor/react';
-import { CircularProgress } from '@mui/material';
 import * as monaco from 'monaco-editor';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -261,7 +261,7 @@ export const CodeEditorBody = (props: CodeEditorBodyProps) => {
   if (!showDiffEditor && (editorContent === undefined || loading)) {
     return (
       <div className="flex justify-center">
-        <CircularProgress style={{ width: '18px', height: '18px' }} />
+        <SpinnerIcon className="text-primary" />
       </div>
     );
   }
@@ -284,7 +284,7 @@ export const CodeEditorBody = (props: CodeEditorBodyProps) => {
             value={editorContent}
             onChange={setEditorContent}
             onMount={onMount}
-            loading={<CircularProgress style={{ width: '18px', height: '18px' }} />}
+            loading={<SpinnerIcon className="text-primary" />}
             options={{
               theme: 'light',
               readOnly: !canEdit,

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeader.tsx
@@ -27,12 +27,12 @@ import {
   DockToRightIcon,
   SaveAndRunIcon,
   SaveAndRunStopIcon,
+  SpinnerIcon,
 } from '@/shared/components/Icons';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
 import { Button } from '@/shared/shadcn/ui/button';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import { CircularProgress } from '@mui/material';
 import * as monaco from 'monaco-editor';
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -211,7 +211,7 @@ export const CodeEditorHeader = ({ editorInst }: CodeEditorHeaderProps) => {
       <div className="ml-auto flex flex-shrink-0 items-center gap-1 py-1">
         {isRunningComputation && (
           <TooltipPopover label={`${language} executing…`} side="bottom">
-            <CircularProgress size="1rem" color={'primary'} className={`mr-2`} />
+            <SpinnerIcon className="mr-2 text-primary" />
           </TooltipPopover>
         )}
 

--- a/quadratic-client/src/shared/components/Icons.tsx
+++ b/quadratic-client/src/shared/components/Icons.tsx
@@ -491,6 +491,14 @@ export const SpillErrorMoveIcon: IconComponent = (props) => {
   return <Icon {...props}>vertical_align_bottom</Icon>;
 };
 
+export const SpinnerIcon: IconComponent = (props) => {
+  return (
+    <Icon {...props} className={cn(props.className, 'animate-spin')}>
+      progress_activity
+    </Icon>
+  );
+};
+
 export const StopIcon: IconComponent = (props) => {
   return <Icon {...props}>stop</Icon>;
 };

--- a/quadratic-client/src/shared/components/connections/ConnectionFormActions.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionFormActions.tsx
@@ -1,9 +1,9 @@
 import { getDeleteConnectionAction } from '@/routes/api.connections';
 import { connectionClient } from '@/shared/api/connectionClient';
 import { ConnectionFormValues } from '@/shared/components/connections/connectionsByType';
+import { SpinnerIcon } from '@/shared/components/Icons';
 import { ROUTES } from '@/shared/constants/routes';
 import { Button } from '@/shared/shadcn/ui/button';
-import { CircularProgress } from '@mui/material';
 import { CheckCircledIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import mixpanel from 'mixpanel-browser';
 import { ConnectionType } from 'quadratic-shared/typesAndSchemasConnections';
@@ -74,7 +74,7 @@ export function ConnectionFormActions({
                   <CheckCircledIcon className="mr-1" /> Connected
                 </>
               ) : connectionState === 'loading' ? (
-                <CircularProgress style={{ width: 18, height: 18 }} />
+                <SpinnerIcon className="text-primary" />
               ) : (
                 'Test'
               )}


### PR DESCRIPTION
Replace all instances of `<CircularProgress>` with our own custom spinner. This removes our dependence on the MUI package.

The new `<SpinnerIcon>` uses the `progress_activity` from our icon set and adds a spinning animation on it.

<img width="621" alt="CleanShot 2025-01-09 at 16 47 29@2x" src="https://github.com/user-attachments/assets/32e8582f-30ea-48fd-88d1-18d7620809d4" />
 