### PR TITLE
feat: trigger file picker from "Insert > Data > From file"

### DIFF
--- a/quadratic-client/src/app/actions/actions.ts
+++ b/quadratic-client/src/app/actions/actions.ts
@@ -6,6 +6,7 @@ export enum Action {
   InsertCodePython = 'insert_code_python',
   InsertCodeJavascript = 'insert_code_javascript',
   InsertCodeFormula = 'insert_code_formula',
+  InsertFile = 'insert_file',
   InsertSheet = 'insert_sheet',
   InsertChartPython = 'insert_chart_python',
   InsertChartJavascript = 'insert_chart_javascript',

--- a/quadratic-client/src/app/actions/insertActionsSpec.ts
+++ b/quadratic-client/src/app/actions/insertActionsSpec.ts
@@ -1,6 +1,7 @@
 import { Action } from '@/app/actions/actions';
 import { ActionSpecRecord } from '@/app/actions/actionsSpec';
 import { sheets } from '@/app/grid/controller/Sheets';
+import { FILE_INPUT_ID } from '@/app/gridGL/HTMLGrid/GridFileInput';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
 import { insertCellRef } from '@/app/ui/menus/CodeEditor/insertCellRef';
 import { SNIPPET_JS_API, SNIPPET_JS_CHART } from '@/app/ui/menus/CodeEditor/snippetsJS';
@@ -31,6 +32,7 @@ type InsertActionSpec = Pick<
   | Action.RemoveInsertedCells
   | Action.InsertToday
   | Action.InsertTodayTime
+  | Action.InsertFile
 >;
 
 export const insertActionsSpec: InsertActionSpec = {
@@ -142,6 +144,16 @@ export const insertActionsSpec: InsertActionSpec = {
           initialCode: SNIPPET_JS_CHART,
         },
       }));
+    },
+  },
+  [Action.InsertFile]: {
+    label: 'From file (CSV, Excel, or Parquet)',
+    labelVerbose: 'Insert file (CSV, Excel, or Parquet)',
+    run: () => {
+      const el = document.getElementById(FILE_INPUT_ID) as HTMLInputElement;
+      if (el) {
+        el.click();
+      }
     },
   },
   [Action.InsertApiRequestJavascript]: {

--- a/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
@@ -1,15 +1,15 @@
+import { Action } from '@/app/actions/actions';
+import { insertActionsSpec } from '@/app/actions/insertActionsSpec';
 import {
   editorInteractionStateShowCellTypeMenuAtom,
   editorInteractionStateShowConnectionsMenuAtom,
 } from '@/app/atoms/editorInteractionStateAtom';
 import { events } from '@/app/events/events';
 import { sheets } from '@/app/grid/controller/Sheets';
-import { supportedFileTypes } from '@/app/helpers/files';
 import { useConnectionsFetcher } from '@/app/ui/hooks/useConnectionsFetcher';
-import { useFileImport } from '@/app/ui/hooks/useFileImport';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
 import { Button } from '@/shared/shadcn/ui/button';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useSetRecoilState } from 'recoil';
 
@@ -20,7 +20,6 @@ const fileHasData = () => sheets.sheets.filter((sheet) => sheet.bounds.type === 
 export function EmptyGridMessage() {
   const {
     userMakingRequest: { filePermissions },
-    team: { uuid: teamUuid },
   } = useFileRouteLoaderData();
   const canEdit = filePermissions.includes('FILE_EDIT');
   const [open, setOpen] = useState(fileHasData() ? false : true);
@@ -83,7 +82,14 @@ export function EmptyGridMessage() {
         Drag and drop a file (CSV, Excel, Parquet) or use a connection (Postgres, MySQL, and more).
       </p>
       <div className="mt-2 flex w-full flex-col justify-center gap-2">
-        <UploadFileButton teamUuid={teamUuid} />
+        <Button
+          className="w-full"
+          onClick={() => {
+            insertActionsSpec[Action.InsertFile].run();
+          }}
+        >
+          Upload file
+        </Button>
 
         {connections.length === 0 ? (
           <Button
@@ -108,36 +114,5 @@ export function EmptyGridMessage() {
         )}
       </div>
     </div>
-  );
-}
-
-function UploadFileButton({ teamUuid }: { teamUuid: string }) {
-  const handleFileImport = useFileImport();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  return (
-    <>
-      <Button className="w-full" onClick={() => fileInputRef.current?.click()}>
-        Upload file
-      </Button>
-      <input
-        ref={fileInputRef}
-        type="file"
-        hidden
-        accept={supportedFileTypes.join(',')}
-        onChange={(e) => {
-          const files = e.target.files;
-          if (files) {
-            handleFileImport({
-              files,
-              sheetId: sheets.sheet.id,
-              insertAt: { x: 1, y: 1 },
-              cursor: sheets.getCursorPosition(),
-              teamUuid,
-            });
-          }
-        }}
-      />
-    </>
   );
 }

--- a/quadratic-client/src/app/gridGL/HTMLGrid/GridFileInput.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/GridFileInput.tsx
@@ -1,0 +1,43 @@
+import { sheets } from '@/app/grid/controller/Sheets';
+import { supportedFileTypesFromGrid } from '@/app/helpers/files';
+import { useFileImport } from '@/app/ui/hooks/useFileImport';
+import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
+import { useRef } from 'react';
+
+export const FILE_INPUT_ID = 'global-file-input-element';
+
+/**
+ * This component is used to handle file uploads for the grid.
+ * It is hidden and only used to trigger the system file picker.
+ * The picker is triggered by `insertActionsSpec[Action.InsertFile].run()`
+ */
+export function GridFileInput() {
+  const handleFileImport = useFileImport();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    team: { uuid: teamUuid },
+  } = useFileRouteLoaderData();
+
+  return (
+    <input
+      id={FILE_INPUT_ID}
+      ref={fileInputRef}
+      type="file"
+      hidden
+      accept={supportedFileTypesFromGrid.join(',')}
+      onChange={(e) => {
+        const files = e.target.files;
+
+        if (files) {
+          handleFileImport({
+            files,
+            sheetId: sheets.sheet.id,
+            insertAt: { x: sheets.sheet.cursor.position.x, y: sheets.sheet.cursor.position.y },
+            cursor: sheets.getCursorPosition(),
+            teamUuid,
+          });
+        }
+      }}
+    />
+  );
+}

--- a/quadratic-client/src/app/gridGL/HTMLGrid/HTMLGridContainer.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/HTMLGridContainer.tsx
@@ -5,6 +5,7 @@ import { CodeHint } from '@/app/gridGL/HTMLGrid/CodeHint';
 import { CodeRunning } from '@/app/gridGL/HTMLGrid/codeRunning/CodeRunning';
 import { EmptyGridMessage } from '@/app/gridGL/HTMLGrid/EmptyGridMessage';
 import { GridContextMenu } from '@/app/gridGL/HTMLGrid/GridContextMenu';
+import { GridFileInput } from '@/app/gridGL/HTMLGrid/GridFileInput';
 import { HoverCell } from '@/app/gridGL/HTMLGrid/hoverCell/HoverCell';
 import { HoverTooltip } from '@/app/gridGL/HTMLGrid/hoverTooltip/HoverTooltip';
 import { HtmlCells } from '@/app/gridGL/HTMLGrid/htmlCells/HtmlCells';
@@ -122,6 +123,8 @@ export const HTMLGridContainer = (props: Props): ReactNode | null => {
           </div>
         </div>
       </div>
+
+      <GridFileInput />
 
       <Following />
 

--- a/quadratic-client/src/app/helpers/files.ts
+++ b/quadratic-client/src/app/helpers/files.ts
@@ -83,3 +83,4 @@ export const uploadFile = async (fileTypes: string[]): Promise<File[]> => {
 };
 
 export const supportedFileTypes = ['.grid', '.xlsx', '.xls', '.csv', '.parquet', '.parq', '.pqt'];
+export const supportedFileTypesFromGrid = supportedFileTypes.filter((type) => type !== '.grid');

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/InsertMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/InsertMenubarMenu.tsx
@@ -1,9 +1,7 @@
 import { Action } from '@/app/actions/actions';
 import { editorInteractionStateShowCellTypeMenuAtom } from '@/app/atoms/editorInteractionStateAtom';
 import { MenubarItemAction } from '@/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction';
-import { useGlobalSnackbar } from '@/shared/components/GlobalSnackbarProvider';
 import { CodeIcon, DataObjectIcon, InsertChartIcon } from '@/shared/components/Icons';
-import { IMPORT_MESSAGE } from '@/shared/constants/appConstants';
 import {
   MenubarContent,
   MenubarItem,
@@ -18,7 +16,7 @@ import { useSetRecoilState } from 'recoil';
 
 export const InsertMenubarMenu = () => {
   const setShowCellTypeMenu = useSetRecoilState(editorInteractionStateShowCellTypeMenuAtom);
-  const { addGlobalSnackbar } = useGlobalSnackbar();
+
   return (
     <MenubarMenu>
       <MenubarTrigger>Insert</MenubarTrigger>
@@ -49,9 +47,8 @@ export const InsertMenubarMenu = () => {
             Data
           </MenubarSubTrigger>
           <MenubarSubContent>
-            <MenubarItem onClick={() => addGlobalSnackbar(IMPORT_MESSAGE)}>
-              From file (CSV, Excel, or Parquet)
-            </MenubarItem>
+            <MenubarItemAction action={Action.InsertFile} actionArgs={undefined} />
+
             <MenubarSeparator />
             <MenubarItemAction action={Action.InsertApiRequestJavascript} actionArgs={undefined} />
             <MenubarItemAction action={Action.InsertApiRequestPython} actionArgs={undefined} />


### PR DESCRIPTION
When a user goes to "Insert -> Data -> From file", now the system file picker will be triggered (rather than what it currently does, which is trigger a toast that says "drag and drop a file").

When a file is chosen, it will insert data at the current cursor position.

This functionality is uniform between the "Insert..." menu and the "Import data" popup that shows when the sheet is empty.

![CleanShot 2025-01-10 at 10 13 31@2x](https://github.com/user-attachments/assets/ea27ab6e-399a-4439-b2bf-dd5d500d4547)
