### PR TITLE
Edit docker file to match docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,10 @@ services:
       - "./docker/localstack/data:/var/lib/localstack:rw"
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
     profiles:
+      - postgres
       - base
+      - dev
+      - all
     networks:
       - host
 


### PR DESCRIPTION
Open Q on whether it's this update or the docs that need updated. The docs instruction "npm run docker:up" doesn't work but "npm run docker:dev" does, but in dev localstack doesn't start so local doesn't work. 

If this isn't the right change then there's something else I don't understand that will require a docs change to update how docker should be started correctly.