### PR TITLE
Table columns properly show after culling

### DIFF
--- a/quadratic-client/src/app/gridGL/cells/tables/Table.ts
+++ b/quadratic-client/src/app/gridGL/cells/tables/Table.ts
@@ -157,7 +157,7 @@ export class Table extends Container {
     }
     if (
       this.codeCell.show_ui &&
-      this.codeCell.show_name &&
+      (this.codeCell.show_name || this.codeCell.show_columns) &&
       this.codeCell.state !== 'RunError' &&
       this.codeCell.state !== 'SpillError'
     ) {


### PR DESCRIPTION
Fixes: if you have a table without a table name but with columns, and move the viewport so the table is off screen, when it comes back on screen, the columns will not render.