### PR TITLE
Minor fixes to ensure visible

### DIFF
--- a/quadratic-client/src/app/actions/selectionActionsSpec.ts
+++ b/quadratic-client/src/app/actions/selectionActionsSpec.ts
@@ -103,10 +103,8 @@ export const selectionActionsSpec: SelectionActionSpec = {
   [Action.MoveCursorLeftWithSelection]: {
     label: 'Move cursor left with selection',
     run: () => {
-      // const cursor = sheets.sheet.cursor;
-      console.warn('todo moveCursorLeftWithSelection');
-      // const selectionEnd = cursor.selectionEnd;
-      // cursor.selectTo(selectionEnd.x - 1, selectionEnd.y, false);
+      // handled in keyboardPosition
+      // todo: probably rethink how we handle keyboard shortcuts
     },
   },
   [Action.MoveCursorRight]: {
@@ -128,10 +126,8 @@ export const selectionActionsSpec: SelectionActionSpec = {
   [Action.MoveCursorRightWithSelection]: {
     label: 'Move cursor right with selection',
     run: () => {
-      console.warn('todo moveCursorRightWithSelection');
-      // const cursor = sheets.sheet.cursor;
-      // const selectionEnd = cursor.selectionEnd;
-      // cursor.selectTo(selectionEnd.x + 1, selectionEnd.y, false);
+      // handled in keyboardPosition
+      // todo: probably rethink how we handle keyboard shortcuts
     },
   },
   [Action.GotoA1]: {

--- a/quadratic-client/src/app/grid/sheet/SheetCursor.ts
+++ b/quadratic-client/src/app/grid/sheet/SheetCursor.ts
@@ -209,7 +209,7 @@ export class SheetCursor {
 
   selectTo = (x: number, y: number, append: boolean, ensureVisible = true) => {
     this.jsSelection.selectTo(x, y, append);
-    this.updatePosition(ensureVisible);
+    this.updatePosition(ensureVisible ? { x, y } : false);
   };
 
   // Selects columns that have a current selection (used by cmd+space)

--- a/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
+++ b/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
@@ -142,7 +142,7 @@ export function cellVisible(
   const cell = sheet.getCellOffsets(coordinate.x, coordinate.y);
   let is_off_screen = false;
 
-  if (cell.x + headingSize.width < viewport.left) {
+  if (cell.x - headingSize.width / viewport.scale.x < viewport.left) {
     viewport.left = cell.x - headingSize.width / viewport.scale.x;
     is_off_screen = true;
   } else if (cell.x + cell.width > viewport.right) {


### PR DESCRIPTION
1. If viewport is slightly to the right of 1, and you keyboard over to 1, it used to not reset the viewport to the start.
2. When you select with shift+arrow key, the viewport moves correctly