### PR TITLE
chore: remove mui avatars

### DIFF
--- a/quadratic-client/src/routes/teams.$teamUuid.index.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.index.tsx
@@ -6,9 +6,10 @@ import { FilesListEmptyState } from '@/dashboard/components/FilesListEmptyState'
 import NewFileButton from '@/dashboard/components/NewFileButton';
 import { OnboardingBanner } from '@/dashboard/components/OnboardingBanner';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
+import { Avatar } from '@/shared/components/Avatar';
+import { AddIcon } from '@/shared/components/Icons';
 import { ROUTES } from '@/shared/constants/routes';
-import { Add } from '@mui/icons-material';
-import { Avatar, AvatarGroup } from '@mui/material';
+import { cn } from '@/shared/shadcn/utils';
 import { FileIcon } from '@radix-ui/react-icons';
 import { Link } from 'react-router-dom';
 
@@ -22,7 +23,6 @@ export const Component = () => {
     },
   } = useDashboardRouteLoaderData();
   const canEdit = teamPermissions.includes('TEAM_EDIT');
-  const avatarSxProps = { width: 24, height: 24, fontSize: '.875rem' };
 
   const usersById: Record<
     number,
@@ -35,6 +35,8 @@ export const Component = () => {
     {}
   );
 
+  const sharedAvatarClasses = '-ml-1 outline outline-2 outline-background';
+
   return (
     <div className="flex flex-grow flex-col">
       <OnboardingBanner />
@@ -44,26 +46,25 @@ export const Component = () => {
         actions={
           <div className={`flex items-center gap-2`}>
             <div className="hidden lg:block">
-              <Link to={ROUTES.TEAM_MEMBERS(teamUuid)}>
-                {/* TODO(ayush): create custom AvatarGroup component */}
-                <AvatarGroup
-                  max={6}
-                  sx={{ cursor: 'pointer', pr: 0 }}
-                  slotProps={{ additionalAvatar: { sx: avatarSxProps } }}
-                >
-                  <Avatar alt="Add" sx={{ ...avatarSxProps }} className="text-sm">
-                    <Add fontSize="inherit" />
+              <Link to={ROUTES.TEAM_MEMBERS(teamUuid)} className="flex items-center">
+                {users.slice(0, 6).map((user, key) => (
+                  <Avatar
+                    key={key}
+                    alt={user.name}
+                    src={getAuth0AvatarSrc(user.picture)}
+                    className={sharedAvatarClasses}
+                  >
+                    {user.name}
                   </Avatar>
-                  {users.map((user, key) => (
-                    <Avatar
-                      key={key}
-                      alt={user.name}
-                      src={getAuth0AvatarSrc(user.picture)}
-                      sx={avatarSxProps}
-                      imgProps={{ crossOrigin: 'anonymous' }}
-                    />
-                  ))}
-                </AvatarGroup>
+                ))}
+                <div
+                  className={cn(
+                    sharedAvatarClasses,
+                    ' flex h-6 w-6 items-center justify-center rounded-full bg-muted-foreground text-sm text-foreground '
+                  )}
+                >
+                  <AddIcon className="text-background" />
+                </div>
               </Link>
             </div>
             {canEdit && <NewFileButton isPrivate={false} />}

--- a/quadratic-client/src/shared/components/Avatar.tsx
+++ b/quadratic-client/src/shared/components/Avatar.tsx
@@ -1,4 +1,5 @@
 import { getAuth0AvatarSrc } from '@/app/helpers/links';
+import { cn } from '@/shared/shadcn/utils';
 import type { ImgHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 
@@ -7,41 +8,46 @@ interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
   children?: string | React.ReactNode;
 }
 
-export const Avatar = forwardRef<HTMLImageElement, AvatarProps>(({ src, alt, size, style, children, ...rest }, ref) => {
-  const [error, setError] = React.useState(false);
+export const Avatar = forwardRef<HTMLImageElement, AvatarProps>(
+  ({ src, alt, size, style, className, children, ...rest }, ref) => {
+    const [error, setError] = React.useState(false);
 
-  const stylePreset = {
-    width: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
-    height: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
-    fontSize: size === 'small' ? '0.75rem' : size === 'medium' ? '1rem' : size === 'large' ? '1.125rem' : '0.8125rem',
-    borderRadius: '50%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: 'white',
-    backgroundColor: '#BDBDBD',
-  };
+    const stylePreset = {
+      width: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
+      height: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
+      fontSize: size === 'small' ? '0.75rem' : size === 'medium' ? '1rem' : size === 'large' ? '1.125rem' : '0.8125rem',
+      borderRadius: '50%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    };
 
-  return (
-    <>
-      {error ? (
-        <span ref={ref} style={{ ...stylePreset, ...style }} {...rest}>
-          {typeof children === 'string' ? getLettersFromString(children) : children}
-        </span>
-      ) : (
-        <img
-          alt={alt}
-          ref={ref}
-          src={getAuth0AvatarSrc(src) ?? ''}
-          crossOrigin="anonymous"
-          onError={() => setError(true)}
-          style={{ ...stylePreset, ...style }}
-          {...rest}
-        />
-      )}
-    </>
-  );
-});
+    return (
+      <>
+        {error ? (
+          <span
+            ref={ref}
+            className={cn(className, 'bg-muted-foreground text-background')}
+            style={{ ...stylePreset, ...style }}
+            {...rest}
+          >
+            {typeof children === 'string' ? getLettersFromString(children) : children}
+          </span>
+        ) : (
+          <img
+            alt={alt}
+            ref={ref}
+            src={getAuth0AvatarSrc(src) ?? ''}
+            crossOrigin="anonymous"
+            onError={() => setError(true)}
+            style={{ ...stylePreset, ...style }}
+            {...rest}
+          />
+        )}
+      </>
+    );
+  }
+);
 
 function getLettersFromString(str: string) {
   let [first, last] = str.split(' ');


### PR DESCRIPTION
This changes the avatars to use shadcn colors as well as removes usage of the MUI `<Avatar>` and `<AvatarGroup>` on the team page. Instead we rely on our own internal `<Avatar>` component which is now sensitive to light/dark mode.

![CleanShot 2025-02-28 at 16 34 22@2x](https://github.com/user-attachments/assets/00f6c097-1897-44b3-a03e-5c8c4adff31c)

![CleanShot 2025-02-28 at 16 34 10@2x](https://github.com/user-attachments/assets/d2f2f3e9-a33b-4b4d-ae91-abac5fa2e4ba)

Part of an on-going effort to remove MUI components and standardize on shadcn.