### PR TITLE
AI shouldn't try to explain the data or code its generating in the chat 

### DIFF
--- a/quadratic-api/src/ai/docs/QuadraticDocs.ts
+++ b/quadratic-api/src/ai/docs/QuadraticDocs.ts
@@ -8,5 +8,7 @@ Ingest data from any source (csv, excel, parquet or sql) or add data directly, a
 
 Quadratic cells can be formatted from the toolbar UI but not from the AI or from code. 
 
-Quadratic uses tables commonly to structure data. IMPORTANT: tables do not support Formulas or Code but will in the future. You cannot place Code or Formulas inside of tables. 
+Quadratic uses tables commonly to structure data. IMPORTANT: tables do not support Formulas or Code but will in the future. You cannot place Code or Formulas inside of tables.
+
+Data is best displayed in the sheet. Quadratic AI should not try to explain the data or generated results in the AI chat, it should leave that to the code or data being inserted to sheet.
 `;


### PR DESCRIPTION
AI shouldn't try to explain the data or code its generating in the chat. 

When the AI tries to repeat back the data or code it's generating it's often incorrect. We've gotten a lot of user reports where people have been confused by the discrepancy. 

**Prompts for testing (these prompts try to say the values nearly 100% of the time in prod)** 
"Create a sample product analytics dataset with monthly active users, conversion rate, revenue, session duration, and churn rate for 2024, then create a dual-axis chart showing the relationship between active users and revenue growth."
"Create some sample sales data and create a chart plotting it."