### PR TITLE
Temp disable auto expansion

### DIFF
--- a/quadratic-core/src/controller/operations/cell_value.rs
+++ b/quadratic-core/src/controller/operations/cell_value.rs
@@ -99,7 +99,7 @@ impl GridController {
     ) -> (Vec<Operation>, Vec<Operation>) {
         let mut ops = vec![];
         let mut compute_code_ops = vec![];
-        let mut data_table_ops = vec![];
+        let data_table_ops = vec![];
 
         if let Some(sheet) = self.try_sheet(sheet_pos.sheet_id) {
             let height = values.len();
@@ -139,10 +139,12 @@ impl GridController {
                         }
                         false => {
                             cell_values[x][y] = Some(cell_value);
-                            data_table_ops.extend(self.set_cell_value_data_table_operations(
-                                SheetPos::from((pos, sheet_pos.sheet_id)),
-                                value,
-                            ));
+                            // TODO(ddimaria): temporary disabling the below until bugs are fixed
+                            // also re-enable the test_expand_data_table_column_row_on_setting_value test
+                            // data_table_ops.extend(self.set_cell_value_data_table_operations(
+                            //     SheetPos::from((pos, sheet_pos.sheet_id)),
+                            //     value,
+                            // ));
                         }
                     };
 
@@ -158,11 +160,6 @@ impl GridController {
                 }
             }
 
-            // println!("cell_values: {:?}", cell_values);
-            // println!(
-            //     "CellValues::from(cell_values): {:?}",
-            //     CellValues::from(cell_values.clone())
-            // );
             if cell_values != init_cell_values() {
                 ops.push(Operation::SetCellValues {
                     sheet_pos,

--- a/quadratic-core/src/controller/user_actions/cells.rs
+++ b/quadratic-core/src/controller/user_actions/cells.rs
@@ -587,15 +587,15 @@ mod test {
 
         gc.set_cell_value(SheetPos::from((8, 4, sheet_id)), "test1".into(), None);
 
-        // column expand
-        let data_table = gc.sheet(sheet_id).data_table(pos).unwrap();
-        assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 8, 13));
-        assert_eq!(
-            data_table.cell_value_at(3, 2),
-            Some(CellValue::Text("test1".into()))
-        );
+        // // column expand
+        // let data_table = gc.sheet(sheet_id).data_table(pos).unwrap();
+        // assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 8, 13));
+        // assert_eq!(
+        //     data_table.cell_value_at(3, 2),
+        //     Some(CellValue::Text("test1".into()))
+        // );
 
-        gc.undo(None);
+        // gc.undo(None);
 
         let sheet = gc.sheet(sheet_id);
         let data_table = sheet.data_table(pos).unwrap();
@@ -615,26 +615,27 @@ mod test {
             Some(CellValue::Text("test2".into()))
         );
 
-        // row expand
-        gc.set_cell_value(SheetPos::from((6, 14, sheet_id)), "test3".into(), None);
+        // TODO(ddimaria): temporary disabling the below until bugs are fixed in set_cell_values_operations()
+        // // row expand
+        // gc.set_cell_value(SheetPos::from((6, 14, sheet_id)), "test3".into(), None);
 
-        let sheet = gc.sheet(sheet_id);
-        let data_table = sheet.data_table(pos).unwrap();
-        assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 7, 14));
-        assert_eq!(
-            data_table.cell_value_at(1, 12),
-            Some(CellValue::Text("test3".into()))
-        );
+        // let sheet = gc.sheet(sheet_id);
+        // let data_table = sheet.data_table(pos).unwrap();
+        // assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 7, 14));
+        // assert_eq!(
+        //     data_table.cell_value_at(1, 12),
+        //     Some(CellValue::Text("test3".into()))
+        // );
 
-        gc.undo(None);
+        // gc.undo(None);
 
-        let sheet = gc.sheet(sheet_id);
-        let data_table = sheet.data_table(pos).unwrap();
-        assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 7, 13));
-        assert_eq!(
-            sheet.cell_value(pos![F14]),
-            Some(CellValue::Text("test3".into()))
-        );
+        // let sheet = gc.sheet(sheet_id);
+        // let data_table = sheet.data_table(pos).unwrap();
+        // assert_eq!(data_table.output_rect(pos, false), Rect::new(5, 2, 7, 13));
+        // assert_eq!(
+        //     sheet.cell_value(pos![F14]),
+        //     Some(CellValue::Text("test3".into()))
+        // );
 
         gc.set_cell_value(SheetPos::from((8, 14, sheet_id)), "test4".into(), None);
 


### PR DESCRIPTION
Temporarily disables table growing to the right and bottom when new data is added via a user or AI.