### PR TITLE
AI refs docs update

### DIFF
--- a/quadratic-api/src/ai/docs/JavascriptDocs.ts
+++ b/quadratic-api/src/ai/docs/JavascriptDocs.ts
@@ -2,9 +2,25 @@ export const JavascriptDocs = `# Javascript Docs
 
 With Javascript in Quadratic, the world's most popular programming language meets the world's most popular tool for working with data - spreadsheets. 
 
-# Reference cells from JavaScript
+In Quadratic, reference tables and named outputs for simplest reference, reference individual cells from JavaScript for single values or reference a range of cells for multiple values. 
 
-In Quadratic, reference individual cells from Javascript for single values or reference a range of cells for multiple values. 
+## Referencing tables (and named outputs)
+
+\`\`\`javascript
+To reference a table, use the global function q.cells along with the table's name in the fashion outlined below. 
+// NOTE: uses the same A1 notation as Formulas
+// References existing Table1 and is read in as array of arrays
+let x = q.cells("Table_name")
+
+// Get a single column out of table into an array
+let x = q.cells("Table_name[column_name]")
+
+// Get the table headers 
+let x = q.cells("Table_name[#HEADERS]")
+
+// Reference a range of columns in a table
+let x = q.cells("Table_name[[Column_name:Column_name]]")
+\`\`\`
 
 ## Referencing individual cells
 
@@ -28,13 +44,13 @@ let let x = q.cells('A1:A5') // Returns a 1x5 array spanning from A1 to A5
 
 let let x = q.cells('A1:C7') // Returns a 3x7 array of arrays spanning from A1 to C7
 
-let let x = q.cells('A') // Returns all values in column A into a single-column DataFrame
+let let x = q.cells('A') // Returns all values in column A into a single array
 
-let let x = q.cells('A:C') // Returns all values in columns A to C into a three-column DataFrame
+let let x = q.cells('A:C') // Returns all values in columns A to C into an array of three arrays 
 
-let let x = q.cells('A5:A') // Returns all values in column A starting at A5 and going down
+let let x = q.cells('A5:A') // Returns all values in column A starting at A5 and going down as an array 
 
-let let x = q.cells('A5:C') // Returns all values in column A to C, starting at A5 and going down
+let let x = q.cells('A5:C') // Returns all values in column A to C, starting at A5 and going down as an array of arrays
 \`\`\`
 
 ## Referencing another sheet

--- a/quadratic-api/src/ai/docs/JavascriptDocs.ts
+++ b/quadratic-api/src/ai/docs/JavascriptDocs.ts
@@ -19,7 +19,7 @@ let x = q.cells("Table_name[column_name]")
 let x = q.cells("Table_name[#HEADERS]")
 
 // Reference a range of columns in a table
-let x = q.cells("Table_name[[Column_name:Column_name]]")
+let x = q.cells("Table_name[[Column_name]:[Column_name]]")
 \`\`\`
 
 ## Referencing individual cells

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -32,6 +32,9 @@ df_column = q.cells("Table1[column_name]")
 
 # Creates an empty DataFrame with just the DataFrame's headers as table's column names
 df_headers = q.cells("Table1[#HEADERS]")
+
+# Reference a range of columns from a table, e.g. in following example we reference columns 1, 2, and 3. Columns can then be dropped or manipulated using Pandas DataFrame logic.
+df_columns = q.cells("Table1[[Column 1:Column 3]]")
 \`\`\`python
 
 Tables should be used whenever possible. Use ranged A1 references or single cell references otherwise. 

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -34,7 +34,7 @@ df_column = q.cells("Table1[column_name]")
 df_headers = q.cells("Table1[#HEADERS]")
 
 # Reference a range of columns from a table, e.g. in following example we reference columns 1, 2, and 3. Columns can then be dropped or manipulated using Pandas DataFrame logic.
-df_columns = q.cells("Table1[[Column 1:Column 3]]")
+df_columns = q.cells("Table1[[Column 1]:[Column 3]]")
 \`\`\`python
 
 Tables should be used whenever possible. Use ranged A1 references or single cell references otherwise. 

--- a/quadratic-api/src/ai/docs/QuadraticDocs.ts
+++ b/quadratic-api/src/ai/docs/QuadraticDocs.ts
@@ -11,4 +11,6 @@ Quadratic cells can be formatted from the toolbar UI but not from the AI or from
 Quadratic uses tables commonly to structure data. IMPORTANT: tables do not support Formulas or Code but will in the future. You cannot place Code or Formulas inside of tables.
 
 Data is best displayed in the sheet. Quadratic AI should not try to explain the data or generated results in the AI chat, it should leave that to the code or data being inserted to sheet.
+
+Code generated in Quadratic is not global to other code cells. The data the code cell outputs to the sheet can be referenced by other cells, but variables in one code cell cannot be read in another. Imports in one code cell do not automatically apply to other code cells. 
 `;


### PR DESCRIPTION
Edits AI docs in following ways: 
**Python docs:** adds column range reference 
**JS docs:** adds table refs and updates some incorrect language 
**Quadratic docs:** adds instructions stating code isn't global; attempts to fix a common error where thinking mode generates code that it thinks it can reference in subsequently created code

Realized this was missing from [this discussion](https://community.quadratichq.com/t/how-do-you-reference-cells-from-programming-languages/17/2) with user