### PR TITLE
Loading fonts in pixi timeouts on slow connections

### DIFF
--- a/quadratic-client/src/app/gridGL/loadAssets.ts
+++ b/quadratic-client/src/app/gridGL/loadAssets.ts
@@ -6,9 +6,11 @@ import { createBorderTypes } from './generateTextures';
 const intervalToCheckBitmapFonts = 100;
 export const bitmapFonts = ['OpenSans', 'OpenSans-Bold', 'OpenSans-Italic', 'OpenSans-BoldItalic'];
 
+const TIMEOUT = 10000;
+
 function loadFont(fontName: string): void {
   const font = new FontFaceObserver(fontName);
-  font.load();
+  font.load(undefined, TIMEOUT);
 }
 
 export function ensureBitmapFontLoaded(resolve: () => void): void {


### PR DESCRIPTION
Fixes an issue when loading the app over a slow connection. Before, after 3s, the font would timeout, which would stop the app from loading.