### PR TITLE
fix: avatar spacing

### DIFF
--- a/quadratic-client/src/shared/components/Avatar.tsx
+++ b/quadratic-client/src/shared/components/Avatar.tsx
@@ -41,6 +41,7 @@ export const Avatar = forwardRef<HTMLImageElement, AvatarProps>(
             crossOrigin="anonymous"
             onError={() => setError(true)}
             style={{ ...stylePreset, ...style }}
+            className={className}
             {...rest}
           />
         )}


### PR DESCRIPTION
The `className` prop wasn't being passed to the `<Avatar>` component, so context-specific UI overrides weren't being applied correctly. For example, grouped avatars weren't spaced/overlaid correctly.

Here's an example from prod:

![CleanShot 2025-03-06 at 16 54 54@2x](https://github.com/user-attachments/assets/2a668c81-eec0-4485-a83d-6339316ae577)

And on local:

![CleanShot 2025-03-06 at 16 52 58@2x](https://github.com/user-attachments/assets/6ecde9cd-d0a7-464f-8b0d-3c55c7533b1e)

**The above are examples of what it SHOULD NOT look like.** Here's what it looks like in the current preview branch:
![CleanShot 2025-03-07 at 16 01 45@2x](https://github.com/user-attachments/assets/26b3fddf-b455-47de-9b8b-ce60a8bf4e9d)

