### PR TITLE
Allow renaming of Sheet names, tables, and columns w/only changes to case

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
@@ -87,6 +87,7 @@ export const TableColumnHeaderRename = () => {
               x: contextMenu.table.x,
               y: contextMenu.table.y,
               tableName: contextMenu.table.name,
+              index: contextMenu.selectedColumn,
               oldColumnName,
               newColumnName: value,
               columns,

--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableRename.tsx
@@ -29,10 +29,7 @@ export const TableRename = () => {
       ) {
         return;
       } else {
-        const bounds = pixiApp.cellsSheets.current?.tables.getTableNamePosition(
-          contextMenu.table.x,
-          contextMenu.table.y
-        );
+        const bounds = pixiApp.cellsSheet().tables.getTableNamePosition(contextMenu.table.x, contextMenu.table.y);
         if (bounds && inputElement) {
           setWidth(bounds.width);
           inputElement.style.top = `${bounds.y}px`;

--- a/quadratic-client/src/app/ui/hooks/useRenameTableColumnName.tsx
+++ b/quadratic-client/src/app/ui/hooks/useRenameTableColumnName.tsx
@@ -14,6 +14,7 @@ export function useRenameTableColumnName() {
       x,
       y,
       tableName,
+      index,
       oldColumnName,
       newColumnName,
       columns,
@@ -22,12 +23,13 @@ export function useRenameTableColumnName() {
       x: number;
       y: number;
       tableName: string;
+      index: number;
       oldColumnName: string;
       newColumnName: string;
       columns: JsDataTableColumnHeader[];
     }) => {
       try {
-        validateColumnName(tableName, newColumnName, sheets.a1Context);
+        validateColumnName(tableName, index, newColumnName, sheets.a1Context);
       } catch (error) {
         addGlobalSnackbar(error as string, { severity: 'error' });
         return;

--- a/quadratic-client/src/app/ui/hooks/useRenameTableName.tsx
+++ b/quadratic-client/src/app/ui/hooks/useRenameTableName.tsx
@@ -24,7 +24,7 @@ export function useRenameTableName() {
       newName = newName.trim();
 
       try {
-        validateTableName(newName, sheets.a1Context);
+        validateTableName(newName, sheetId, x, y, sheets.a1Context);
       } catch (error) {
         addGlobalSnackbar(error as string, { severity: 'error' });
         return;

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeaderLabel.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorHeaderLabel.tsx
@@ -84,14 +84,20 @@ export function CodeEditorHeaderLabel() {
 
         let isValid = false;
         try {
-          isValid = validateTableName(value, sheets.a1Context);
+          isValid = validateTableName(
+            value,
+            codeCellState.sheetId,
+            codeCellState.pos.x,
+            codeCellState.pos.y,
+            sheets.a1Context
+          );
         } catch (error) {
           isValid = false;
         }
         input.setAttribute('aria-invalid', (!isValid).toString());
       }
     },
-    [tableName]
+    [codeCellState.pos.x, codeCellState.pos.y, codeCellState.sheetId, tableName]
   );
 
   const handleBlur = useCallback(

--- a/quadratic-client/src/app/ui/menus/SheetBar/SheetBarTab.tsx
+++ b/quadratic-client/src/app/ui/menus/SheetBar/SheetBarTab.tsx
@@ -183,7 +183,7 @@ function TabName({
   const validateName = useCallback(
     (value: string) => {
       try {
-        validateSheetName(value, sheets.a1Context);
+        validateSheetName(value, sheet.id, sheets.a1Context);
         return true;
       } catch (error) {
         setErrorMessage(error as string);
@@ -191,7 +191,7 @@ function TabName({
         return false;
       }
     },
-    [setErrorMessage]
+    [setErrorMessage, sheet.id]
   );
 
   // When a rename begins, focus contenteditable and select its contents

--- a/quadratic-core/src/a1/js_selection/validate_name.rs
+++ b/quadratic-core/src/a1/js_selection/validate_name.rs
@@ -30,9 +30,10 @@ pub fn js_validate_table_name(
 #[wasm_bindgen(js_name = "validateColumnName")]
 pub fn jsvalidate_column_name(
     table_name: &str,
+    index: i32,
     column_name: &str,
     context: &str,
 ) -> Result<bool, String> {
     let context = serde_json::from_str::<A1Context>(context).map_err(|e| e.to_string())?;
-    DataTable::validate_column_name(table_name, column_name, &context)
+    DataTable::validate_column_name(table_name, index as usize, column_name, &context)
 }

--- a/quadratic-core/src/a1/js_selection/validate_name.rs
+++ b/quadratic-core/src/a1/js_selection/validate_name.rs
@@ -1,11 +1,16 @@
+use std::str::FromStr;
+
 use wasm_bindgen::prelude::*;
+
+use crate::grid::SheetId;
 
 use super::{A1Context, DataTable, Sheet};
 
 #[wasm_bindgen(js_name = "validateSheetName")]
-pub fn js_validate_sheet_name(name: &str, context: &str) -> Result<bool, String> {
+pub fn js_validate_sheet_name(name: &str, sheet_id: &str, context: &str) -> Result<bool, String> {
+    let sheet_id = SheetId::from_str(sheet_id).map_err(|e| e.to_string())?;
     let context = serde_json::from_str::<A1Context>(context).map_err(|e| e.to_string())?;
-    Sheet::validate_sheet_name(name, &context)
+    Sheet::validate_sheet_name(name, sheet_id, &context)
 }
 
 #[wasm_bindgen(js_name = "validateTableName")]

--- a/quadratic-core/src/a1/js_selection/validate_name.rs
+++ b/quadratic-core/src/a1/js_selection/validate_name.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use wasm_bindgen::prelude::*;
 
-use crate::grid::SheetId;
+use crate::{grid::SheetId, SheetPos};
 
 use super::{A1Context, DataTable, Sheet};
 
@@ -14,9 +14,17 @@ pub fn js_validate_sheet_name(name: &str, sheet_id: &str, context: &str) -> Resu
 }
 
 #[wasm_bindgen(js_name = "validateTableName")]
-pub fn js_validate_table_name(name: &str, context: &str) -> Result<bool, String> {
+pub fn js_validate_table_name(
+    name: &str,
+    sheet_id: &str,
+    x: i32,
+    y: i32,
+    context: &str,
+) -> Result<bool, String> {
+    let sheet_id = SheetId::from_str(sheet_id).map_err(|e| e.to_string())?;
+    let sheet_pos = SheetPos::new(sheet_id, x as i64, y as i64);
     let context = serde_json::from_str::<A1Context>(context).map_err(|e| e.to_string())?;
-    DataTable::validate_table_name(name, &context)
+    DataTable::validate_table_name(name, sheet_pos, &context)
 }
 
 #[wasm_bindgen(js_name = "validateColumnName")]

--- a/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
@@ -674,6 +674,7 @@ impl GridController {
                             // validate column name
                             if let Err(e) = DataTable::validate_column_name(
                                 &old_name,
+                                index,
                                 &new_column.name.to_string(),
                                 &context,
                             ) {

--- a/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
@@ -640,7 +640,9 @@ impl GridController {
             if let Some(name) = name.to_owned() {
                 if old_name != name {
                     // validate table name
-                    if let Err(e) = DataTable::validate_table_name(&name, self.a1_context()) {
+                    if let Err(e) =
+                        DataTable::validate_table_name(&name, sheet_pos, self.a1_context())
+                    {
                         if cfg!(target_family = "wasm") || cfg!(test) {
                             crate::wasm_bindings::js::jsClientMessage(
                                 e.to_owned(),

--- a/quadratic-core/src/controller/execution/execute_operation/execute_sheets.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_sheets.rs
@@ -197,7 +197,7 @@ impl GridController {
         op: Operation,
     ) -> Result<()> {
         if let Operation::SetSheetName { sheet_id, name } = op {
-            if let Err(e) = Sheet::validate_sheet_name(&name, self.a1_context()) {
+            if let Err(e) = Sheet::validate_sheet_name(&name, sheet_id, self.a1_context()) {
                 if cfg!(target_family = "wasm") || cfg!(test) {
                     crate::wasm_bindings::js::jsClientMessage(
                         e.to_owned(),
@@ -208,7 +208,6 @@ impl GridController {
                 transaction.operations.clear();
                 bail!(e);
             }
-
             let context = self.a1_context().to_owned();
 
             let sheet = self.try_sheet_result(sheet_id)?;

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -343,6 +343,7 @@ impl DataTable {
     /// Column name must be unique
     pub fn validate_column_name(
         table_name: &str,
+        index: usize,
         column_name: &str,
         context: &A1Context,
     ) -> std::result::Result<bool, String> {
@@ -357,7 +358,10 @@ impl DataTable {
         }
 
         // Check if column name already exists
-        if context.table_map.table_has_column(table_name, column_name) {
+        if context
+            .table_map
+            .table_has_column(table_name, column_name, index)
+        {
             return Err("Column name must be unique".to_string());
         }
 
@@ -1171,7 +1175,7 @@ pub mod test {
 
         for name in valid_names {
             assert!(
-                DataTable::validate_column_name(table_name, name, &context).is_ok(),
+                DataTable::validate_column_name(table_name, 10, name, &context).is_ok(),
                 "Expected '{}' to be valid",
                 name
             );
@@ -1222,7 +1226,7 @@ pub mod test {
         ];
 
         for (name, expected_error) in test_cases {
-            let result = DataTable::validate_column_name(table_name, name, &context);
+            let result = DataTable::validate_column_name(table_name, 10, name, &context);
             assert!(
                 result.is_err(),
                 "Expected '{}' to be invalid, but it was valid",
@@ -1237,8 +1241,12 @@ pub mod test {
         }
 
         // Test duplicate column name
-        let result = DataTable::validate_column_name(table_name, "existing_col", &context);
+        let result = DataTable::validate_column_name(table_name, 10, "existing_col", &context);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Column name must be unique");
+
+        // Allow duplicate column name if the index is the same as the existing column index
+        let result = DataTable::validate_column_name(table_name, 0, "existing_col", &context);
+        assert!(result.is_ok());
     }
 }

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -295,15 +295,15 @@ impl DataTable {
         self.show_columns = show_columns;
         self
     }
-    /// Validates the table name.
+    /// Validates the table name. SheetPos is provided to allow the table to be
+    /// renamed to itself (eg, with different casing).
     ///
-    /// Table name must be between 1 and 255 characters
-    /// Table name cannot be a single 'R' or 'C'
-    /// Table name cannot be a cell reference
-    /// Table name cannot contain invalid characters
-    /// Table name must be unique
+    /// Table name must be between 1 and 255 characters Table name cannot be a
+    /// single 'R' or 'C' Table name cannot be a cell reference Table name
+    /// cannot contain invalid characters Table name must be unique
     pub fn validate_table_name(
         name: &str,
+        sheet_pos: SheetPos,
         context: &A1Context,
     ) -> std::result::Result<bool, String> {
         // Check length limit
@@ -327,8 +327,10 @@ impl DataTable {
         }
 
         // Check if table name already exists
-        if context.table_map.try_table(name).is_some() {
-            return Err("Table name must be unique".to_string());
+        if let Some(table) = context.table_map.try_table(name) {
+            if table.sheet_id != sheet_pos.sheet_id || table.bounds.min != sheet_pos.into() {
+                return Err("Table name must be unique".to_string());
+            }
         }
 
         std::result::Result::Ok(true)
@@ -1088,8 +1090,10 @@ pub mod test {
             "a",
         ];
 
+        let sheet_pos = SheetPos::from((1, 1, SheetId::TEST));
+
         for name in valid_names {
-            assert!(DataTable::validate_table_name(name, &context).is_ok());
+            assert!(DataTable::validate_table_name(name, sheet_pos, &context).is_ok());
         }
 
         // invalid table name
@@ -1113,7 +1117,7 @@ pub mod test {
         ];
 
         for (name, expected_error) in test_cases {
-            let result = DataTable::validate_table_name(name, &context);
+            let result = DataTable::validate_table_name(name, sheet_pos, &context);
             assert!(result.is_err());
             assert_eq!(result.unwrap_err(), expected_error);
         }
@@ -1126,9 +1130,17 @@ pub mod test {
                 ("Table2", &["col3", "col4"], Rect::test_a1("D1:E3")),
             ],
         );
-        let result = DataTable::validate_table_name("Table1", &context);
+        let result = DataTable::validate_table_name(
+            "Table1",
+            SheetPos::new(SheetId::TEST, 10, 10),
+            &context,
+        );
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Table name must be unique");
+
+        // duplicate table name with different casing
+        let result = DataTable::validate_table_name("TABLE1", sheet_pos, &context);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -108,7 +108,11 @@ impl Sheet {
         Sheet::new(SheetId::TEST, String::from("Sheet1"), String::from("a0"))
     }
 
-    pub fn validate_sheet_name(name: &str, context: &A1Context) -> Result<bool, String> {
+    pub fn validate_sheet_name(
+        name: &str,
+        sheet_id: SheetId,
+        context: &A1Context,
+    ) -> Result<bool, String> {
         // Check length limit
         if name.is_empty() || name.len() > 31 {
             return Err("Sheet name must be between 1 and 31 characters".to_string());
@@ -121,8 +125,10 @@ impl Sheet {
 
         // Check if sheet name already exists
 
-        if context.sheet_map.try_sheet_name(name).is_some() {
-            return Err("Sheet name must be unique".to_string());
+        if let Some(existing_sheet_id) = context.sheet_map.try_sheet_name(name) {
+            if existing_sheet_id != sheet_id {
+                return Err("Sheet name must be unique".to_string());
+            }
         }
 
         Ok(true)
@@ -1262,7 +1268,7 @@ mod test {
 
         for name in valid_names {
             assert!(
-                Sheet::validate_sheet_name(name, &context).is_ok(),
+                Sheet::validate_sheet_name(name, SheetId::TEST, &context).is_ok(),
                 "Expected '{}' to be valid",
                 name
             );
@@ -1312,7 +1318,7 @@ mod test {
         ];
 
         for (name, expected_error) in test_cases {
-            let result = Sheet::validate_sheet_name(name, &context);
+            let result = Sheet::validate_sheet_name(name, SheetId::TEST, &context);
             assert!(
                 result.is_err(),
                 "Expected '{}' to be invalid, but it was valid",
@@ -1327,9 +1333,13 @@ mod test {
         }
 
         // Test duplicate sheet name
-        let result = Sheet::validate_sheet_name("ExistingSheet", &context);
+        let result = Sheet::validate_sheet_name("ExistingSheet", SheetId::new(), &context);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Sheet name must be unique");
+
+        // Test same sheet name with different case
+        let result = Sheet::validate_sheet_name("EXISTINGSHEET", SheetId::TEST, &context);
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2360 

- [x] sheet names with different case
- [x] tables with different case
- [x] column names with different case