### PR TITLE
Add issue templates & PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a bug report
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## Expected behavior
+A clear and concise description of what you expect to happen.
+
+## Reproduction
+Steps to reproduce the behavior:
+1.
+2.
+3.
+
+## Device details (optional)
+If not Desktop, MacOS, and Chrome please fill out the following:
+- Device type: [e.g. Mobile]
+- OS: [e.g. Windows]
+- Browser [e.g. Safari]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,9 +10,6 @@ assignees: ''
 ## (Optional) Basic description/background
 Include any basic details that aren't self explanatory in the issue title. Optionally include background on why this feature is necessary (user comments, research, etc).
 
-## (Optional) Discussion items
-Items that the person scoping the issue is unclear on that requires discussion. E.g. "I think abc and xyz should be included, but maybe only abc should be?"
-
 ## Wireframing, in-depth details, docs, etc.
 Include here an in-depth description of how the feature should work. This can also be a link to some place else that has the description.
 
@@ -20,3 +17,6 @@ A good feature request should ideally include:
 - Clear and concise descriptions of how the feature should work 
 - Wireframing for every UI element added 
 - Best effort description of how features should interact, edge cases, etc.
+
+## (Optional) To be discussed
+Items that the person scoping the issue is unclear on that requires discussion. E.g. "I think abc and xyz should be included, but maybe only abc should be?"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## (Optional) Basic description/background
+Include any basic details that aren't self explanatory in the issue title. Optionally include background on why this feature is necessary (user comments, research, etc).
+
+## Wireframing, in-depth details, docs, etc.
+Include here an in-depth description of how the feature should work. This can also be a link to some place else that has the description.
+
+A good feature request should ideally include: 
+- Clear and concise descriptions of how the feature should work 
+- Wireframing for every UI element added 
+- Best effort description of how features should interact, edge cases, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,9 @@ assignees: ''
 ## (Optional) Basic description/background
 Include any basic details that aren't self explanatory in the issue title. Optionally include background on why this feature is necessary (user comments, research, etc).
 
+## (Optional) Discussion items
+Items that the person scoping the issue is unclear on that requires discussion. E.g. "I think abc and xyz should be included, but maybe only abc should be?"
+
 ## Wireframing, in-depth details, docs, etc.
 Include here an in-depth description of how the feature should work. This can also be a link to some place else that has the description.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Relevant issue(s)
+[insert link(s) here]
+
+## Description
+This should sufficiently describe the functionality added/improved in the PR. 
+
+## (Optional) Any extra testing considerations?
+E.g. "this changes the core functionality of tables, all the basic table functionality should be validated to be working as expected."
+
+## (Optional) Any dependent docs, links, etc.?
+E.g. "@xyzperson need docs link to security page for link in-app" 


### PR DESCRIPTION
## Relevant issue(s)
#2455 

## Description
This adds all the issue & PR templates outlined in #2455. These include bug, feature, and PR templates. 

## (Optional) Any extra testing considerations?
This doesn't touch any relevant code and doesn't require testing. 

You can review how this feels by visiting [this repo](https://github.com/luke-quadratic/template-testing/). This repo includes the issue and PR templates in this PR; to test just play with creating an issue or PR. 

## (Optional) Any dependent docs, links, etc.?
N/A
