### PR TITLE
fix: resizing a grid column/row does not properly reset when pressing escape

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerHeading.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerHeading.ts
@@ -36,6 +36,7 @@ export class PointerHeading {
     width?: number;
     height?: number;
     lastSize: number;
+    oldSize: number;
   };
 
   // tracks changes to viewport caused by resizing negative column/row headings
@@ -49,6 +50,10 @@ export class PointerHeading {
     if (this.active) {
       this.active = false;
       sheets.sheet.offsets.cancelResize();
+      if (this.resizing) {
+        const delta = this.resizing.lastSize - this.resizing.oldSize;
+        renderWebWorker.updateSheetOffsetsTransient(sheets.current, this.resizing.column, this.resizing.row, delta);
+      }
       pixiApp.gridLines.dirty = true;
       pixiApp.cursor.dirty = true;
       pixiApp.headings.dirty = true;
@@ -88,6 +93,7 @@ export class PointerHeading {
       };
       this.resizing = {
         lastSize: this.viewportChanges.originalSize,
+        oldSize: this.viewportChanges.originalSize,
         start: headingResize.start,
         row: headingResize.row,
         column: headingResize.column,

--- a/quadratic-core/src/sheet_offsets/resize_transient.rs
+++ b/quadratic-core/src/sheet_offsets/resize_transient.rs
@@ -47,6 +47,7 @@ impl SheetOffsets {
                 self.resize_row_transiently(row, Some(resize.old_size));
             }
         }
+        self.transient_resize = None;
     }
 
     /// Resizes a column and returns the old width.


### PR DESCRIPTION
## Relevant issue(s)
closes #2375 

## Description
fixes the linked issue

## (Optional) Any extra testing considerations?
no

## (Optional) Any dependent docs, links, etc.?
no