### PR TITLE
remove legacy database tables

### DIFF
--- a/quadratic-api/prisma/migrations/20250312165630_remove_unused_tables/migration.sql
+++ b/quadratic-api/prisma/migrations/20250312165630_remove_unused_tables/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `qUserId` on the `QFeedback` table. All the data in the column will be lost.
+  - You are about to drop the `QFile` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `QUser` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "QFile" DROP CONSTRAINT "QFile_qUserId_fkey";
+
+-- AlterTable
+ALTER TABLE "QFeedback" DROP COLUMN "qUserId";
+
+-- DropTable
+DROP TABLE "QFile";
+
+-- DropTable
+DROP TABLE "QUser";

--- a/quadratic-api/prisma/schema.prisma
+++ b/quadratic-api/prisma/schema.prisma
@@ -230,34 +230,10 @@ model QFeedback {
     id           Int      @id @default(autoincrement())
     feedback     String
     created_date DateTime @default(now())
-    qUserId      Int? // Linked to the old QUser object
     userId       Int?
     user         User?    @relation(fields: [userId], references: [id])
 }
 
-// !!Legacy user model
-// use User instead
-model QUser {
-    id            Int     @id @default(autoincrement())
-    auth0_user_id String? @unique
-    QFile         QFile[]
-}
-
-// !!Legacy user model
-// use File instead
-model QFile {
-    id            Int      @id @default(autoincrement())
-    uuid          String   @unique @default(uuid())
-    user_owner    QUser    @relation(fields: [qUserId], references: [id])
-    name          String
-    contents      Json
-    created_date  DateTime @default(now())
-    updated_date  DateTime @default(now())
-    qUserId       Int
-    // analytics fields
-    times_updated Int      @default(1)
-    version       String?
-}
 
 model AnalyticsAIChat {
     id          Int                      @id @default(autoincrement())


### PR DESCRIPTION
## Description
The old QFile table takes a ton of space in our database, this cleans up unused tables and will help our database migration go faster.

We have backups of this data.