### PR TITLE
Data missing when changing dataframe code cell to a single value

### DIFF
--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -107,12 +107,14 @@ impl GridController {
                 new_data_table.header_is_first_row |= old_data_table.header_is_first_row;
             }
 
-            // if the new data table is a single value and is a code cell, then we don't want to show the name
+            // if the new data table is a single value and is a code cell, then we
+            // don't want to show the name or columns headers
             if new_data_table.is_single_value()
                 && is_code_cell
                 && !new_data_table.is_html_or_image()
             {
                 new_data_table.show_name = false;
+                new_data_table.show_columns = false;
             }
 
             // if the width of the old and new data tables are the same,
@@ -513,9 +515,11 @@ impl GridController {
         transaction.cells_accessed.clear();
         data_table.show_columns = js_code_result.has_headers;
 
-        // if the new data table is a single value and is a code cell, then we don't want to show the name
+        // if the new data table is a single value and is a code cell, then we
+        // don't want to show the name or columns headers
         if is_single_value && language.is_code_language() && !data_table.is_html_or_image() {
             data_table.show_name = false;
+            data_table.show_columns = false;
         }
 
         // If no headers were returned, we want column headers: [0, 1, 2, 3, ...etc]

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -618,7 +618,8 @@ mod test {
             true,
             None,
         )
-        .with_show_name(false);
+        .with_show_name(false)
+        .with_show_columns(false);
         gc.finalize_data_table(transaction, sheet_pos, Some(new_data_table.clone()), None);
         assert_eq!(transaction.forward_operations.len(), 1);
         assert_eq!(transaction.reverse_operations.len(), 1);


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/quadratichq/quadratic/issues/2483

## Description
In Python, you can now create code that outputs a data frame, then switch to code that outputs a single value (and back again) with data still displaying properly

### DataFrame output, then single value output, then DataFrame output
![dataframe-to-single-value](https://github.com/user-attachments/assets/afa9d7d1-161a-4997-8882-13b91bbb4d68)
