### PR TITLE
Guess at first row is heading

### DIFF
--- a/quadratic-client/src/app/ui/hooks/useFileImport.tsx
+++ b/quadratic-client/src/app/ui/hooks/useFileImport.tsx
@@ -1,6 +1,6 @@
 import { getFileType, stripExtension, supportedFileTypes, uploadFile } from '@/app/helpers/files';
 import type { JsCoordinate } from '@/app/quadratic-core-types';
-import { DEFAULT_CSV_DELIMITER, DEFAULT_HAS_HEADING } from '@/app/ui/components/CSVImportSettings';
+import { DEFAULT_CSV_DELIMITER } from '@/app/ui/components/CSVImportSettings';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import type { FileImportProgress } from '@/dashboard/atoms/filesImportProgressAtom';
 import { filesImportProgressAtom } from '@/dashboard/atoms/filesImportProgressAtom';
@@ -105,7 +105,7 @@ export function useFileImport() {
       const totalFiles = files.length;
 
       let csvDelimiter: number | undefined = DEFAULT_CSV_DELIMITER.charCodeAt(0);
-      let hasHeading: boolean | undefined = DEFAULT_HAS_HEADING;
+      // let hasHeading: boolean | undefined = DEFAULT_HAS_HEADING;
       // const firstCSVFile = files.find((file) => getFileType(file) === 'csv');
       // if (firstCSVFile) {
       //   try {
@@ -187,7 +187,7 @@ export function useFileImport() {
               sheetId,
               location: insertAt,
               csvDelimiter,
-              hasHeading,
+              // hasHeading,
             });
           } else {
             throw new Error(`Error importing ${fileName} (${fileSize} bytes): Unsupported file type.`);

--- a/quadratic-core/src/controller/operations/import.rs
+++ b/quadratic-core/src/controller/operations/import.rs
@@ -24,6 +24,33 @@ use super::operation::Operation;
 const IMPORT_LINES_PER_OPERATION: u32 = 10000;
 
 impl GridController {
+    /// Guesses if the first row of a CSV file is a header based on the types of the
+    /// first three rows.
+    pub fn guess_csv_first_row_is_header(&self, cell_values: &Array) -> bool {
+        if cell_values.height() < 3 {
+            return false;
+        }
+
+        let types = |row: usize| {
+            cell_values
+                .get_row(row)
+                .unwrap_or_default()
+                .iter()
+                .map(|c| c.type_id())
+                .collect::<Vec<_>>()
+        };
+
+        let row_0 = types(0);
+        let row_1 = types(1);
+        let row_2 = types(2);
+
+        let row_0_is_different_from_row_1 = row_0 != row_1;
+        let row_1_is_same_as_row_2 = row_1 == row_2;
+        let first_row_is_header = row_0_is_different_from_row_1 && row_1_is_same_as_row_2;
+
+        first_row_is_header
+    }
+
     pub fn get_csv_preview(
         file: Vec<u8>,
         max_rows: u32,
@@ -186,14 +213,20 @@ impl GridController {
         let mut data_table =
             DataTable::from((import.to_owned(), Array::new_empty(array_size), context));
 
+        let apply_first_row_as_header = match header_is_first_row {
+            Some(true) => true,
+            Some(false) => false,
+            None => self.guess_csv_first_row_is_header(&cell_values),
+        };
+
         data_table.value = cell_values.into();
         data_table.formats.apply_updates(&sheet_format_updates);
 
-        drop(sheet_format_updates);
-
-        if Some(true) == header_is_first_row {
+        if apply_first_row_as_header {
             data_table.apply_first_row_as_header();
         }
+
+        drop(sheet_format_updates);
 
         let ops = vec![Operation::AddDataTable {
             sheet_pos,
@@ -488,6 +521,7 @@ fn read_utf16(bytes: &[u8]) -> Option<String> {
 mod test {
     use super::{read_utf16, *};
     use crate::{
+        controller::user_actions::import::tests::simple_csv_at,
         test_util::{assert_data_table_cell_value, assert_display_cell_value},
         CellValue,
     };
@@ -495,6 +529,14 @@ mod test {
 
     const INVALID_ENCODING_FILE: &[u8] =
         include_bytes!("../../../../quadratic-rust-shared/data/csv/encoding_issue.csv");
+
+    #[test]
+    fn guesses_the_csv_header() {
+        let (gc, sheet_id, pos, _) = simple_csv_at(Pos { x: 1, y: 1 });
+        let sheet = gc.sheet(sheet_id);
+        let values = sheet.data_table(pos).unwrap().value_as_array().unwrap();
+        assert_eq!(gc.guess_csv_first_row_is_header(values), true);
+    }
 
     #[test]
     fn test_get_csv_preview_with_valid_csv() {


### PR DESCRIPTION
## Description
This PR is a simple approach to guessing the header of a CSV file.  

## Justification
We currently assume that the first row is never the header.  This PR simply gets the types of the first 3 rows and only sets the header if the types of the first row is different from the second and the second is the same as the third.  If there less than 3 rows, it assumes that the first row is not the header.

## Demo
![guess-at-first-row](https://github.com/user-attachments/assets/e905f15e-ab2c-4696-bb21-80cdbfdc5092)

