### PR TITLE
improve the starting prompts

### DIFF
--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -6,22 +6,22 @@ import { useEffect, useState } from 'react';
 
 const examples = [
   {
-    title: 'Create a table',
-    description: 'All 50 U.S. states with their population and GDP',
+    title: 'Give me sample data',
+    description: 'Sample data is a great way to get started with Quadratic.',
     icon: <TableIcon className="text-primary" />,
-    prompt: 'Create a table with the 50 U.S. states and their populations and GDP.',
-  },
-  {
-    title: 'Generate code',
-    description: 'The first 100 prime numbers using Python',
-    icon: <CodeIcon className="text-primary" />,
-    prompt: 'Generate Python code that calculates the first 100 prime numbers.',
+    prompt: 'Create sample data in my sheet.',
   },
   {
     title: 'Build a chart',
-    description: 'Plot Apple’s employee count by year',
+    description: 'Charts let you visualize data on your sheet.',
     icon: <InsertChartIcon className="text-primary" />,
-    prompt: 'Find data on Apple’s employee count by year up to 2020, put it in a table, then plot it.',
+    prompt: 'Help me build a chart in Quadratic.',
+  },
+  {
+    title: 'Generate code',
+    description: 'Use code to manipulate data, query APIs, and more.',
+    icon: <CodeIcon className="text-primary" />,
+    prompt: 'Help me use code in Quadratic.',
   },
 ];
 

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -15,7 +15,7 @@ const examples = [
     title: 'Build a chart',
     description: 'Charts let you visualize data on your sheet.',
     icon: <InsertChartIcon className="text-primary" />,
-    prompt: 'Help me build a chart in Quadratic.',
+    prompt: 'Help me build a chart in Quadratic. If there is no data on the sheet add sample data and plot it',
   },
   {
     title: 'Generate code',

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -13,7 +13,7 @@ const examples = [
   },
   {
     title: 'Build a chart',
-    description: 'Charts let you visualize data on your sheet.',
+    description: 'Visualize your data with a chart.',
     icon: <InsertChartIcon className="text-primary" />,
     prompt: 'Help me build a chart in Quadratic. If there is no data on the sheet add sample data and plot it',
   },


### PR DESCRIPTION
Currently it's not clear that these are examples if you only read the headers (not the subheaders). 
![CleanShot 2025-03-13 at 13 19 04@2x](https://github.com/user-attachments/assets/baef78cb-9d74-467d-946e-96ae5473d930)

Changed to prompts that work both if the sheet is empty and if the sheet already has users data. If they click on create a chart it will either add example data if the sheet is blank or it will chart the users data on the sheet.
![CleanShot 2025-03-13 at 13 18 26@2x](https://github.com/user-attachments/assets/f8625170-4ebe-4003-a053-765dcb1a1639)
