### PR TITLE
infra: enable global accelerator for previews

### DIFF
--- a/.github/workflows/preview-build-deploy-images.yml
+++ b/.github/workflows/preview-build-deploy-images.yml
@@ -124,13 +124,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Generate Build Metadata
-        id: build-metadata
-        run: |
-          echo "BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          echo "GIT_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "BRANCH_NAME=$(echo "${{ github.head_ref }}" | tr '/' '-')" >> $GITHUB_OUTPUT
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -186,16 +179,8 @@ jobs:
           file: quadratic-${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ steps.create-ecr.outputs.ECR_URL }}:pr-${{ github.event.pull_request.number }}
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max,compression=zstd,force-compression=true
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
-          build-args: |
-            BUILD_TIME=${{ steps.build-metadata.outputs.BUILD_TIME }}
-            GIT_SHA_SHORT=${{ steps.build-metadata.outputs.GIT_SHA_SHORT }}
-            BRANCH_NAME=${{ steps.build-metadata.outputs.BRANCH_NAME }}
-            PR_NUMBER=${{ github.event.pull_request.number }}
-          labels: |
-            org.opencontainers.image.created=${{ steps.build-metadata.outputs.BUILD_TIME }}
-            org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Find Build & Deploy Images Comment
         if: failure()

--- a/infra/aws-cloudformation/quadratic-preview.yml
+++ b/infra/aws-cloudformation/quadratic-preview.yml
@@ -161,6 +161,45 @@ Resources:
           ./login.sh
           ./pull_start.sh
 
+  # Global Accelerator
+  GlobalAccelerator:
+    Type: AWS::GlobalAccelerator::Accelerator
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      Name: !Sub "${ImageTag}"
+      Enabled: true
+      Tags:
+        - Key: Name
+          Value: !Ref ImageTag
+
+  # Global Accelerator Listener
+  GlobalAcceleratorListener:
+    Type: AWS::GlobalAccelerator::Listener
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AcceleratorArn: !Ref GlobalAccelerator
+      Protocol: TCP
+      PortRanges:
+        - FromPort: 80
+          ToPort: 80
+        - FromPort: 443
+          ToPort: 443
+
+  # Global Accelerator Endpoint Group
+  GlobalAcceleratorEndpointGroup:
+    Type: AWS::GlobalAccelerator::EndpointGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      ListenerArn: !Ref GlobalAcceleratorListener
+      EndpointGroupRegion: !Ref AWS::Region
+      EndpointConfigurations:
+        - EndpointId: !Ref EC2Instance
+          Weight: 100
+          ClientIPPreservationEnabled: true
+
   # DNS record for the main application
   DNSRecord:
     Type: AWS::Route53::RecordSet
@@ -170,9 +209,10 @@ Resources:
       HostedZoneId: Z0126430TJ1UYIMO3SYX
       Name: !Sub "${SubDomainName}.quadratic-preview.com."
       Type: A
-      TTL: 300
-      ResourceRecords:
-        - !GetAtt EC2Instance.PublicIp
+      AliasTarget:
+        DNSName: !GetAtt GlobalAccelerator.DnsName
+        HostedZoneId: Z2BJ6XQ5FK7U4H
+        EvaluateTargetHealth: true
 
   # Wildcard DNS record for all services on subdomains
   WildcardDNSRecord:
@@ -183,9 +223,10 @@ Resources:
       HostedZoneId: Z0126430TJ1UYIMO3SYX
       Name: !Sub "*.${SubDomainName}.quadratic-preview.com."
       Type: A
-      TTL: 300
-      ResourceRecords:
-        - !GetAtt EC2Instance.PublicIp
+      AliasTarget:
+        DNSName: !GetAtt GlobalAccelerator.DnsName
+        HostedZoneId: Z2BJ6XQ5FK7U4H
+        EvaluateTargetHealth: true
 
 Outputs:
   WebsiteURL:


### PR DESCRIPTION
## Relevant issue(s)
none

## Description
 - reverts https://github.com/quadratichq/quadratic/pull/2464 , we have a higher number of global accelerators available, preview should not fail because of global accelerators quota exceeded
 - adds compression to preview images, saving and loading cache should be faster now reducing build time
