### PR TITLE
Nit: Fix Hover Error + Click Cell, Error Disappears

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/hoverCell/HoverCell.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/hoverCell/HoverCell.tsx
@@ -177,11 +177,11 @@ export function HoverCell() {
 
     pixiApp.viewport.on('moved', remove);
     pixiApp.viewport.on('zoomed', remove);
-    events.on('cursorPosition', remove);
+    // events.on('cursorPosition', remove);
     return () => {
       pixiApp.viewport.off('moved', remove);
       pixiApp.viewport.off('zoomed', remove);
-      events.off('cursorPosition', remove);
+      // events.off('cursorPosition', remove);
     };
   }, [hideHoverCell]);
 


### PR DESCRIPTION
When hovering an error, then clicking the cell with the error the error disappears. This fixes that.

New Behavior 
https://github.com/user-attachments/assets/932a9fb2-204c-446e-815c-9b32534e8cfd

Old Behavior
https://github.com/user-attachments/assets/8c565529-5ff8-4460-9d5c-80661e8df474
