### PR TITLE
Cleans up chart icons after thumbnail

### DIFF
--- a/quadratic-client/src/app/gridGL/UI/HtmlPlaceholders.ts
+++ b/quadratic-client/src/app/gridGL/UI/HtmlPlaceholders.ts
@@ -35,6 +35,7 @@ export class HtmlPlaceholders extends Graphics {
   }
 
   prepare() {
+    this.removeChildren();
     this.clear();
     const firstId = sheets.getFirst().id;
     htmlCellsHandler.getCells().forEach((cell) => {


### PR DESCRIPTION
## Relevant issue(s)
#2499 

## Description
Chart icons are no longer kept after rendering

