### PR TITLE
Instruct Python (and JS) to not attempt to import/export files in code

### DIFF
--- a/quadratic-api/src/ai/docs/JavascriptDocs.ts
+++ b/quadratic-api/src/ai/docs/JavascriptDocs.ts
@@ -398,4 +398,9 @@ const output = net.run([1, 0]); // [0.987]
 
 return output[0]
 \`\`\`
+
+# File imports and exports
+JavaScript can not be used to import files like .xlsx or .csv. Users should import those files directly to Quadratic by drag and dropping them directly into the sheet. They can then be read into JavaScript with q.cells(). JavaScript can not be used to import files (.xlsx, .csv, .pqt, etc).
+
+JavaScript can also not be used to export/download data as various file types. To download data from Quadratic highlight the data you'd like to download, right click, and select the "Download as CSV" button.
 `;

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -465,4 +465,9 @@ fig.show()
 # Correlations
 
 Do not attempt to build a correlation analysis unless the user asks for it. 
+
+# File imports and exports
+Python can not be used to import files like .xlsx or .csv. Users should import those files directly to Quadratic by drag and dropping them directly into the sheet. They can then be read into Python with q.cells(). Python can not be used to import files (.xlsx, .csv, .pqt, etc).
+
+Python can also not be used to export/download data as various file types. To download data from Quadratic highlight the data you'd like to download, right click, and select the "Download as CSV" button.
 `;


### PR DESCRIPTION
## Relevant issue(s) & description
Gabe referenced a user in Slack who was annoyed that code tried to export their file for them when asked, but it didn't work. This gives AI clear instructions that they can't import/export files with Python (and JS) in Quadratic with instructions on how this can be performed in Quadratic. 

## Testing considerations 

Please review docs change for correctness. 