### PR TITLE
Viewport Improvements

### DIFF
--- a/quadratic-client/src/app/gridGL/UI/gridHeadings/GridHeadings.ts
+++ b/quadratic-client/src/app/gridGL/UI/gridHeadings/GridHeadings.ts
@@ -70,10 +70,10 @@ export class GridHeadings extends Container {
   }
 
   private findIntervalX(i: number): number {
-    if (i > 100) return 50;
+    if (i > 100) return 52;
     if (i > 20) return 26;
-    if (i > 5) return 10;
-    return 5;
+    if (i > 5) return 13;
+    return 2;
   }
 
   private findIntervalY(i: number): number {
@@ -82,8 +82,9 @@ export class GridHeadings extends Container {
     if (i > 50) return 50;
     if (i > 25) return 25;
     if (i > 10) return 10;
-    if (i > 5) return 5;
-    return 5;
+    if (i > 3) return 5;
+    if (i > 2) return 2;
+    return 1;
   }
 
   // Fills horizontal bar based on selection.
@@ -174,8 +175,14 @@ export class GridHeadings extends Container {
       // show selected numbers
       const selected = Array.isArray(this.selectedColumns) ? this.selectedColumns.includes(column) : false;
 
-      // only show the label if selected or mod calculation
-      if (selected || mod === 0 || column % mod === 0) {
+      // only show the label if selected or mod calculation or first column
+      if (
+        selected ||
+        mod === 0 ||
+        (mod === 2 && column % 2 === 1) ||
+        (mod !== 2 && column % mod === 0) ||
+        column === start.index
+      ) {
         const charactersWidth = (this.characterSize.width * column.toString().length) / scale;
 
         // only show labels that will fit (unless grid lines are hidden)
@@ -342,8 +349,14 @@ export class GridHeadings extends Container {
       // show selected numbers
       const selected = selectedRows.includes(row);
 
-      // only show the label if selected or mod calculation
-      if (selected || mod === 0 || row % mod === 0) {
+      // only show the label if selected or mod calculation or first row
+      if (
+        selected ||
+        mod === 0 ||
+        (mod === 2 && row % 2 === 1) ||
+        (mod !== 2 && row % mod === 0) ||
+        row === start.index
+      ) {
         // only show labels that will fit (unless grid lines are hidden)
         let yPosition = y + currentHeight / 2;
         const top = yPosition - halfCharacterHeight / 2;

--- a/quadratic-client/src/app/gridGL/UI/gridHeadings/GridHeadings.ts
+++ b/quadratic-client/src/app/gridGL/UI/gridHeadings/GridHeadings.ts
@@ -72,7 +72,8 @@ export class GridHeadings extends Container {
   private findIntervalX(i: number): number {
     if (i > 100) return 52;
     if (i > 20) return 26;
-    if (i > 5) return 13;
+    if (i > 10) return 13;
+    if (i > 5) return 6;
     return 2;
   }
 
@@ -187,6 +188,7 @@ export class GridHeadings extends Container {
 
         // only show labels that will fit (unless grid lines are hidden)
         if (
+          scale < 0.2 || // this fixes a bug where multi letter labels were not showing when zoomed out
           currentWidth > charactersWidth ||
           pixiApp.gridLines.alpha < colors.headerSelectedRowColumnBackgroundColorAlpha
         ) {

--- a/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
@@ -16,8 +16,8 @@ const MINIMUM_VIEWPORT_SCALE = 0.01;
 const MAXIMUM_VIEWPORT_SCALE = 10;
 const WHEEL_ZOOM_PERCENT = 1.5;
 
-const WAIT_TO_SNAP_TIME = 200;
-const SNAPPING_TIME = 150;
+const WAIT_TO_SNAP_TIME = 50;
+const SNAPPING_TIME = 50;
 
 type SnapState = 'waiting' | 'snapping' | undefined;
 
@@ -257,7 +257,9 @@ export class Viewport extends PixiViewport {
         const headings = this.pixiApp.headings.headingSize;
         if (this.x > headings.width || this.y > headings.height) {
           if (this.pixiApp.momentumDetector.hasMomentumScroll()) {
-            this.startSnap();
+            if (!this.plugins.get('drag')?.active) {
+              this.startSnap();
+            }
           } else {
             this.snapTimeout = Date.now();
             this.snapState = 'waiting';
@@ -265,7 +267,9 @@ export class Viewport extends PixiViewport {
         }
       } else if (this.snapState === 'waiting' && this.snapTimeout) {
         if (Date.now() - this.snapTimeout > WAIT_TO_SNAP_TIME) {
-          this.startSnap();
+          if (!this.plugins.get('drag')?.active) {
+            this.startSnap();
+          }
         }
       }
     }

--- a/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
@@ -16,7 +16,7 @@ const MINIMUM_VIEWPORT_SCALE = 0.01;
 const MAXIMUM_VIEWPORT_SCALE = 10;
 const WHEEL_ZOOM_PERCENT = 1.5;
 
-const WAIT_TO_SNAP_TIME = 50;
+const WAIT_TO_SNAP_TIME = 200;
 const SNAPPING_TIME = 50;
 
 type SnapState = 'waiting' | 'snapping' | undefined;
@@ -258,6 +258,7 @@ export class Viewport extends PixiViewport {
         if (this.x > headings.width || this.y > headings.height) {
           if (this.pixiApp.momentumDetector.hasMomentumScroll()) {
             if (!this.plugins.get('drag')?.active) {
+              console.log('startSnap A');
               this.startSnap();
             }
           } else {
@@ -267,7 +268,11 @@ export class Viewport extends PixiViewport {
         }
       } else if (this.snapState === 'waiting' && this.snapTimeout) {
         if (Date.now() - this.snapTimeout > WAIT_TO_SNAP_TIME) {
-          if (!this.plugins.get('drag')?.active) {
+          // Check for trackpad pinch using pointer type
+          const isPinching = window.TouchEvent && navigator.maxTouchPoints > 0 && (window as any).touches?.length > 1;
+          console.log('touches', (window as any).touches?.length);
+          if (!this.plugins.get('drag')?.active && !isPinching) {
+            console.log('startSnap B');
             this.startSnap();
           }
         }
@@ -318,6 +323,7 @@ export class Viewport extends PixiViewport {
 
   private handleZoomEnd = () => {
     this.waitForZoomEnd = false;
+    console.log('handleZoomEnd');
     this.startSnap();
   };
 

--- a/quadratic-client/src/app/gridGL/pixiApp/viewport/Wheel.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/viewport/Wheel.ts
@@ -10,7 +10,7 @@ import { Plugin } from 'pixi-viewport';
 
 export const SCALE_OUT_OF_BOUNDS_SCROLL = 0.1;
 
-const MAX_RUBBER_BAND_GAP = 50;
+const MAX_RUBBER_BAND_GAP = 0;
 const RUBBER_BAND_DECELERATION_POWER = 5;
 
 /** Options for {@link Wheel}. */


### PR DESCRIPTION
This does a few things to the Viewport:
- While dragging prevent snap back until dragging is released (when pressing space to drag and beyond the bounds.)
- Don't allow momentum scrolling past the bounds, this was a bit glitchy looking. You can still zoom beyond the bounds, and drag past the bounds.
- Reduce the time after zooming to snap back.

This also makes some changes to the GridHeadings:
- always shows A and 1 heading labels
- on the numbered axis adds a step to count by 2s showing 1, 3, 5, etc
- on the vertical axis, make the counting by numbers that fit into the alphabet 
- fixes a bug where if you zoom out past 13% all the letter labels start to disappear