### PR TITLE
fix: use presigned urls for file-storage

### DIFF
--- a/quadratic-api/src/storage/storage.ts
+++ b/quadratic-api/src/storage/storage.ts
@@ -1,6 +1,6 @@
 import type multer from 'multer';
 import { STORAGE_TYPE } from '../env-vars';
-import { getPresignedStorageUrl, getStorageUrl, multerFileSystemStorage, upload } from './fileSystem';
+import { getPresignedStorageUrl, multerFileSystemStorage, upload } from './fileSystem';
 import { generatePresignedUrl, multerS3Storage, S3Bucket, uploadStringAsFileS3 } from './s3';
 
 export type UploadFileResponse = {
@@ -14,7 +14,7 @@ export const getFileUrl = async (key: string) => {
     case 's3':
       return await generatePresignedUrl(key, S3Bucket.FILES);
     case 'file-system':
-      return getStorageUrl(key);
+      return getPresignedStorageUrl(key);
     default:
       throw new Error(`Unsupported storage type in getFileUrl(): ${STORAGE_TYPE}`);
   }

--- a/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
+++ b/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
@@ -69,26 +69,15 @@ import { Rectangle } from 'pixi.js';
 class Core {
   gridController?: GridController;
 
-  private async loadGridFile(file: string, addToken: boolean): Promise<Uint8Array> {
-    let requestInit = {};
-
-    if (addToken) {
-      const jwt = await coreClient.getJwt();
-      requestInit = { headers: { Authorization: `Bearer ${jwt}` } };
-    }
-
-    const res = await fetch(file, requestInit);
+  private async loadGridFile(file: string): Promise<Uint8Array> {
+    const res = await fetch(file);
     return new Uint8Array(await res.arrayBuffer());
   }
 
   // Creates a Grid from a file. Initializes bother coreClient and coreRender w/metadata.
-  async loadFile(
-    message: ClientCoreLoad,
-    renderPort: MessagePort,
-    addToken: boolean
-  ): Promise<{ version: string } | { error: string }> {
+  async loadFile(message: ClientCoreLoad, renderPort: MessagePort): Promise<{ version: string } | { error: string }> {
     coreRender.init(renderPort);
-    const results = await Promise.all([this.loadGridFile(message.url, addToken), initCore()]);
+    const results = await Promise.all([this.loadGridFile(message.url), initCore()]);
     try {
       this.gridController = GridController.newFromFile(results[0], message.sequenceNumber, true);
     } catch (e) {

--- a/quadratic-client/src/app/web-workers/quadraticCore/worker/coreClient.ts
+++ b/quadratic-client/src/app/web-workers/quadraticCore/worker/coreClient.ts
@@ -147,12 +147,10 @@ class CoreClient {
       case 'clientCoreLoad':
         await offline.init(e.data.fileId);
 
-        const addToken = this.env.VITE_STORAGE_TYPE === 'file-system';
-
         this.send({
           type: 'coreClientLoad',
           id: e.data.id,
-          ...(await core.loadFile(e.data, e.ports[0], addToken)),
+          ...(await core.loadFile(e.data, e.ports[0])),
         });
         return;
 


### PR DESCRIPTION
## Description
File storage now uses presigned urls same as s3, so same file permissions flow works now for shared files on self-hosted app
