### PR TITLE
feat: add shortcut route to active team

### DIFF
--- a/quadratic-client/src/router.tsx
+++ b/quadratic-client/src/router.tsx
@@ -1,5 +1,6 @@
 import { protectedRouteLoaderWrapper } from '@/auth/auth';
 import { BrowserCompatibilityLayoutRoute } from '@/dashboard/components/BrowserCompatibilityLayoutRoute';
+import getActiveTeam from '@/dashboard/shared/getActiveTeam';
 import * as Page404 from '@/routes/404';
 import * as RootRoute from '@/routes/_root';
 import * as Login from '@/routes/login';
@@ -84,6 +85,16 @@ export const router = createBrowserRouter(
               shouldRevalidate={dontRevalidateDialogs}
             />
             <Route path={ROUTES.LABS} lazy={() => import('./routes/labs')} />
+
+            {/* Shortcut route to get to get to a route for whatever the 'active' team is */}
+            <Route
+              path="team/*"
+              loader={async ({ params }) => {
+                const { teams } = await apiClient.teams.list();
+                const { teamUuid } = await getActiveTeam(teams, undefined);
+                return redirect(ROUTES.TEAM(teamUuid) + '/' + params['*']);
+              }}
+            />
 
             <Route path="teams">
               <Route path="create" lazy={() => import('./routes/teams.create')} />


### PR DESCRIPTION
## Description

This allows you to navigate to a route on the dashboard without knowing exactly what your team is.

For example: want to link someone to the Billing page but you don't know what their team is?

In the dashboard, Billing is in Settings, which is accessible at:

`/teams/:uuid/settings`

But if you don't know what somebody's team is, you can send them a link to:

`/team/settings`

And the app will automatically figure out what the active team is for the user accessing it, then route them to that page.

**Note:** this uses a splat route, so if you send someone to a route that doesn't exist, e.g. `/team/foo`, then they'll end up with a 404 because it will route them to `/teams/:uuid/foo`.

## To Test

- `/team/settings` routes you the Settings page on the dashboard for your active team
- `/team/connections` routes you the Settings page on the dashboard for your active team
- `/team/members` routes you the Settings page on the dashboard for your active team