### PR TITLE
Add Insert->Table to the toolbar menu, disable for single cells

### DIFF
--- a/quadratic-client/src/app/actions/actions.ts
+++ b/quadratic-client/src/app/actions/actions.ts
@@ -12,6 +12,7 @@ export enum Action {
   InsertChartJavascript = 'insert_chart_javascript',
   InsertApiRequestJavascript = 'insert_api_request_javascript',
   InsertApiRequestPython = 'insert_api_request_python',
+  InsertDataTable = 'insert_data_table',
   InsertCheckbox = 'insert_checkbox',
   InsertDropdown = 'insert_dropdown',
   ToggleDataValidation = 'toggle_data_validation',

--- a/quadratic-client/src/app/actions/actionsSpec.ts
+++ b/quadratic-client/src/app/actions/actionsSpec.ts
@@ -52,7 +52,7 @@ export type ActionSpec<ActionArgsType> = {
   isAvailable?: (args: ActionAvailabilityArgs) => boolean;
 
   // function to disable the action
-  isDisabled?: (args: ActionAvailabilityArgs) => boolean;
+  isDisabled?: () => boolean;
 
   // Used for command palette search
   keywords?: string[];

--- a/quadratic-client/src/app/actions/actionsSpec.ts
+++ b/quadratic-client/src/app/actions/actionsSpec.ts
@@ -51,6 +51,9 @@ export type ActionSpec<ActionArgsType> = {
   // function to show/hide the action
   isAvailable?: (args: ActionAvailabilityArgs) => boolean;
 
+  // function to disable the action
+  isDisabled?: (args: ActionAvailabilityArgs) => boolean;
+
   // Used for command palette search
   keywords?: string[];
 };

--- a/quadratic-client/src/app/actions/dataTableSpec.ts
+++ b/quadratic-client/src/app/actions/dataTableSpec.ts
@@ -175,7 +175,7 @@ const isCodeCell = (language: CodeCellLanguage) => {
   return table?.language === language;
 };
 
-const isSingleCell = () => {
+export const isSingleCell = () => {
   const table = getTable();
 
   if (!table) return false;

--- a/quadratic-client/src/app/actions/insertActionsSpec.ts
+++ b/quadratic-client/src/app/actions/insertActionsSpec.ts
@@ -1,5 +1,6 @@
 import { Action } from '@/app/actions/actions';
 import type { ActionSpecRecord } from '@/app/actions/actionsSpec';
+import { gridToDataTable } from '@/app/actions/dataTableSpec';
 import { sheets } from '@/app/grid/controller/Sheets';
 import { FILE_INPUT_ID } from '@/app/gridGL/HTMLGrid/GridFileInput';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
@@ -13,6 +14,7 @@ import {
   DataValidationsIcon,
   FormatDateTimeIcon,
   SheetIcon,
+  TableConvertIcon,
 } from '@/shared/components/Icons';
 
 type InsertActionSpec = Pick<
@@ -24,6 +26,7 @@ type InsertActionSpec = Pick<
   | Action.InsertChartJavascript
   | Action.InsertApiRequestJavascript
   | Action.InsertApiRequestPython
+  | Action.InsertDataTable
   | Action.InsertSheet
   | Action.InsertCheckbox
   | Action.InsertDropdown
@@ -254,6 +257,15 @@ export const insertActionsSpec: InsertActionSpec = {
           initialCode: SNIPPET_PY_API,
         },
       }));
+    },
+  },
+  [Action.InsertDataTable]: {
+    label: 'Table',
+    labelVerbose: 'Insert a table',
+    Icon: TableConvertIcon,
+    isDisabled: () => sheets.sheet.cursor.isSingleSelection(),
+    run: () => {
+      gridToDataTable();
     },
   },
   [Action.InsertSheet]: {

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/InsertMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/InsertMenubarMenu.tsx
@@ -55,6 +55,7 @@ export const InsertMenubarMenu = () => {
             <MenubarSeparator />
             <MenubarItem onClick={() => setShowCellTypeMenu(true)}>From connection…</MenubarItem>
           </MenubarSubContent>
+          <MenubarItemAction action={Action.InsertDataTable} actionArgs={undefined} />
         </MenubarSub>
 
         <MenubarSeparator />

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
@@ -24,6 +24,7 @@ export const MenubarItemAction = <T extends Action>({
   const Icon = 'Icon' in actionSpec ? actionSpec.Icon : undefined;
   const keyboardShortcut = shortcutOverride ? shortcutOverride : keyboardShortcutEnumToDisplay(action);
   const isAvailable = 'isAvailable' in actionSpec ? actionSpec.isAvailable : undefined;
+  const isDisabled = 'isDisabled' in actionSpec ? actionSpec.isDisabled : undefined;
 
   if (isAvailable && !isAvailable(isAvailableArgs)) {
     return null;
@@ -31,6 +32,7 @@ export const MenubarItemAction = <T extends Action>({
 
   return (
     <MenubarItem
+      disabled={isDisabled ? isDisabled(isAvailableArgs) : false}
       onClick={() => {
         mixpanel.track('[FileMenu].selected', { label });
         if (disableFocusGridRef) {

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
@@ -32,7 +32,7 @@ export const MenubarItemAction = <T extends Action>({
 
   return (
     <MenubarItem
-      disabled={isDisabled ? isDisabled(isAvailableArgs) : false}
+      disabled={isDisabled ? isDisabled() : false}
       onClick={() => {
         mixpanel.track('[FileMenu].selected', { label });
         if (disableFocusGridRef) {


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/quadratichq/quadratic/issues/2323

## Description
Adds `Insert -> Table` to the toolbar menu.
`Table` is disabled when a single cell is selected.

## Demo
![insert-data-table-from-menu](https://github.com/user-attachments/assets/6978cc0e-fb05-4bf0-aa4b-43d053279f05)
