### PR TITLE
Fixes firefox pointer issue

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -76,7 +76,8 @@ export class Pointer {
 
   // check if more than one touch point (let the viewport handle the event)
   private isMoreThanOneTouch(e: FederatedPointerEvent): boolean {
-    return e.nativeEvent instanceof TouchEvent && e.nativeEvent.touches.length > 1;
+    const nativeEvent = e.nativeEvent as any;
+    return nativeEvent?.touches?.length > 1;
   }
 
   // todo: this should be removed when the code editor's layout is changed
@@ -90,6 +91,7 @@ export class Pointer {
   }
 
   private handlePointerDown = (e: FederatedPointerEvent): void => {
+    console.log(1);
     if (this.isMoreThanOneTouch(e)) return;
     const world = pixiApp.viewport.toWorld(e.global);
 

--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -76,8 +76,7 @@ export class Pointer {
 
   // check if more than one touch point (let the viewport handle the event)
   private isMoreThanOneTouch(e: FederatedPointerEvent): boolean {
-    const nativeEvent = e.nativeEvent as any;
-    return nativeEvent?.touches?.length > 1;
+    return (nativeEvent?.touches?.length ?? 0) > 1;
   }
 
   // todo: this should be removed when the code editor's layout is changed

--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -90,7 +90,6 @@ export class Pointer {
   }
 
   private handlePointerDown = (e: FederatedPointerEvent): void => {
-    console.log(1);
     if (this.isMoreThanOneTouch(e)) return;
     const world = pixiApp.viewport.toWorld(e.global);
 

--- a/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/Pointer.ts
@@ -76,7 +76,7 @@ export class Pointer {
 
   // check if more than one touch point (let the viewport handle the event)
   private isMoreThanOneTouch(e: FederatedPointerEvent): boolean {
-    return (nativeEvent?.touches?.length ?? 0) > 1;
+    return ((e.nativeEvent as any)?.touches?.length ?? 0) > 1;
   }
 
   // todo: this should be removed when the code editor's layout is changed


### PR DESCRIPTION
## Relevant issue(s)
Firefox did not allow clicking on the sheet.

## Explanation
`TouchEvent` doesn't exist in Firefox, so you can't use `instanceof` w/o throwing an error.