### PR TITLE
Check for out of bounds on the display buffer when inserting a row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-connection"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "arrow 51.0.0",
  "arrow-schema 51.0.0",
@@ -4793,7 +4793,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-core"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "arrow-array 54.2.1",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-files"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "axum 0.8.1",
  "axum-extra 0.10.0",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-multiplayer"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "axum 0.8.1",
  "axum-extra 0.10.0",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-rust-client"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-rust-shared"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "aes",
  "arrow 54.2.1",

--- a/quadratic-core/src/grid/data_table/row.rs
+++ b/quadratic-core/src/grid/data_table/row.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 use super::DataTable;
 use crate::{CellValue, CopyFormats};
@@ -42,14 +42,23 @@ impl DataTable {
         self.borders.insert_row(row_index + 1, CopyFormats::None);
 
         let row_index = u64::try_from(row_index)?;
+
         // add the row to the display buffer
         if let Some(display_buffer) = &mut self.display_buffer {
+            let len = display_buffer.len();
+            let index = usize::try_from(row_index)?;
+
+            if index >= len {
+                bail!("Row index {index} is out of bounds. Display buffer length: {len}");
+            }
+
             for y in display_buffer.iter_mut() {
                 if *y >= row_index {
                     *y += 1;
                 }
             }
-            display_buffer.insert(usize::try_from(row_index)?, row_index);
+
+            display_buffer.insert(index, row_index);
         }
 
         Ok(())
@@ -106,7 +115,10 @@ impl DataTable {
 pub mod test {
     use crate::{
         ArraySize, CellValue,
-        grid::test::{new_data_table, pretty_print_data_table},
+        grid::{
+            sort::SortDirection,
+            test::{new_data_table, pretty_print_data_table},
+        },
     };
 
     #[test]
@@ -122,6 +134,12 @@ pub mod test {
         // this should be a 5x4 array
         let expected_size = ArraySize::new(4, 6).unwrap();
         assert_eq!(data_table.output_size(), expected_size);
+
+        // expect index out of bounds error
+        // first sort the table to create the display buffer
+        data_table.sort_column(0, SortDirection::Ascending).unwrap();
+        let expected_error = data_table.insert_row(10, None);
+        assert!(expected_error.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Resolves this error in data dog: 

> Time | Host
> T-----------------------------
> T17:39:52 UTC | i-0e01831a0b83cbb77
> Tnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
> T-----------------------------
> T17:39:52 UTC | i-0e01831a0b83cbb77
> Tinsertion index (is 42) should be <= len (is 41)
> T-----------------------------
> T17:39:52 UTC | i-0e01831a0b83cbb77
> Tthread 'tokio-runtime-worker' panicked at /quadratic/quadratic-core/src/grid/data_table/row.rs:52:28:

Also adds a test to validate and avoid regressions.