### PR TITLE
bugfix: clear GridFileInput value after import

### DIFF
--- a/quadratic-client/src/app/actions/insertActionsSpec.ts
+++ b/quadratic-client/src/app/actions/insertActionsSpec.ts
@@ -198,6 +198,10 @@ export const insertActionsSpec: InsertActionSpec = {
       const el = document.getElementById(FILE_INPUT_ID) as HTMLInputElement;
       if (el) {
         el.click();
+
+        // clear the file input to trigger the onChange event for subsequent
+        // file imports
+        el.value = '';
       }
     },
   },


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/quadratichq/quadratic/issues/2459

## Description
This is happening with any supported file when the next import has the same name. It's due to the onChange event not firing in these cases.

## Demo
![import-csv-same-name](https://github.com/user-attachments/assets/659cbd30-fe06-45a4-8065-c01fccdc4533)
