### PR TITLE
#DATA for reference is popping up in Python 

### DIFF
--- a/quadratic-client/src/app/ai/hooks/useCurrentSheetContextMessages.tsx
+++ b/quadratic-client/src/app/ai/hooks/useCurrentSheetContextMessages.tsx
@@ -111,9 +111,9 @@ Note: All this data is only for your reference to data on the sheet. This data c
 - In formula, cell reference are done using A1 notation directly, without quotes. Example: \`=SUM(A1:B2)\`. Always use sheet name in a1 notation to reference cells from different sheets. Sheet name is always enclosed in single quotes. Example: \`=SUM('Sheet 1'!A1:B2)\`.\n
 - In Python and Javascript use the cell reference function \`q.cells\`, i.e. \`q.cells(a1_notation_selection_string)\`, to reference data cells. Always use sheet name in a1 notation to reference cells from different sheets. Sheet name is always enclosed in single quotes. In Python and Javascript, the complete a1 notation selection string is enclosed in double quotes. Example: \`q.cells("'Sheet 1'!A1:B2")\`.\n
 - Tables can be referenced using \`q.cells("Table_Name")\` to reference the entire table.\n
-- Use \`q.cells("Table_Name[#ALL]")\` to reference the entire table including the header.\n
-- Use \`q.cells("Table_Name[#HEADERS]")\` to reference the header of the table.\n
-- Use \`q.cells("Table_Name[#DATA]")\` to reference the data of the table.\n
+- In Formulas and JavaScript use \`q.cells("Table_Name[#ALL]")\` to reference the entire table including the header. This does not work in Python.\n
+- In all languages use \`q.cells("Table_Name[#HEADERS]")\` to reference the headers of the table.\n
+- In Formulas and JavaScript use \`q.cells("Table_Name[#DATA]")\` to reference the data of the table. This does not work in Python.\n
 - Sheet name is optional, if not provided, it is assumed to be the currently open sheet.\n
 - Sheet name is case sensitive, and is required to be enclosed in single quotes.\n
 - To reference data from different tabular data rectangles, use multiple \`q.cells\` functions.\n


### PR DESCRIPTION
## Description

There are a few places in the docs where #DATA aren't explicitly explaining they're for Formulas and JavaScript. As a result a lot of Python requests are popping up that erroneously use this reference. 