### PR TITLE
Code peek should not appear on data table

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/pointerCursor.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/pointerCursor.ts
@@ -23,7 +23,7 @@ export class PointerCursor {
 
     let foundCodeCell = false;
     const codeCell = pixiApp.cellsSheets.current.tables.intersectsCodeInfo(world);
-    if (codeCell) {
+    if (codeCell && codeCell.language !== 'Import') {
       if (this.lastInfo?.x !== codeCell.x || this.lastInfo?.y !== codeCell.y) {
         events.emit('hoverCell', codeCell);
         this.lastInfo = codeCell;


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2590 

## Description
Code peek (when turned on) should not show when hovering data tables
