### PR TITLE
Ensure shift+enter in the inline editor doesn't add a linebreak

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorKeyboard.ts
@@ -183,6 +183,7 @@ class InlineEditorKeyboard {
     // Shift+Enter key
     else if (matchShortcut(Action.SaveInlineEditorMoveUp, e)) {
       e.stopPropagation();
+      e.preventDefault();
       if (!(await this.handleValidationError())) {
         inlineEditorHandler.close(0, -1, false);
       }


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2258 

## Description
In prod, if you press shift+enter when editing a cell when the cursor is in the middle of the text, then a line break is added at that point. This PR removes that behavior.