### PR TITLE
Keep AI from using try-except blocks

### DIFF
--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -247,6 +247,8 @@ y
 
 Do NOT try to use try-except blocks. It is much more useful to simply return the output to the sheet and let the error surface in the sheet and the console. 
 
+If you create an error and need to see the data, a print statement (e.g. print(df.head(3)) of the data can allow you to see the data to continue with a more useful result. 
+
 # Packages
 
 Using and installing Python packages.

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -245,6 +245,8 @@ else:
 y
 \'\'\'
 
+Do NOT try to use try catch blocks unless the user asks for them. It is much more useful to simply return the output to the sheet and let the error surface in the console. 
+
 # Packages
 
 Using and installing Python packages.

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -245,7 +245,7 @@ else:
 y
 \'\'\'
 
-Do NOT try to use try catch blocks unless the user asks for them. It is much more useful to simply return the output to the sheet and let the error surface in the console. 
+Do NOT try to use try-except blocks. It is much more useful to simply return the output to the sheet and let the error surface in the sheet and the console. 
 
 # Packages
 


### PR DESCRIPTION
## Description

Seeing lots of try-except usage from Analyst (especially in Thinking mode). These are not useful and make AI provide confusing results. 

AI should attempt things and if they fail they need to surface as errors in the sheet so AI knows to fix. If it's stuck in a try-except the error doesn't get surfaced and the AI doesn't know it needs to automatically perform a fix. 