### PR TITLE
feat: make theme switcher accessible in dashboard sidebar

### DIFF
--- a/quadratic-client/src/app/ui/QuadraticSidebar.tsx
+++ b/quadratic-client/src/app/ui/QuadraticSidebar.tsx
@@ -48,7 +48,7 @@ export const QuadraticSidebar = () => {
           <Link
             to="/"
             reloadDocument
-            className="group relative flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:bg-border"
+            className="group relative flex h-9 w-9 items-center justify-center rounded text-muted-foreground hover:bg-border"
           >
             <QuadraticLogo />
             {isRunningAsyncAction && (
@@ -115,7 +115,7 @@ export const SidebarToggle = React.forwardRef<HTMLButtonElement, React.Component
         {...props}
         ref={ref}
         className={cn(
-          'relative h-8 w-8 rounded text-muted-foreground hover:bg-border hover:text-foreground aria-pressed:bg-border data-[state=open]:bg-border',
+          'relative h-9 w-9 rounded text-muted-foreground hover:bg-border hover:text-foreground aria-pressed:bg-border data-[state=open]:bg-border',
           props.className
         )}
       >

--- a/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
+++ b/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
@@ -1,3 +1,4 @@
+import { ThemePickerMenu } from '@/app/ui/components/ThemePickerMenu';
 import { TeamSwitcher } from '@/dashboard/components/TeamSwitcher';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
 import { useRootRouteLoaderData } from '@/routes/_root';
@@ -15,6 +16,7 @@ import {
   FileSharedWithMeIcon,
   GroupIcon,
   LabsIcon,
+  LogoutIcon,
   SettingsIcon,
 } from '@/shared/components/Icons';
 import { Type } from '@/shared/components/Type';
@@ -23,6 +25,13 @@ import { ROUTES, SEARCH_PARAMS } from '@/shared/constants/routes';
 import { CONTACT_URL, DOCUMENTATION_URL } from '@/shared/constants/urls';
 import { Badge } from '@/shared/shadcn/ui/badge';
 import { Button } from '@/shared/shadcn/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/shared/shadcn/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
 import { RocketIcon } from '@radix-ui/react-icons';
@@ -39,6 +48,7 @@ const SHOW_EXAMPLES = import.meta.env.VITE_STORAGE_TYPE !== 'file-system';
 export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
   const [, setSearchParams] = useSearchParams();
   const { loggedInUser: user } = useRootRouteLoaderData();
+  const submit = useSubmit();
   const {
     userMakingRequest: { id: ownerUserId },
     eduStatus,
@@ -192,16 +202,37 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
             Labs
           </SidebarNavLink>
         )}
-        <SidebarNavLink to="/account">
-          <Avatar src={user?.picture} alt={user?.name}>
-            {user?.name}
-          </Avatar>
-
-          <div className={`flex flex-col overflow-hidden text-left`}>
-            {user?.name || 'You'}
-            {user?.email && <p className={`truncate ${TYPE.caption} text-muted-foreground`}>{user?.email}</p>}
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger className="relative flex min-w-0 flex-grow items-center gap-2 rounded bg-accent p-2 no-underline hover:brightness-95 hover:saturate-150 dark:hover:brightness-125 dark:hover:saturate-100">
+              <Avatar src={user?.picture} alt={user?.name} size="xs">
+                {user?.name}
+              </Avatar>
+              <p className={`truncate text-xs`}>{user?.email}</p>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-60" side="top" align="start">
+              <DropdownMenuItem disabled className="flex-col items-start">
+                {user?.name || 'You'}
+                <span className="text-xs">{user?.email}</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  submit(null, {
+                    method: 'post',
+                    action: ROUTES.LOGOUT,
+                  });
+                }}
+              >
+                <LogoutIcon className="mr-2 text-muted-foreground" /> Logout
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <div className="flex flex-shrink-0 items-center">
+            <ThemePickerMenu />
           </div>
-        </SidebarNavLink>
+        </div>
       </div>
     </nav>
   );

--- a/quadratic-client/src/router.tsx
+++ b/quadratic-client/src/router.tsx
@@ -80,11 +80,6 @@ export const router = createBrowserRouter(
               lazy={() => import('./routes/examples')}
               shouldRevalidate={dontRevalidateDialogs}
             />
-            <Route
-              path={ROUTES.ACCOUNT}
-              lazy={() => import('./routes/account')}
-              shouldRevalidate={dontRevalidateDialogs}
-            />
             <Route path={ROUTES.LABS} lazy={() => import('./routes/labs')} />
 
             {/* Shortcut route to get to a route for whatever the 'active' team is */}

--- a/quadratic-client/src/shared/components/Avatar.tsx
+++ b/quadratic-client/src/shared/components/Avatar.tsx
@@ -4,7 +4,7 @@ import type { ImgHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 
 interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
-  size?: 'small' | 'medium' | 'large';
+  size?: 'xs' | 'small' | 'medium' | 'large';
   children?: string | React.ReactNode;
 }
 
@@ -13,9 +13,36 @@ export const Avatar = forwardRef<HTMLImageElement, AvatarProps>(
     const [error, setError] = React.useState(false);
 
     const stylePreset = {
-      width: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
-      height: size === 'small' ? '24px' : size === 'medium' ? '32px' : size === 'large' ? '40px' : '24px',
-      fontSize: size === 'small' ? '0.75rem' : size === 'medium' ? '1rem' : size === 'large' ? '1.125rem' : '0.8125rem',
+      width:
+        size === 'xs'
+          ? '20px'
+          : size === 'small'
+          ? '24px'
+          : size === 'medium'
+          ? '32px'
+          : size === 'large'
+          ? '40px'
+          : '24px',
+      height:
+        size === 'xs'
+          ? '20px'
+          : size === 'small'
+          ? '24px'
+          : size === 'medium'
+          ? '32px'
+          : size === 'large'
+          ? '40px'
+          : '24px',
+      fontSize:
+        size === 'xs'
+          ? '0.625rem'
+          : size === 'small'
+          ? '0.75rem'
+          : size === 'medium'
+          ? '1rem'
+          : size === 'large'
+          ? '1.125rem'
+          : '0.8125rem',
       borderRadius: '50%',
       display: 'flex',
       alignItems: 'center',

--- a/quadratic-client/src/shared/constants/routes.ts
+++ b/quadratic-client/src/shared/constants/routes.ts
@@ -49,7 +49,6 @@ export const ROUTES = {
   TEAM_SETTINGS: (teamUuid: string) => `/teams/${teamUuid}/settings`,
   EDIT_TEAM: (teamUuid: string) => `/teams/${teamUuid}/edit`,
   EXAMPLES: '/examples',
-  ACCOUNT: '/account',
   LABS: '/labs',
 
   API: {


### PR DESCRIPTION
## Description

Clones the theme picker from the app (on the bottom left) into the sidebar of the dashboard (on the bottom left) so it's universally accessible via a single click.

- The `/account` page was removed, and now clicking the user avatar shows a popup with the info that was previously on the `/account` page
- Theme picker is a flyout, same as in the app

https://github.com/user-attachments/assets/bfa7773c-3284-4dfa-b408-1802170cac0d

