### PR TITLE
add an ab test on ai exceeded copy

### DIFF
--- a/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
+++ b/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
@@ -1,3 +1,4 @@
+import { ABTest } from '@/shared/components/ABTest';
 import { memo } from 'react';
 
 type AIUsageExceededProps = {
@@ -11,18 +12,39 @@ export const AIUsageExceeded = memo(({ show, delaySeconds }: AIUsageExceededProp
   }
 
   return (
-    <div className="mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50">
-      AI free tier exceeded. Wait {delaySeconds} seconds or{' '}
-      <a
-        href="/team/settings"
-        target="_blank"
-        rel="noreferrer"
-        className="font-semibold text-primary hover:underline"
-        onClick={(e) => e.stopPropagation()}
-      >
-        upgrade to Quadratic Pro
-      </a>
-      .
-    </div>
+    <ABTest
+      name="ai-usage-exceeded"
+      probability={0.5}
+      control={
+        <div className="mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50">
+          AI free tier exceeded. Wait {delaySeconds} seconds or{' '}
+          <a
+            href="/team/settings"
+            target="_blank"
+            rel="noreferrer"
+            className="font-semibold text-primary hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            upgrade to Quadratic Pro
+          </a>
+          .
+        </div>
+      }
+      variant={
+        <div className="mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50">
+          Message slowed. Wait {delaySeconds} seconds or{' '}
+          <a
+            href="/team/settings"
+            target="_blank"
+            rel="noreferrer"
+            className="font-semibold text-primary hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            upgrade to Quadratic Pro
+          </a>{' '}
+          for more fast requests.
+        </div>
+      }
+    />
   );
 });

--- a/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
+++ b/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
@@ -6,6 +6,10 @@ type AIUsageExceededProps = {
   delaySeconds?: number;
 };
 
+const divClassName =
+  'mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50';
+const linkClassName = 'font-semibold text-primary hover:underline';
+
 export const AIUsageExceeded = memo(({ show, delaySeconds }: AIUsageExceededProps) => {
   if (!show || !delaySeconds) {
     return null;
@@ -16,13 +20,13 @@ export const AIUsageExceeded = memo(({ show, delaySeconds }: AIUsageExceededProp
       name="ai-usage-exceeded"
       probability={0.5}
       control={
-        <div className="mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50">
+        <div className={divClassName}>
           AI free tier exceeded. Wait {delaySeconds} seconds or{' '}
           <a
             href="/team/settings"
             target="_blank"
             rel="noreferrer"
-            className="font-semibold text-primary hover:underline"
+            className={linkClassName}
             onClick={(e) => e.stopPropagation()}
           >
             upgrade to Quadratic Pro
@@ -31,13 +35,13 @@ export const AIUsageExceeded = memo(({ show, delaySeconds }: AIUsageExceededProp
         </div>
       }
       variant={
-        <div className="mx-2 my-2 rounded-md border border-yellow-200 bg-yellow-50 px-2 py-1.5 text-xs font-medium dark:border-yellow-800 dark:bg-yellow-950/50">
+        <div className={divClassName}>
           Message slowed. Wait {delaySeconds} seconds or{' '}
           <a
             href="/team/settings"
             target="_blank"
             rel="noreferrer"
-            className="font-semibold text-primary hover:underline"
+            className={linkClassName}
             onClick={(e) => e.stopPropagation()}
           >
             upgrade to Quadratic Pro

--- a/quadratic-client/src/shared/components/ABTest.tsx
+++ b/quadratic-client/src/shared/components/ABTest.tsx
@@ -1,6 +1,7 @@
-import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
+import { editorInteractionStateTeamUuidAtom } from '@/app/atoms/editorInteractionStateAtom';
 import mixpanel from 'mixpanel-browser';
 import { memo } from 'react';
+import { useRecoilValue } from 'recoil';
 
 type ABTestProps = {
   name: string;
@@ -10,13 +11,13 @@ type ABTestProps = {
 };
 
 export const ABTest = memo(({ name, control, variant, probability = 0.1 }: ABTestProps) => {
-  const { team } = useFileRouteLoaderData();
+  const teamUuid = useRecoilValue(editorInteractionStateTeamUuidAtom);
 
   // Convert the team's UUID to a number between 0 and 1
   // This is a simple hash function that will return a number between 0 and 1
   // This will allow us to split the users into two groups, control and variant
-  // consistently puting the same user in the same group by using the same UUID
-  const hash = parseInt(team.uuid.replace(/-/g, '').slice(0, 8), 16) / 0xffffffff;
+  // consistently putting the same user in the same group by using the same UUID
+  const hash = parseInt(teamUuid.replace(/-/g, '').slice(0, 8), 16) / 0xffffffff;
 
   // Send to mixpanel
   mixpanel.track('[ABTest].started', {

--- a/quadratic-client/src/shared/components/ABTest.tsx
+++ b/quadratic-client/src/shared/components/ABTest.tsx
@@ -1,0 +1,30 @@
+import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
+import mixpanel from 'mixpanel-browser';
+import { memo } from 'react';
+
+type ABTestProps = {
+  name: string;
+  control: React.ReactNode;
+  variant: React.ReactNode;
+  probability?: number; // Probability of getting the variant (default 0.1)
+};
+
+export const ABTest = memo(({ name, control, variant, probability = 0.1 }: ABTestProps) => {
+  const { team } = useFileRouteLoaderData();
+
+  // Convert the team's UUID to a number between 0 and 1
+  // This is a simple hash function that will return a number between 0 and 1
+  // This will allow us to split the users into two groups, control and variant
+  // consistently puting the same user in the same group by using the same UUID
+  const hash = parseInt(team.uuid.replace(/-/g, '').slice(0, 8), 16) / 0xffffffff;
+
+  // Send to mixpanel
+  mixpanel.track('[ABTest].started', {
+    name,
+    variant: hash < probability ? 'variant' : 'control',
+    probability,
+  });
+
+  // Return variant if hash is less than probability, otherwise control
+  return hash < probability ? variant : control;
+});


### PR DESCRIPTION
Run an A/B test using Mixpanel on the copy for upgrading to Pro. 

Uses `team.uuid` to determine control vs variant group, so a user will always see the same one.

Control
![CleanShot 2025-04-09 at 15 59 47@2x](https://github.com/user-attachments/assets/ba13d5b4-91e6-4638-a782-0ca54754158e)

Variant
![CleanShot 2025-04-09 at 16 00 33@2x](https://github.com/user-attachments/assets/ba3b4cb2-83fa-45cb-97d9-af1ee7359c96)
