### PR TITLE
fix: code editor resizes beyond its bounds

### DIFF
--- a/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelsResize.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/panels/CodeEditorPanelsResize.tsx
@@ -1,10 +1,13 @@
+import { showAIAnalystAtom } from '@/app/atoms/aiAnalystAtom';
 import { ResizeControl } from '@/app/ui/components/ResizeControl';
+import { useAIAnalystPanelWidth } from '@/app/ui/menus/AIAnalyst/hooks/useAIAnalystPanelWidth';
 import {
   MIN_WIDTH_PANEL,
   MIN_WIDTH_VISIBLE_GRID,
   useCodeEditorPanelData,
 } from '@/app/ui/menus/CodeEditor/panels/useCodeEditorPanelData';
 import { memo, useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 const MIN_WIDTH_EDITOR = 350;
 
@@ -14,6 +17,8 @@ interface CodeEditorPanelsResizeProps {
 
 export const CodeEditorPanels = memo(({ codeEditorRef }: CodeEditorPanelsResizeProps) => {
   const codeEditorPanelData = useCodeEditorPanelData();
+  const showAIAnalyst = useRecoilValue(showAIAnalystAtom);
+  const { panelWidth: aiAnalystPanelWidth } = useAIAnalystPanelWidth();
 
   // we need to calculate the console height after a change in bottomHidden
   const [consoleHeaderHeight, setConsoleHeaderHeight] = useState(0);
@@ -46,7 +51,7 @@ export const CodeEditorPanels = memo(({ codeEditorRef }: CodeEditorPanelsResizeP
             setState={(mouseEvent) => {
               const offsetFromRight = window.innerWidth - mouseEvent.x;
               const min = MIN_WIDTH_PANEL + MIN_WIDTH_EDITOR;
-              const max = window.innerWidth - MIN_WIDTH_VISIBLE_GRID;
+              const max = window.innerWidth - (showAIAnalyst ? aiAnalystPanelWidth : 0) - MIN_WIDTH_VISIBLE_GRID;
 
               if (offsetFromRight > min && offsetFromRight < max) {
                 // change only the editor width
@@ -92,7 +97,7 @@ export const CodeEditorPanels = memo(({ codeEditorRef }: CodeEditorPanelsResizeP
             setState={(mouseEvent) => {
               const offsetFromRight = window.innerWidth - mouseEvent.x;
               const min = MIN_WIDTH_EDITOR;
-              const max = window.innerWidth - MIN_WIDTH_VISIBLE_GRID;
+              const max = window.innerWidth - (showAIAnalyst ? aiAnalystPanelWidth : 0) - MIN_WIDTH_VISIBLE_GRID;
               const newValue = offsetFromRight > max ? max : offsetFromRight < min ? min : offsetFromRight;
               codeEditorPanelData.setEditorWidth(newValue);
             }}


### PR DESCRIPTION
## Relevant issue(s)
_Very narrowly_ fixes #2196 

## Description

Some notes here after researching a solve for this issue:

There is a much larger problem than #2196, which is that we don't have proper "paneling" in the app. The code editor resizing beyond its bounds is a function of the different panels in the app not knowing about each other (and their sizes) when one of them is resized.

Currently there are four different panels that can all be open at the same time:

1. The AI Analyst
2. The grid (x/y axis, cells, sheetbar)
3. Code editor
4. Validations

![CleanShot 2025-04-11 at 13 46 02@2x](https://github.com/user-attachments/assets/147a13f8-b716-4df5-a5d9-89c2cfacdaf4)

There are all kinds of bugs that come out of these four different panels competing for space when resizing mechanisms are triggered in the app. And, if you start playing with the four different panels, you're going to find _lots_ of bugs. All of those we'll have to solve at a later time and date.

In the future we'll have lots of things we'll have to think through. For example, we know the grid will always be visible, but that's all we can assume. How will the different panels respond when:

- A new panel is opened or closed?
- An open panel is resized?
- The window is resized?
- Presentation mode is toggled on or off?

Other future considerations:

- What happens on narrower devices (e.g. mobile, tablet, etc)?
- How does the code handle us adding a new panel or removing an existing one?

For later reference, I'm going to link relevant issues that all stem from the underlying problem that we don't have a comprehensive solution to paneling in Quadratic:

- https://github.com/quadratichq/quadratic/issues/2196
- https://github.com/quadratichq/quadratic/issues/1117
- https://github.com/quadratichq/quadratic/issues/1941
- https://github.com/quadratichq/quadratic/issues/1573
- https://github.com/quadratichq/quadratic/issues/449

## Testing considerations

Test _only_ the functionality in #2196, which is: when the AI Analyst is open and you drag the code editor too far to the left, it won't go beyond its bounds. That's it. Don't test anything beyond that. You'll find all kinds of existing bugs that this PR doesn't aim to solve this.