### PR TITLE
fix: rendering of multiplayer transactions

### DIFF
--- a/quadratic-client/src/app/atoms/editorInteractionStateAtom.ts
+++ b/quadratic-client/src/app/atoms/editorInteractionStateAtom.ts
@@ -61,30 +61,26 @@ export const editorInteractionStateAtom = atom<EditorInteractionState>({
   default: defaultEditorInteractionState,
   effects: [
     ({ setSelf }) => {
-      const handleTransactionStart = (transaction: TransactionInfo) => {
+      const handleTransaction = (transaction: TransactionInfo, add: boolean) => {
         setSelf((prev) => {
           if (prev instanceof DefaultValue) return prev;
-
           return {
             ...prev,
             transactionsInfo: [
               ...prev.transactionsInfo.filter((t) => t.transactionId !== transaction.transactionId),
-              transaction,
+              ...(add ? [transaction] : []),
             ],
           };
         });
       };
+
+      const handleTransactionStart = (transaction: TransactionInfo) => {
+        handleTransaction(transaction, true);
+      };
       events.on('transactionStart', handleTransactionStart);
 
       const handleTransactionEnd = (transaction: TransactionInfo) => {
-        setSelf((prev) => {
-          if (prev instanceof DefaultValue) return prev;
-
-          return {
-            ...prev,
-            transactionsInfo: [...prev.transactionsInfo.filter((t) => t.transactionId !== transaction.transactionId)],
-          };
-        });
+        handleTransaction(transaction, false);
       };
       events.on('transactionEnd', handleTransactionEnd);
 

--- a/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/BottomBar/KernelMenu.tsx
@@ -6,7 +6,6 @@ import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import { focusGrid } from '@/app/helpers/focusGrid';
 import { KeyboardSymbols } from '@/app/helpers/keyboardSymbols';
 import { xyToA1 } from '@/app/quadratic-rust-client/quadratic_rust_client';
-import type { TransactionInfo } from '@/app/shared/types/transactionInfo';
 import { colors } from '@/app/theme/colors';
 import { SidebarToggle, SidebarTooltip } from '@/app/ui/QuadraticSidebar';
 import type { CodeRun } from '@/app/web-workers/CodeRun';
@@ -28,29 +27,11 @@ import { Tooltip, TooltipContent } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
 import { TooltipTrigger } from '@radix-ui/react-tooltip';
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 // Update the KernelMenu component to accept a custom trigger
 export const KernelMenu = ({ triggerIcon }: { triggerIcon: React.ReactNode }) => {
-  const [transactionsInfo, setTransactionsInfo] = useRecoilState(editorInteractionStateTransactionsInfoAtom);
-  useEffect(() => {
-    const handleTransactionStart = (transaction: TransactionInfo) => {
-      setTransactionsInfo((prev) => [
-        ...prev.filter((t) => t.transactionId !== transaction.transactionId),
-        transaction,
-      ]);
-    };
-    events.on('transactionStart', handleTransactionStart);
-
-    const handleTransactionEnd = (transaction: TransactionInfo) => {
-      setTransactionsInfo((prev) => prev.filter((t) => t.transactionId !== transaction.transactionId));
-    };
-    events.on('transactionEnd', handleTransactionEnd);
-    return () => {
-      events.off('transactionStart', handleTransactionStart);
-      events.off('transactionEnd', handleTransactionEnd);
-    };
-  }, [setTransactionsInfo]);
+  const transactionsInfo = useRecoilValue(editorInteractionStateTransactionsInfoAtom);
 
   const [disableRunCodeCell, setDisableRunCodeCell] = useState(true);
   useEffect(() => {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellsTextHash.ts
@@ -199,7 +199,7 @@ export class CellsTextHash {
           );
           this.renderCellsReceivedTime = performance.now();
         } catch (e) {
-          this.dirty = true;
+          this.dirty = dirty;
           console.warn(`[CellsTextHash] update: Error getting render cells: ${e}`);
           return false;
         }

--- a/quadratic-core/src/controller/active_transactions/pending_transaction.rs
+++ b/quadratic-core/src/controller/active_transactions/pending_transaction.rs
@@ -178,10 +178,7 @@ impl PendingTransaction {
 
     /// Sends the transaction to the multiplayer server (if needed)
     pub fn send_transaction(&self) {
-        if self.complete
-            && self.is_user_undo_redo()
-            && (cfg!(target_family = "wasm") || cfg!(test))
-            && !self.is_server()
+        if self.complete && self.is_user_undo_redo() && (cfg!(target_family = "wasm") || cfg!(test))
         {
             let transaction_id = self.id.to_string();
 
@@ -477,57 +474,6 @@ impl PendingTransaction {
 
         if let Ok(json) = serde_json::to_string(&selection) {
             self.update_selection = Some(json);
-        }
-    }
-
-    pub fn add_updates_from_transaction(&mut self, transaction: PendingTransaction) {
-        if !(cfg!(target_family = "wasm") || cfg!(test)) || self.is_server() {
-            return;
-        }
-
-        self.generate_thumbnail |= transaction.generate_thumbnail;
-
-        self.validations.extend(transaction.validations);
-
-        for (sheet_id, dirty_hashes) in transaction.dirty_hashes {
-            self.dirty_hashes
-                .entry(sheet_id)
-                .or_default()
-                .extend(dirty_hashes);
-        }
-
-        self.sheet_borders.extend(transaction.sheet_borders);
-
-        for (sheet_id, code_cells) in transaction.code_cells {
-            self.code_cells
-                .entry(sheet_id)
-                .or_default()
-                .extend(code_cells);
-        }
-
-        for (sheet_id, html_cells) in transaction.html_cells {
-            self.html_cells
-                .entry(sheet_id)
-                .or_default()
-                .extend(html_cells);
-        }
-
-        for (sheet_id, image_cells) in transaction.image_cells {
-            self.image_cells
-                .entry(sheet_id)
-                .or_default()
-                .extend(image_cells);
-        }
-
-        self.fill_cells.extend(transaction.fill_cells);
-
-        self.sheet_info.extend(transaction.sheet_info);
-
-        for (sheet_id, offsets_modified) in transaction.offsets_modified {
-            self.offsets_modified
-                .entry(sheet_id)
-                .or_default()
-                .extend(offsets_modified);
         }
     }
 


### PR DESCRIPTION
## Relevant issue(s)
closes #2623

## Description
there are side effects (mostly rendering) on transaction which happen in `finalize_transaction`, these were not happening correctly for multiplayer transactions
now `finalize_transaction` is called for all transactions (mp, rollback, reapply, etc)