### PR TITLE
Make AI chat aware of PDF capabilities 

### DIFF
--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -603,7 +603,7 @@ fig.show()
 \`\`\`
 
 ## File imports and exports
-Python can NOT be used to import files like .xlsx or .csv. Users should import xlsx and csv files directly to Quadratic by drag and dropping them directly into the sheet. They can then be read into Python with q.cells(). Python can not be used to import files (.xlsx, .csv, .pqt, etc).
+Python can NOT be used to import files like .xlsx, .pqt, .csv. Users should import xlsx, .pqt, and csv files to Quadratic by drag and dropping them directly into the sheet. They can then be read into Python with q.cells(). Python can not be used to import files (.xlsx, .csv, .pqt, etc).
 
 To import PDF and image files, insert them to the AI chat with the paperclip attach button, copy/paste, or drag and drop directly in the chat. PDF and image files can not be imported via Python. Once in the sheet, they can be analyzed by first being read into Python with q.cells().
 

--- a/quadratic-api/src/ai/docs/PythonDocs.ts
+++ b/quadratic-api/src/ai/docs/PythonDocs.ts
@@ -603,7 +603,9 @@ fig.show()
 \`\`\`
 
 ## File imports and exports
-Python can NOT be used to import files like .xlsx or .csv. Users should import those files directly to Quadratic by drag and dropping them directly into the sheet. They can then be read into Python with q.cells(). Python can not be used to import files (.xlsx, .csv, .pqt, etc).
+Python can NOT be used to import files like .xlsx or .csv. Users should import xlsx and csv files directly to Quadratic by drag and dropping them directly into the sheet. They can then be read into Python with q.cells(). Python can not be used to import files (.xlsx, .csv, .pqt, etc).
+
+To import PDF and image files, insert them to the AI chat with the paperclip attach button, copy/paste, or drag and drop directly in the chat. PDF and image files can not be imported via Python. Once in the sheet, they can be analyzed by first being read into Python with q.cells().
 
 Python can also not be used to export/download data as various file types. To download data from Quadratic, highlight the data you'd like to download, right click, and select the "Download as CSV" button.
 

--- a/quadratic-api/src/ai/docs/QuadraticDocs.ts
+++ b/quadratic-api/src/ai/docs/QuadraticDocs.ts
@@ -4,7 +4,9 @@ Quadratic is a modern AI-enabled spreadsheet. Quadratic is purpose built to make
 
 Quadratic combines a familiar spreadsheet and formulas with the power of AI and modern coding languages like Python, SQL, and JavaScript. 
 
-Ingest data from any source (csv, excel, parquet or sql) or add data directly, analyze it with coding languages, and speed up the entire process with AI.
+Files can be imported by drag and dropping into the sheet, those supported file types are: csv, excel, parquet. SQL can be used to connect to databases. Once in the sheet, data can be analyzed with coding languages and sped up with AI.
+
+The AI chat can import PDFs and images. To add PDFs and images to the chat, use the paperclip attach button to attach your file from the chat box. You can also paste PDFs and images into the chat box or drag and drop.
 
 Quadratic cells can be formatted from the toolbar UI but not from the AI or from code. 
 

--- a/quadratic-api/src/ai/docs/QuadraticDocs.ts
+++ b/quadratic-api/src/ai/docs/QuadraticDocs.ts
@@ -4,7 +4,7 @@ Quadratic is a modern AI-enabled spreadsheet. Quadratic is purpose built to make
 
 Quadratic combines a familiar spreadsheet and formulas with the power of AI and modern coding languages like Python, SQL, and JavaScript. 
 
-Files can be imported by drag and dropping into the sheet, those supported file types are: csv, excel, parquet. SQL can be used to connect to databases. Once in the sheet, data can be analyzed with coding languages and sped up with AI.
+Files can be imported by drag and dropping into the sheet, those supported file types are: csv, excel, parquet. SQL can be used to connect to databases. Once in the sheet, data can be analyzed with coding languages and AI.
 
 The AI chat can import PDFs and images. To add PDFs and images to the chat, use the paperclip attach button to attach your file from the chat box. You can also paste PDFs and images into the chat box or drag and drop.
 


### PR DESCRIPTION
## Relevant issue(s)
Response to report from Cole that he got two comments in a single day from AI trying to tell people incorrect info about PDFs. 

## Description
Edits the following: 
- Quadraticdocs: adds clarity to file imports 
- Pythondocs: adds clarity to file imports 

## Examples 
![CleanShot 2025-04-14 at 09 47 54@2x](https://github.com/user-attachments/assets/930edd5f-ec20-4c45-9a42-ee07cb8c3fe7)
![CleanShot 2025-04-14 at 09 48 15@2x](https://github.com/user-attachments/assets/a2620501-045e-4ba0-bf5a-70519373dec3)

