### PR TITLE
fix: qa docker image tag

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -177,7 +177,7 @@ jobs:
           context: .
           file: quadratic-${{ matrix.service }}/Dockerfile
           push: true
-          tags: ${{ steps.get-ecr-url.outputs.ECR_URL }}:${{ github.sha }}
+          tags: ${{ steps.get-ecr-url.outputs.ECR_URL }}:pr-qa
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max,compression=zstd,force-compression=true
           cache-from: type=local,src=/tmp/.buildx-cache
 


### PR DESCRIPTION
## Description
Fixes docker image tag to `pr-qa` which is used by pulumi to deploy latest images