### PR TITLE
initial commit

### DIFF
--- a/quadratic-client/src/app/ui/QuadraticUI.tsx
+++ b/quadratic-client/src/app/ui/QuadraticUI.tsx
@@ -31,7 +31,7 @@ import { QuadraticSidebar } from '@/app/ui/QuadraticSidebar';
 import { UpdateAlertVersion } from '@/app/ui/UpdateAlertVersion';
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { DialogRenameItem } from '@/shared/components/DialogRenameItem';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { ShareFileDialog } from '@/shared/components/ShareDialog';
 import { UserMessage } from '@/shared/components/UserMessage';
 import { COMMUNITY_A1_FILE_UPDATE_URL } from '@/shared/constants/urls';
@@ -87,13 +87,11 @@ export default function QuadraticUI() {
 
   if (error) {
     return (
-      <Empty
-        className="z-50 h-full w-full"
+      <EmptyPage
         title="Quadratic crashed"
         description="Something went wrong. Our team has been notified of this issue. Please reload the application to continue."
         Icon={CrossCircledIcon}
         actions={<Button onClick={() => window.location.reload()}>Reload</Button>}
-        severity="error"
         error={error.error}
         source={error.from}
       />

--- a/quadratic-client/src/dashboard/components/FilesList.tsx
+++ b/quadratic-client/src/dashboard/components/FilesList.tsx
@@ -5,7 +5,7 @@ import { FilesListViewControls } from '@/dashboard/components/FilesListViewContr
 import { Layout, Order, Sort, type ViewPreferences } from '@/dashboard/components/FilesListViewControlsDropdown';
 import { DRAWER_WIDTH } from '@/routes/_dashboard';
 import type { Action as FilesAction } from '@/routes/api.files.$uuid';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyState } from '@/shared/components/Empty';
 import { ShareFileDialog } from '@/shared/components/ShareDialog';
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
@@ -241,6 +241,12 @@ export function ExampleFilesList({ files, emptyState }: { files: FilesListExampl
 
 function EmptyFilterState() {
   return (
-    <Empty title="No matches" description={<>No files found with that specified name.</>} Icon={MagnifyingGlassIcon} />
+    <div className="flex min-h-80 items-center justify-center">
+      <EmptyState
+        title="No matches"
+        description={'No files found with that specified name.'}
+        Icon={MagnifyingGlassIcon}
+      />
+    </div>
   );
 }

--- a/quadratic-client/src/dashboard/components/FilesListEmptyState.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListEmptyState.tsx
@@ -1,5 +1,5 @@
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyState } from '@/shared/components/Empty';
 import { ROUTES } from '@/shared/constants/routes';
 import { FileIcon } from '@radix-ui/react-icons';
 import mixpanel from 'mixpanel-browser';
@@ -14,7 +14,7 @@ export const FilesListEmptyState = ({ isPrivate = false }: { isPrivate?: boolean
 
   return (
     <div className="flex min-h-80 items-center justify-center border-2 border-dashed border-border">
-      <Empty
+      <EmptyState
         className="max-w-lg"
         title="No files"
         description={

--- a/quadratic-client/src/routes/404.tsx
+++ b/quadratic-client/src/routes/404.tsx
@@ -1,15 +1,18 @@
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { SUPPORT_EMAIL } from '@/shared/constants/appConstants';
 import { Button } from '@/shared/shadcn/ui/button';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { Link } from 'react-router';
 
 export const Component = () => (
-  <Empty
+  <EmptyPage
     title="404: not found"
     description={
       <>
-        Check the URL and try again. Or, contact us for help at <a href={SUPPORT_EMAIL}>{SUPPORT_EMAIL}</a>
+        Check the URL and try again. Or, contact us for help at{' '}
+        <a href={SUPPORT_EMAIL} className="underline">
+          {SUPPORT_EMAIL}
+        </a>
       </>
     }
     Icon={ExclamationTriangleIcon}

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -4,7 +4,7 @@ import { DashboardSidebar } from '@/dashboard/components/DashboardSidebar';
 import { EducationDialog } from '@/dashboard/components/EducationDialog';
 import { ImportProgressList } from '@/dashboard/components/ImportProgressList';
 import { apiClient } from '@/shared/api/apiClient';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { MenuIcon } from '@/shared/components/Icons';
 import { ROUTE_LOADER_IDS, ROUTES, SEARCH_PARAMS } from '@/shared/constants/routes';
 import { CONTACT_URL, SCHEDULE_MEETING } from '@/shared/constants/urls';
@@ -224,7 +224,7 @@ export const ErrorBoundary = () => {
   if (isRouteErrorResponse(error)) {
     if (error.status === 402)
       return (
-        <Empty
+        <EmptyPage
           title="License Revoked"
           description="Your license has been revoked. Please contact Quadratic Support."
           Icon={InfoCircledIcon}
@@ -233,29 +233,27 @@ export const ErrorBoundary = () => {
       );
     if (error.status === 403)
       return (
-        <Empty
+        <EmptyPage
           title="You don’t have access to this team"
           description="Reach out to the team owner for permission to access this team."
           Icon={InfoCircledIcon}
           actions={actions}
-          showLoggedInUser
         />
       );
     if (error.status === 404 || error.status === 400)
       return (
-        <Empty
+        <EmptyPage
           title="Team not found"
           description="This team may have been deleted, moved, or made unavailable. Try reaching out to the team owner."
           Icon={ExclamationTriangleIcon}
           actions={actions}
-          showLoggedInUser
         />
       );
   }
 
   console.error(error);
   return (
-    <Empty
+    <EmptyPage
       title="Unexpected error"
       description="Something went wrong loading this team. If the error continues, contact us."
       Icon={ExclamationTriangleIcon}
@@ -264,9 +262,7 @@ export const ErrorBoundary = () => {
           <Link to="/">Go home</Link>
         </Button>
       }
-      severity="error"
       error={error}
-      showLoggedInUser
     />
   );
 };

--- a/quadratic-client/src/routes/_root.tsx
+++ b/quadratic-client/src/routes/_root.tsx
@@ -1,6 +1,6 @@
 import type { User } from '@/auth/auth';
 import { authClient } from '@/auth/auth';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { GlobalSnackbarProvider } from '@/shared/components/GlobalSnackbarProvider';
 import { MuiTheme } from '@/shared/components/MuiTheme';
 import { ROUTE_LOADER_IDS } from '@/shared/constants/routes';
@@ -43,13 +43,11 @@ export const ErrorBoundary = () => {
   const error = useRouteError();
 
   return (
-    <Empty
+    <EmptyPage
       title="Something went wrong"
       description="An unexpected error occurred. Try reloading the page or contact us if the error continues."
       Icon={ExclamationTriangleIcon}
-      severity="error"
       error={error}
-      showLoggedInUser
     />
   );
 };

--- a/quadratic-client/src/routes/file.$uuid.history.tsx
+++ b/quadratic-client/src/routes/file.$uuid.history.tsx
@@ -1,7 +1,7 @@
 import { requireAuth } from '@/auth/auth';
 import { getActionFileDownload, getActionFileDuplicate } from '@/routes/api.files.$uuid';
 import { apiClient } from '@/shared/api/apiClient';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { ChevronRightIcon, RefreshIcon } from '@/shared/components/Icons';
 import { QuadraticLogo } from '@/shared/components/QuadraticLogo';
 import { Type } from '@/shared/components/Type';
@@ -211,11 +211,10 @@ export const ErrorBoundary = () => {
   const error = useRouteError();
 
   return (
-    <Empty
+    <EmptyPage
       title="Failed to load version history"
       description="An unexpected error occurred. Try reloading the page or contact us if the error continues."
       Icon={ExclamationTriangleIcon}
-      severity="error"
       error={error}
       actions={
         <div className="flex justify-center gap-2">

--- a/quadratic-client/src/routes/file.$uuid.tsx
+++ b/quadratic-client/src/routes/file.$uuid.tsx
@@ -24,7 +24,7 @@ import { Link, Outlet, isRouteErrorResponse, redirect, useLoaderData, useParams,
 
 import type { MutableSnapshot } from 'recoil';
 import { RecoilRoot } from 'recoil';
-import { Empty } from '../shared/components/Empty';
+import { EmptyPage } from '../shared/components/Empty';
 
 type FileData = ApiTypes['/v0/files/:uuid.GET.response'];
 
@@ -251,14 +251,12 @@ export const ErrorBoundary = () => {
       reportError = true;
     }
     return (
-      <Empty
+      <EmptyPage
         title={title}
         description={description}
         Icon={ExclamationTriangleIcon}
         actions={actions}
-        showLoggedInUser
         error={reportError ? error : undefined}
-        severity={reportError ? 'error' : undefined}
       />
     );
   }
@@ -266,14 +264,12 @@ export const ErrorBoundary = () => {
   // If we reach here, it's an error we don't know how to handle.
   console.error(error);
   return (
-    <Empty
+    <EmptyPage
       title="Unexpected error"
       description="Something went wrong loading this file. If the error continues, contact us."
       Icon={ExclamationTriangleIcon}
       actions={actionsDefault}
-      severity="error"
       error={error}
-      showLoggedInUser
     />
   );
 };

--- a/quadratic-client/src/routes/file.tsx
+++ b/quadratic-client/src/routes/file.tsx
@@ -1,4 +1,4 @@
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { DOCUMENTATION_BROWSER_COMPATIBILITY_URL } from '@/shared/constants/urls';
 import { isWASMSupported } from '@/shared/utils/isWASMSupported';
 import { isWebGLSupported } from '@pixi/utils';
@@ -25,7 +25,7 @@ export function Component() {
 
   if (!isWASMSupported || !isWebGLSupported()) {
     return (
-      <Empty
+      <EmptyPage
         title="Browser not supported"
         description={[
           'Your browser does not support WebAssembly or WebGL. We recommend using the latest version of Google Chrome and enabling hardware acceleration. ',

--- a/quadratic-client/src/routes/files.shared-with-me.tsx
+++ b/quadratic-client/src/routes/files.shared-with-me.tsx
@@ -5,7 +5,7 @@ import type { LoaderFunctionArgs } from 'react-router';
 import { useLoaderData, useRouteError } from 'react-router';
 import { debugShowUILogs } from '../app/debugFlags';
 import { DashboardHeader } from '../dashboard/components/DashboardHeader';
-import { Empty } from '../shared/components/Empty';
+import { EmptyPage, EmptyState } from '../shared/components/Empty';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const files = await apiClient.files.list({ shared: 'with-me' });
@@ -31,7 +31,7 @@ export const Component = () => {
       <FilesList
         files={files}
         emptyState={
-          <Empty
+          <EmptyState
             title="No shared files"
             description="When someone invites you to a file, it will show up here."
             Icon={FileIcon}
@@ -47,14 +47,11 @@ export const ErrorBoundary = () => {
   if (debugShowUILogs) console.error('[<MineRoute>.<ErrorBoundary>]', error);
 
   return (
-    <div className={`mx-auto max-w-lg py-4`}>
-      <Empty
-        title="Unexpected error"
-        description="An unexpected error occurred while retrieving your files. Try reloading the page. If the issue continues, contact us."
-        Icon={ExclamationTriangleIcon}
-        severity="error"
-        error={error}
-      />
-    </div>
+    <EmptyPage
+      title="Unexpected error"
+      description="An unexpected error occurred while retrieving your files. Try reloading the page. If the issue continues, contact us."
+      Icon={ExclamationTriangleIcon}
+      error={error}
+    />
   );
 };

--- a/quadratic-client/src/routes/teams.$teamUuid.files.private.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.files.private.tsx
@@ -1,4 +1,5 @@
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
+import { EmptyPage } from '@/shared/components/Empty';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useRouteError } from 'react-router';
 import { debugShowUILogs } from '../app/debugFlags';
@@ -6,7 +7,6 @@ import { DashboardHeader } from '../dashboard/components/DashboardHeader';
 import { FilesList } from '../dashboard/components/FilesList';
 import { FilesListEmptyState } from '../dashboard/components/FilesListEmptyState';
 import NewFileButton from '../dashboard/components/NewFileButton';
-import { Empty } from '../shared/components/Empty';
 
 export const Component = () => {
   const {
@@ -50,14 +50,11 @@ export const ErrorBoundary = () => {
   if (debugShowUILogs) console.error('[<MineRoute>.<ErrorBoundary>]', error);
 
   return (
-    <div className="mx-auto max-w-prose py-4">
-      <Empty
-        title="Unexpected error"
-        description="An unexpected error occurred while retrieving your files. Try reloading the page. If the issue continues, contact us."
-        Icon={ExclamationTriangleIcon}
-        severity="error"
-        error={error}
-      />
-    </div>
+    <EmptyPage
+      title="Unexpected error"
+      description="An unexpected error occurred while retrieving your files. Try reloading the page. If the issue continues, contact us."
+      Icon={ExclamationTriangleIcon}
+      error={error}
+    />
   );
 };

--- a/quadratic-client/src/routes/teams.$teamUuid.index.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.index.tsx
@@ -6,7 +6,7 @@ import NewFileButton from '@/dashboard/components/NewFileButton';
 import { OnboardingBanner } from '@/dashboard/components/OnboardingBanner';
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
 import { Avatar } from '@/shared/components/Avatar';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyState } from '@/shared/components/Empty';
 import { AddIcon } from '@/shared/components/Icons';
 import { ROUTES } from '@/shared/constants/routes';
 import { cn } from '@/shared/shadcn/utils';
@@ -92,7 +92,7 @@ export const Component = () => {
           canEdit ? (
             <FilesListEmptyState />
           ) : (
-            <Empty
+            <EmptyState
               title="No team files yet"
               description={`Files created by your team members will show up here.`}
               Icon={FileIcon}

--- a/quadratic-client/src/routes/teams.$teamUuid.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.tsx
@@ -1,5 +1,5 @@
 import { apiClient } from '@/shared/api/apiClient';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyPage } from '@/shared/components/Empty';
 import { Button } from '@/shared/shadcn/ui/button';
 import { setActiveTeam } from '@/shared/utils/activeTeam';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
@@ -143,7 +143,7 @@ export const ErrorBoundary = () => {
   const error = useRouteError();
   console.error(error);
   return (
-    <Empty
+    <EmptyPage
       title="Unexpected error"
       description="Something went wrong loading this team. If the error continues, contact us."
       Icon={ExclamationTriangleIcon}
@@ -152,7 +152,6 @@ export const ErrorBoundary = () => {
           <Link to="/">Go home</Link>
         </Button>
       }
-      severity="error"
       error={error}
     />
   );

--- a/quadratic-client/src/shared/components/connections/ConnectionsList.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionsList.tsx
@@ -1,6 +1,6 @@
 import { LanguageIcon } from '@/app/ui/components/LanguageIcon';
 import { ConnectionsIcon } from '@/dashboard/components/CustomRadixIcons';
-import { Empty } from '@/shared/components/Empty';
+import { EmptyState } from '@/shared/components/Empty';
 import { AddIcon } from '@/shared/components/Icons';
 import { Type } from '@/shared/components/Type';
 import type {
@@ -97,8 +97,9 @@ export const ConnectionsList = ({
             />
           </>
         ) : (
-          <Empty
+          <EmptyState
             title="No connections"
+            className="mt-8"
             description="Create a connection from the options above, then open a spreadsheet and pull in data from it."
             Icon={ConnectionsIcon}
           />


### PR DESCRIPTION
## Description

The concerns of the `<Empty>` component began to conflate and so I've split it into two different components:

- `<EmptyPage>` which is used for the pages in the app where nothing renders except a message (e.g. on a crash, a 404 page, etc)
  - This component is the one that reports errors happening, as it takes over the entire page.
- `<EmptyState>` which is used in a variety of places in the app, including `<EmptyPage>`, and represents a state where not content exists. For example, if the app crashes, that's an empty state in an empty page. But also, if a list of files is empty, that's also an empty state but it's wrapped inside the UI of the dashboard.
  - This is a pure component with no side effects like tracking errors, etc. It is solely for display purposes.

Additionally, full screen empty pages now render centered in the screen. I think this is better because that's where your eyes go when the page loads (because that's where the loading UI is). It's weird when, for example, a file fails to load and your eyes go from middle to top in an otherwise blank screen. Now they stay centered on the area of focus.

Before:

https://github.com/user-attachments/assets/da8d6f23-5ce0-405f-af63-811554897202

After:

https://github.com/user-attachments/assets/58c36508-6bab-4793-bcdc-7c5e53368ee2




## To test
Test easily-reproducible views that replaced `<Empty>`  with either `<EmptyPage>` or `<EmptyState>`. This includes:

`<EmptyPage>` (should be an EmptyState centered in the middle of the page (with login info if you're logged in):

- [ ] File 404
- [ ] General 404 page - [link](TODO)
- [ ] Team 404
- [ ] File history - [link]() (try to access this file as a logged in user which is on a team you don't belong to)

`<EmptyState>`

- [ ] Shared files when you have none - [link](TODO)
- [ ] Connections list with 0 connections
- [ ] Files - no files
- [ ] Files - search filter with 0 results

There are more views like this, but they're harder to reproduce easily. If the above work, we can assume the others work too.