### PR TITLE
bugfix: Auto-expand on sorted table causes disappearing data

### DIFF
--- a/quadratic-connection/Cargo.lock
+++ b/quadratic-connection/Cargo.lock
@@ -1593,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2219,9 +2219,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",

--- a/quadratic-core/src/controller/operations/cell_value.rs
+++ b/quadratic-core/src/controller/operations/cell_value.rs
@@ -335,13 +335,13 @@ mod test {
 
     use bigdecimal::BigDecimal;
 
-    use crate::Rect;
     use crate::cell_values::CellValues;
     use crate::controller::GridController;
     use crate::controller::operations::operation::Operation;
+    use crate::controller::user_actions::import::tests::simple_csv;
     use crate::grid::{CodeCellLanguage, CodeCellValue, NumericFormat, NumericFormatKind, SheetId};
-    use crate::test_util::print_table_in_rect;
     use crate::{CellValue, SheetPos, SheetRect, a1::A1Selection};
+    use crate::{Rect, print_table_sheet};
 
     #[test]
     fn test() {
@@ -700,18 +700,20 @@ mod test {
 
     #[test]
     fn test_set_cell_values_operations() {
-        let mut gc = GridController::test();
+        // let mut gc = GridController::test();
+        let (mut gc, _, _, _) = simple_csv();
         let sheet_id = gc.sheet_ids()[0];
         let sheet_pos = SheetPos {
             x: 1,
-            y: 1,
+            y: 13,
             sheet_id,
         };
 
-        let values = vec![vec!["a".to_string(), "b".to_string()]];
+        let values = vec![vec!["a".to_string()]];
         let (ops, data_table_ops) = gc.set_cell_values_operations(sheet_pos, values).unwrap();
         println!("{:?}", ops);
         println!("{:?}", data_table_ops);
-        print_table_in_rect(&gc, sheet_id, Rect::from_numbers(1, 1, 2, 2));
+        let sheet = gc.try_sheet(sheet_id).unwrap();
+        print_table_sheet(sheet, Rect::from_numbers(1, 1, 4, 14), true);
     }
 }

--- a/quadratic-core/src/grid/data_table/column.rs
+++ b/quadratic-core/src/grid/data_table/column.rs
@@ -55,7 +55,13 @@ impl DataTable {
 
         if let Some(headers) = &mut self.column_headers {
             let new_header = DataTableColumnHeader::new(column_name, true, column_index as u32);
-            headers.insert(column_index, new_header);
+
+            if column_index < headers.len() {
+                headers.insert(column_index, new_header);
+            } else {
+                headers.push(new_header);
+            }
+
             for (index, header) in headers.iter_mut().enumerate() {
                 header.value_index = index as u32;
             }

--- a/quadratic-core/src/grid/data_table/row.rs
+++ b/quadratic-core/src/grid/data_table/row.rs
@@ -36,7 +36,6 @@ impl DataTable {
     /// Insert a new row at the given index.
     pub fn insert_row(&mut self, row_index: usize, values: Option<Vec<CellValue>>) -> Result<()> {
         let row_index = row_index as i64 - self.y_adjustment(true);
-
         let array = self.mut_value_as_array()?;
         array.insert_row(usize::try_from(row_index)?, values)?;
 
@@ -51,7 +50,7 @@ impl DataTable {
             let len = display_buffer.len();
             let index = usize::try_from(row_index)?;
 
-            if index >= len {
+            if index > len {
                 bail!("Row index {index} is out of bounds. Display buffer length: {len}");
             }
 
@@ -135,16 +134,24 @@ pub mod test {
 
         pretty_print_data_table(&data_table, Some("Original Data Table"), None);
 
-        data_table.insert_row(4, None).unwrap();
+        data_table.insert_row(5, None).unwrap();
         pretty_print_data_table(&data_table, Some("Data Table with New Row"), None);
 
-        // this should be a 5x4 array
+        // this should be a 4x6 array
         let expected_size = ArraySize::new(4, 6).unwrap();
         assert_eq!(data_table.output_size(), expected_size);
 
-        // expect index out of bounds error
         // first sort the table to create the display buffer
         data_table.sort_column(0, SortDirection::Ascending).unwrap();
+
+        data_table.insert_row(6, None).unwrap();
+        pretty_print_data_table(&data_table, Some("Data Table with second New Row"), None);
+
+        // this should be a 4x7 array
+        let expected_size = ArraySize::new(4, 7).unwrap();
+        assert_eq!(data_table.output_size(), expected_size);
+
+        // expect index out of bounds error
         let expected_error = data_table.insert_row(10, None);
         assert!(expected_error.is_err());
     }


### PR DESCRIPTION
## Relevant issue(s)
Fixes: https://github.com/quadratichq/quadratic/issues/2739

## Description
Expanding a table that is sorted causes a major issue, see attached vid for recreation (sort table and then try to auto expand on bottom)

## (Optional) QA Wolf tests 
@luke-quadratic your call here

## Demo
![auto-grow-on-sorted-data-table-bug](https://github.com/user-attachments/assets/2e95b54a-51e9-41c7-ae8c-779b461a6208)

