### PR TITLE
fix: tooltip shortcut label

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerLink.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerLink.ts
@@ -63,7 +63,7 @@ export class PointerLink {
     if (link) {
       this.cursor = matchShortcut(Action.CmdClick, event) ? 'pointer' : undefined;
       const tooltipText = 'Open link ';
-      const tooltipSubtext = `(${defaultActionSpec[Action.CmdClick].label})`;
+      const tooltipSubtext = `(${defaultActionSpec[Action.CmdClick].label()})`;
       this.emitHoverTooltip(link, tooltipText, tooltipSubtext);
       return true;
     }


### PR DESCRIPTION
## Description

When you hover a tooltip, it shows the function rather than the executed label.

![CleanShot 2025-04-17 at 17 00 55@2x](https://github.com/user-attachments/assets/ac48684b-527b-48ed-a1cd-21755b40a2ba)

