### PR TITLE
Only show clear color for the border's color picker  

### DIFF
--- a/quadratic-client/src/app/ui/components/BorderMenu.tsx
+++ b/quadratic-client/src/app/ui/components/BorderMenu.tsx
@@ -107,6 +107,7 @@ export const BorderMenu = () => {
             onClear={() => {
               borders.clearBorders();
             }}
+            removeColor
           />
         </div>
       </div>

--- a/quadratic-client/src/app/ui/components/qColorPicker.scss
+++ b/quadratic-client/src/app/ui/components/qColorPicker.scss
@@ -35,7 +35,7 @@
 }
 
 /* Overrides the last color to add the transparency indicator */
-.color-picker-submenu > div > span:last-of-type > div {
+.color-picker-submenu-last-color > div > span:last-of-type > div {
   background: white !important;
 
   &:before {

--- a/quadratic-client/src/app/ui/components/qColorPicker.tsx
+++ b/quadratic-client/src/app/ui/components/qColorPicker.tsx
@@ -6,66 +6,81 @@ interface IProps {
   onChangeComplete: ColorChangeHandler | undefined;
   onClear?: () => void;
   color?: string;
+  removeColor?: boolean;
 }
 
 export const QColorPicker = (props: IProps) => {
+  const colors = [
+    '#F9D2CE' /* first row of colors */,
+    '#FFEAC8',
+    '#FFF3C1',
+    '#D8FFE8',
+    '#D5FFF7',
+    '#DAF0FF',
+    '#EBD7F3',
+    '#D9F2FA',
+    '#FFB4AC' /* second row of colors */,
+    '#FFDA9F',
+    '#F2E2A4',
+    '#AAF1C8',
+    '#ADEFE2',
+    '#AFD0E7',
+    '#D1B4DD',
+    '#B4D3DC',
+    '#EE8277' /* third row of colors */,
+    '#F8C97D',
+    '#F5D657',
+    '#86E3AE',
+    '#7BE9D3',
+    '#84BFE7',
+    '#C39BD3',
+    '#A1B9BA',
+    '#E74C3C' /* forth row of colors */,
+    '#F39C12',
+    '#F1C40F',
+    '#2ECC71',
+    '#17C8A5',
+    '#3498DB',
+    '#9B59B6',
+    '#698183',
+    '#963127' /* fifth row of colors */,
+    '#C46B1D',
+    '#B69100',
+    '#1C8347',
+    '#056D6D',
+    '#1F608B',
+    '#6F258E',
+    '#34495E',
+    '#000000' /* sixth row of colors */,
+    '#333333',
+  ];
+  if (props.removeColor) {
+    colors.push(
+      // '#4d4d4d', // removed so we can add clear color at end
+      '#737373',
+      '#cccccc',
+      '#dddddd',
+      '#eeeeee',
+      '#ffffff',
+      '#123456' // special indicator for remove color. See useBorders.tsx#CLEAR_COLOR
+    );
+  } else {
+    colors.push(
+      '#4d4d4d', // removed so we can add clear color at end
+      '#737373',
+      '#cccccc',
+      '#dddddd',
+      '#eeeeee',
+      '#ffffff'
+    );
+  }
   return (
     <>
       <CompactPicker
         color={props.color}
-        className="color-picker-submenu"
+        className={'color-picker-submenu' + (props.removeColor ? ' color-picker-submenu-last-color' : '')}
         onChangeComplete={props.onChangeComplete}
-        colors={[
-          '#F9D2CE' /* first row of colors */,
-          '#FFEAC8',
-          '#FFF3C1',
-          '#D8FFE8',
-          '#D5FFF7',
-          '#DAF0FF',
-          '#EBD7F3',
-          '#D9F2FA',
-          '#FFB4AC' /* second row of colors */,
-          '#FFDA9F',
-          '#F2E2A4',
-          '#AAF1C8',
-          '#ADEFE2',
-          '#AFD0E7',
-          '#D1B4DD',
-          '#B4D3DC',
-          '#EE8277' /* third row of colors */,
-          '#F8C97D',
-          '#F5D657',
-          '#86E3AE',
-          '#7BE9D3',
-          '#84BFE7',
-          '#C39BD3',
-          '#A1B9BA',
-          '#E74C3C' /* forth row of colors */,
-          '#F39C12',
-          '#F1C40F',
-          '#2ECC71',
-          '#17C8A5',
-          '#3498DB',
-          '#9B59B6',
-          '#698183',
-          '#963127' /* fifth row of colors */,
-          '#C46B1D',
-          '#B69100',
-          '#1C8347',
-          '#056D6D',
-          '#1F608B',
-          '#6F258E',
-          '#34495E',
-          '#000000' /* sixth row of colors */,
-          '#333333',
-          // '#4d4d4d', // removed so we can add clear color at end
-          '#737373',
-          '#cccccc',
-          '#dddddd',
-          '#eeeeee',
-          '#ffffff',
-          '#123456', // special indicator for color color. See useBorders.tsx#CLEAR_COLOR
-        ]}
+        colors={colors}
       />
       {props.onClear && (
         <div className="color-picker-clear">


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2640

## Description
Removes clear color (last color in color picker) for all palettes except for borders. (Borders allow you to apply a clear color to a certain line, which is why that special color is necessary).
