### PR TITLE
Python data table name states

### DIFF
--- a/quadratic-client/src/app/actions/dataTableSpec.ts
+++ b/quadratic-client/src/app/actions/dataTableSpec.ts
@@ -655,7 +655,7 @@ export const dataTableSpec: DataTableSpec = {
   },
   [Action.ToggleTableName]: {
     label: () => 'Show name',
-    isAvailable: () => isCodeCell('Python') || !isSingleCell(),
+    isAvailable: () => isCodeCell('Python') || isCodeCell('Javascript') || !isSingleCell(),
     labelVerbose: 'Show table name',
     checkbox: isTableNameShowing,
     run: toggleTableName,

--- a/quadratic-client/src/app/actions/dataTableSpec.ts
+++ b/quadratic-client/src/app/actions/dataTableSpec.ts
@@ -655,7 +655,7 @@ export const dataTableSpec: DataTableSpec = {
   },
   [Action.ToggleTableName]: {
     label: () => 'Show name',
-    isAvailable: () => !isSingleCell(),
+    isAvailable: () => isCodeCell('Python') || !isSingleCell(),
     labelVerbose: 'Show table name',
     checkbox: isTableNameShowing,
     run: toggleTableName,

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -112,12 +112,6 @@ impl GridController {
                 new_data_table.header_is_first_row |= old_data_table.header_is_first_row;
             }
 
-            // if the new data table is a single value and is a code cell, then we
-            // don't want to show the name or columns headers
-            if new_data_table.is_single_value() && is_code_cell {
-                new_data_table.apply_single_value_settings(false);
-            }
-
             // if the width of the old and new data tables are the same,
             // then we can preserve other user-selected properties
             if old_data_table.output_size().w == new_data_table.output_size().w {

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -618,8 +618,8 @@ mod test {
             true,
             None,
         )
-        .with_show_name(false)
-        .with_show_columns(false);
+        .with_show_name(true)
+        .with_show_columns(true);
         new_data_table.column_headers = None;
 
         gc.finalize_data_table(transaction, sheet_pos, Some(new_data_table.clone()), None);

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -55,7 +55,6 @@ impl GridController {
             return;
         };
         let pos: Pos = sheet_pos.into();
-
         // index for SetCodeRun is either set by execute_set_code_run or calculated
         let index = index.unwrap_or(
             sheet
@@ -116,7 +115,7 @@ impl GridController {
             // if the new data table is a single value and is a code cell, then we
             // don't want to show the name or columns headers
             if new_data_table.is_single_value() && is_code_cell {
-                new_data_table.apply_single_value_settings();
+                new_data_table.apply_single_value_settings(false);
             }
 
             // if the width of the old and new data tables are the same,
@@ -411,6 +410,7 @@ impl GridController {
             _ => "Table1",
         };
 
+        // sheet may have been deleted before the async operation completed
         let Some(sheet) = self.try_sheet_mut(start.sheet_id) else {
             // todo: this is probably not the best place to handle this
             // sheet may have been deleted before the async operation completed
@@ -439,6 +439,8 @@ impl GridController {
                 None,
             );
         };
+
+        let first_run = sheet.data_table(start.into()).is_none();
 
         let value = if js_code_result.success {
             if let Some(array_output) = js_code_result.output_array {
@@ -511,7 +513,7 @@ impl GridController {
         // if the new data table is a single value and is a code cell, then we
         // don't want to show the name or columns headers
         if data_table.is_single_value() && language.is_code_language() {
-            data_table.apply_single_value_settings();
+            data_table.apply_single_value_settings(first_run);
         }
 
         // If no headers were returned, we want column headers: [0, 1, 2, 3, ...etc]

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -82,10 +82,6 @@ impl GridController {
         if let (Some(old_data_table), Some(new_data_table)) =
             (sheet.data_table(pos), &mut new_data_table)
         {
-            let is_code_cell = sheet
-                .get_table_language(pos, new_data_table)
-                .is_some_and(|lang| lang.is_code_language());
-
             new_data_table.alternating_colors = old_data_table.alternating_colors;
             new_data_table.name = old_data_table.name.to_owned();
             new_data_table.show_name = old_data_table.show_name;

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -88,6 +88,7 @@ impl GridController {
 
             new_data_table.alternating_colors = old_data_table.alternating_colors;
             new_data_table.name = old_data_table.name.to_owned();
+            new_data_table.show_name = old_data_table.show_name;
 
             // for python dataframes, we don't want preserve the show_columns setting
             // for other data tables types, we want to preserve most settings
@@ -97,7 +98,6 @@ impl GridController {
                 && !new_data_table.is_html_or_image()
             {
                 new_data_table.show_ui = old_data_table.show_ui;
-                new_data_table.show_name = old_data_table.show_name;
                 new_data_table.show_columns = old_data_table.show_columns;
 
                 // since we don't automatically apply the first row as headers in JS,

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -648,8 +648,8 @@ impl DataTable {
     ///
     /// This is used when a single value data table is created from a code run
     /// and is a code cell.
-    pub fn apply_single_value_settings(&mut self) {
-        if self.is_single_value() {
+    pub fn apply_single_value_settings(&mut self, first_run: bool) {
+        if self.is_single_value() && first_run {
             self.show_name = false;
             self.show_columns = false;
             self.header_is_first_row = false;


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/quadratichq/quadratic/issues/2637
Fixes https://github.com/quadratichq/quadratic/issues/2516

## Description
- [x] Python and JS: Single value output: add ability to show name, once shown it stays shown until/unless user hides, reflect user choice in that cell
- [x] Python and JS: List: shows name by default, if user disables name and re-runs code the name should stay hidden. For it to reappear on that code cell they'd need to manually re-enable
- [x] Python only: DataFrame: shows name by default, if user disables name and re-runs code the name should stay hidden. For it to reappear on that code cell they'd need to manually re-enable 
- [x] Dragged code cell that has "show name" disabled shows name on some autocompleted cells. 

## QA Wolf
IDK if this will break current QA Wolf tests

## Demo for https://github.com/quadratichq/quadratic/issues/2637
![python-data-table-name-states](https://github.com/user-attachments/assets/a2a6b63f-e657-474c-8e8d-cd8762bb9c63)

## Demo for Fixes https://github.com/quadratichq/quadratic/issues/2516
![autocomplete-no-name](https://github.com/user-attachments/assets/edc023c8-00c0-427c-a6c0-0a8af7366b4d)

