### PR TITLE
fix: new users go to a new file

### DIFF
--- a/quadratic-client/src/routes/login-result.tsx
+++ b/quadratic-client/src/routes/login-result.tsx
@@ -1,5 +1,6 @@
 import { authClient } from '@/auth/auth';
 import { apiClient } from '@/shared/api/apiClient';
+import { isMobile } from 'react-device-detect';
 import { redirect } from 'react-router';
 
 export const loader = async () => {
@@ -42,6 +43,11 @@ export const loader = async () => {
       }
 
       let redirectTo = new URLSearchParams(window.location.search).get('redirectTo') || '/';
+      // For new users coming directly to `/`, we'll send them to a new file
+      // Otherwise, respect the route they were trying to access (e.g. `/files/create?prompt=...`)
+      if (userCreated && !isMobile && redirectTo === '/') {
+        return redirect('/files/create');
+      }
       return redirect(redirectTo);
     }
   } catch (e) {

--- a/quadratic-client/src/shared/utils/activeTeam.ts
+++ b/quadratic-client/src/shared/utils/activeTeam.ts
@@ -19,9 +19,6 @@
 //
 // This is a bit of an edge case, but it's good to be aware of how this works.
 import { apiClient } from '@/shared/api/apiClient';
-import { ROUTES } from '@/shared/constants/routes';
-import { isMobile } from 'react-device-detect';
-import { redirect } from 'react-router';
 
 const KEY = 'activeTeamUuid';
 
@@ -77,17 +74,6 @@ export async function getOrInitializeActiveTeam(): Promise<string> {
     const newTeam = await apiClient.teams.create({ name: 'My Team' });
     const newTeamUuid = newTeam.uuid;
     localStorage.setItem(KEY, newTeamUuid);
-    // Handle new users specially
-    // (because we use this in loaders, we can throw redirects)
-    // If it's mobile, send them to the dashboard.
-    // If they're going to the root, create a new file for them and send them there.
-    // Otherwise, respect the route they were trying to access (e.g. `/files/create?prompt=...)
-    if (isMobile) {
-      throw redirect(ROUTES.TEAM(newTeamUuid));
-    }
-    if (window.location.pathname === '/') {
-      throw redirect(ROUTES.CREATE_FILE(newTeamUuid));
-    }
     return newTeamUuid;
   })();
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2789 

Logic: if you're a new user, you come to the root of the app (`/`), and you're not on mobile, we'll create a new file and send you to that.