### PR TITLE
fix bugs with validations

### DIFF
--- a/quadratic-client/src/app/gridGL/cells/cellsLabel/CellsTextHashValidations.ts
+++ b/quadratic-client/src/app/gridGL/cells/cellsLabel/CellsTextHashValidations.ts
@@ -28,8 +28,9 @@ export class CellsTextHashValidations extends Container {
   private addWarning(x: number, y: number, color: number): Sprite {
     const sprite = this.addChild(new Sprite(generatedTextures.triangle));
     sprite.tint = color;
-    sprite.scale.set(TRIANGLE_SCALE);
-    sprite.position.set(x, y + sprite.height);
+    // flips the triangle so it properly aligns to the top-right corner
+    sprite.scale.set(-TRIANGLE_SCALE, TRIANGLE_SCALE);
+    sprite.position.set(x, y);
     sprite.anchor.set(1, 0);
     sprite.rotation = Math.PI / 2;
     this.bounds.addRectanglePoints(

--- a/quadratic-client/src/app/gridGL/interaction/pointer/pointerCursor.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/pointerCursor.ts
@@ -10,6 +10,21 @@ import type { Point } from 'pixi.js';
 export class PointerCursor {
   private lastInfo?: JsRenderCodeCell | EditingCell | ErrorValidation;
 
+  constructor() {
+    events.on('cursorPosition', this.checkLastHoverCell);
+  }
+
+  destroy() {
+    events.off('cursorPosition', this.checkLastHoverCell);
+  }
+
+  // ensure we check the hover cell whenever the cursor moves (this removes the
+  // double hover cell when the cursor is already in a cell that has a
+  // validation message)
+  private checkLastHoverCell = () => {
+    this.checkHoverCell(pixiApp.viewport.getWorld());
+  };
+
   private checkHoverCell(world: Point) {
     if (!pixiApp.cellsSheets.current) throw new Error('Expected cellsSheets.current to be defined in PointerCursor');
     const cell = sheets.sheet.getColumnRow(world.x, world.y);
@@ -33,7 +48,9 @@ export class PointerCursor {
 
     let foundValidation = false;
     const validation = pixiApp.cellsSheets.current.cellsLabels.intersectsErrorMarkerValidation(world);
-    if (validation) {
+    // don't allow hover cell when it's already open b/c the cursor is in the cell
+    const cursor = sheets.sheet.cursor.position;
+    if (validation && (cell.x !== cursor.x || cell.y !== cursor.y)) {
       if (this.lastInfo?.x !== validation.x || this.lastInfo?.y !== validation.y) {
         events.emit('hoverCell', validation);
         this.lastInfo = validation;

--- a/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/viewport/Viewport.ts
@@ -158,6 +158,10 @@ export class Viewport extends PixiViewport {
     this.dirty = true;
   };
 
+  getWorld = () => {
+    return this.toWorld(this.pixiApp.renderer.events.pointer.global);
+  };
+
   enableMouseEdges = (world?: Point, direction?: 'horizontal' | 'vertical') => {
     this.lastMouse = world;
     const mouseEdges = this.plugins.get('mouse-edges');

--- a/quadratic-core/src/grid/sheet/rendering/code.rs
+++ b/quadratic-core/src/grid/sheet/rendering/code.rs
@@ -331,12 +331,15 @@ mod tests {
             None,
         );
 
+        let context = A1Context::default();
+
         // render rect is larger than code rect
         let code_cells = sheet.get_code_cells(
             &code_cell,
             &data_table,
             &Rect::from_numbers(0, 0, 10, 10),
             &Rect::from_numbers(5, 5, 3, 2),
+            &context,
         );
         assert_eq!(code_cells.len(), 6);
         assert_eq!(code_cells[0].value, "1".to_string());
@@ -351,6 +354,7 @@ mod tests {
             &data_table,
             &Rect::from_numbers(2, 1, 10, 10),
             &Rect::from_numbers(0, 0, 3, 2),
+            &context,
         );
         assert_eq!(code_cells.len(), 1);
         assert_eq!(code_cells[0].value, "6".to_string());
@@ -362,6 +366,7 @@ mod tests {
             &data_table,
             &Rect::from_numbers(0, 0, 3, 2),
             &Rect::from_numbers(2, 1, 10, 10),
+            &context,
         );
         assert_eq!(code_cells.len(), 1);
         assert_eq!(code_cells[0].value, "1".to_string());
@@ -391,6 +396,7 @@ mod tests {
             &code_run,
             &Rect::from_numbers(0, 0, 10, 10),
             &Rect::from_numbers(5, 5, 1, 1),
+            &context,
         );
         assert_eq!(code_cells[0].value, "1".to_string());
         assert_eq!(code_cells[0].language, Some(CodeCellLanguage::Python));

--- a/quadratic-rust-shared/Cargo.lock
+++ b/quadratic-rust-shared/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "quadratic-rust-shared"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "aes",
  "arrow",


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2315 (although this PR does not disable validations in tables, but properly supports them)

Also fixes:
- [x] properly display validation triangle (it was flipped improperly)
- [x] hovering validation message box goes away when cursor is in cell (since it's permanent)