### PR TITLE
fix: add write permission to Github Release workflow

### DIFF
--- a/.github/workflows/production-github-release.yml
+++ b/.github/workflows/production-github-release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   github_release:
-    name: github_release
+    name: Github Release
+    permissions:
+      contents: write
     runs-on: blacksmith-2vcpu-ubuntu-2204
     concurrency:
       group: production-github-release


### PR DESCRIPTION
## Description
debugging failure of last run by adding write permission to the workflow
ref: https://github.com/quadratichq/quadratic/actions/runs/14644893695/job/41096406151****