### PR TITLE
Test more rows in context 

### DIFF
--- a/quadratic-core/src/grid/sheet/ai_context.rs
+++ b/quadratic-core/src/grid/sheet/ai_context.rs
@@ -215,7 +215,7 @@ impl Sheet {
                 1,
             );
             let first_row_visible_values = self
-                .js_cell_value_pos_in_rect(first_row_rect, Some(1))
+                .js_cell_value_pos_in_rect(first_row_rect, Some(75))
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();

--- a/quadratic-core/src/grid/sheet/ai_context.rs
+++ b/quadratic-core/src/grid/sheet/ai_context.rs
@@ -212,7 +212,7 @@ impl Sheet {
                 bounds.min.x,
                 bounds.min.y + table.y_adjustment(false),
                 bounds.width() as i64,
-                1,
+                75,
             );
             let first_row_visible_values = self
                 .js_cell_value_pos_in_rect(first_row_rect, Some(75))

--- a/quadratic-core/src/grid/sheet/ai_context.rs
+++ b/quadratic-core/src/grid/sheet/ai_context.rs
@@ -51,7 +51,7 @@ impl Sheet {
                 rect_origin: tabular_data_rect.min.a1_string(),
                 rect_width: tabular_data_rect.width(),
                 rect_height: tabular_data_rect.height(),
-                starting_rect_values: self.js_cell_value_pos_in_rect(tabular_data_rect, Some(3)),
+                starting_rect_values: self.js_cell_value_pos_in_rect(tabular_data_rect, Some(75)),
             };
             data_rects.push(cell_value_pos);
         }


### PR DESCRIPTION
Testing the AI performance hit from showing 75 rows per table by default 

I'm seeing negligible performance hits at 75 rows across datasets where the 75 are numerical, heavy text, etc.