### PR TITLE
Fix insert next to code

### DIFF
--- a/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
@@ -306,9 +306,8 @@ mod tests {
             CellsAccessed, CodeCellLanguage, CodeCellValue, CodeRun, DataTable, DataTableKind,
             sheet::validations::{validation::Validation, validation_rules::ValidationRule},
         },
-        test_util::{
-            assert_data_table_size, first_sheet_id, test_create_html_chart, test_create_js_chart,
-        },
+        test_create_gc,
+        test_util::*,
         wasm_bindings::js::{clear_js_calls, expect_js_call_count, expect_js_offsets},
     };
 
@@ -1081,5 +1080,14 @@ mod tests {
 
         gc.undo(None);
         assert_data_table_size(&gc, sheet_id, pos![B2], 3, 3, false);
+    }
+
+    #[test]
+    fn test_insert_col_next_to_code() {
+        let mut gc = test_create_gc();
+        let sheet_id = first_sheet_id(&gc);
+
+        test_create_formula_array(&mut gc, pos![C2], 2, 2);
+        print_first_sheet(&gc);
     }
 }

--- a/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
@@ -1087,7 +1087,12 @@ mod tests {
         let mut gc = test_create_gc();
         let sheet_id = first_sheet_id(&gc);
 
-        test_create_formula_array(&mut gc, pos![C2], 2, 2);
+        let table = test_create_code_table(&mut gc, sheet_id, pos![C2], 2, 2);
         print_first_sheet(&gc);
+
+        gc.insert_column(sheet_id, 3, false, None);
+        print_first_sheet(&gc);
+
+        assert_eq!(&table, gc.data_table(pos![sheet_id!d2]).unwrap());
     }
 }

--- a/quadratic-core/src/controller/user_actions/data_table.rs
+++ b/quadratic-core/src/controller/user_actions/data_table.rs
@@ -1,12 +1,21 @@
 use crate::{
     CopyFormats, Pos, SheetPos, SheetRect,
     controller::{GridController, active_transactions::transaction_name::TransactionName},
-    grid::{data_table::column_header::DataTableColumnHeader, sort::DataTableSort},
+    grid::{DataTable, data_table::column_header::DataTableColumnHeader, sort::DataTableSort},
 };
 
 use anyhow::Result;
 
 impl GridController {
+    /// Gets a data table based on a sheet position.
+    pub fn data_table(&self, sheet_pos: SheetPos) -> Option<&DataTable> {
+        if let Some(sheet) = self.try_sheet(sheet_pos.sheet_id) {
+            sheet.data_table(sheet_pos.into())
+        } else {
+            None
+        }
+    }
+
     /// Returns all data tables within the given sheet position.
     pub fn data_tables_within(&self, sheet_pos: SheetPos) -> Result<Vec<Pos>> {
         let sheet = self.try_sheet_result(sheet_pos.sheet_id)?;
@@ -167,7 +176,8 @@ mod tests {
             user_actions::import::tests::simple_csv,
         },
         grid::{CodeCellLanguage, CodeCellValue, CodeRun, DataTable, DataTableKind},
-        test_util::{assert_cell_value, assert_cell_value_row, print_table_in_rect},
+        test_create_data_table,
+        test_util::*,
         wasm_bindings::js::{clear_js_calls, expect_js_call},
     };
 
@@ -591,5 +601,16 @@ mod tests {
             assert_eq!(headers[0].name, "Column 1".into());
             assert_eq!(headers[1].name, "Column 2".into());
         }
+    }
+
+    #[test]
+    fn test_data_table() {
+        let mut gc = test_create_gc();
+        let sheet_id = first_sheet_id(&gc);
+
+        let dt = test_create_data_table(&mut gc, sheet_id, pos![A1], 2, 2);
+
+        assert_eq!(gc.data_table(pos![sheet_id!A1]), Some(&dt));
+        assert!(gc.data_table(pos![sheet_id!A2]).is_none());
     }
 }

--- a/quadratic-core/src/test_util/assert_values.rs
+++ b/quadratic-core/src/test_util/assert_values.rs
@@ -114,7 +114,7 @@ pub fn assert_cell_value_col(
 #[track_caller]
 #[cfg(test)]
 pub fn assert_cell_value_row(
-    grid_controller: &GridController,
+    gc: &GridController,
     sheet_id: SheetId,
     x_start: i64,
     x_end: i64,
@@ -123,7 +123,7 @@ pub fn assert_cell_value_row(
 ) {
     for (index, x) in (x_start..=x_end).enumerate() {
         if let Some(cell_value) = value.get(index) {
-            assert_display_cell_value(grid_controller, sheet_id, x, y, cell_value);
+            assert_display_cell_value(gc, sheet_id, x, y, cell_value);
         } else {
             panic!("No value at position ({},{})", index, y);
         }

--- a/quadratic-core/src/test_util/create_code_table.rs
+++ b/quadratic-core/src/test_util/create_code_table.rs
@@ -6,7 +6,7 @@ use bigdecimal::BigDecimal;
 
 #[cfg(test)]
 use crate::{
-    Array, ArraySize, CellValue, Pos, Value,
+    Array, ArraySize, CellValue, Pos, SheetPos, Value,
     controller::{
         GridController, active_transactions::transaction_name::TransactionName,
         operations::operation::Operation,
@@ -89,6 +89,18 @@ pub fn test_create_code_table_with_values(
 }
 
 #[cfg(test)]
+pub fn test_create_formula_array(
+    gc: &mut GridController,
+    sheet_pos: SheetPos,
+    w: usize,
+    h: usize,
+) -> DataTable {
+    let code = format!("{{1..{w}}}*{{1..{h}}}");
+    gc.set_code_cell(sheet_pos, CodeCellLanguage::Formula, code, None);
+    gc.data_table(sheet_pos).unwrap().clone()
+}
+
+#[cfg(test)]
 mod tests {
     use crate::test_util::sheet;
 
@@ -152,6 +164,67 @@ mod tests {
             );
             // Fourth cell should be empty
             assert_eq!(array.get(1, 1).unwrap(), &CellValue::Blank);
+        } else {
+            panic!("Expected array value");
+        }
+    }
+
+    #[test]
+    fn test_formula_array_creation() {
+        let mut gc = GridController::test();
+        let sheet_id = SheetId::TEST;
+        let pos = pos![A1];
+        let sheet_pos = pos.to_sheet_pos(sheet_id);
+
+        // Create a 3x3 multiplication table
+        let created_dt = test_create_formula_array(&mut gc, sheet_pos, 3, 3);
+
+        let sheet = sheet(&gc, sheet_id);
+        let table = sheet.data_table(pos).unwrap();
+
+        assert_eq!(&created_dt, table);
+
+        if let Value::Array(array) = &table.value {
+            assert_eq!(array.width(), 3);
+            assert_eq!(array.height(), 3);
+
+            // Verify the multiplication table values
+            assert_eq!(
+                array.get(0, 0).unwrap(),
+                &CellValue::Number(BigDecimal::from(1))
+            );
+            assert_eq!(
+                array.get(1, 0).unwrap(),
+                &CellValue::Number(BigDecimal::from(2))
+            );
+            assert_eq!(
+                array.get(2, 0).unwrap(),
+                &CellValue::Number(BigDecimal::from(3))
+            );
+            assert_eq!(
+                array.get(0, 1).unwrap(),
+                &CellValue::Number(BigDecimal::from(2))
+            );
+            assert_eq!(
+                array.get(1, 1).unwrap(),
+                &CellValue::Number(BigDecimal::from(4))
+            );
+            assert_eq!(
+                array.get(2, 1).unwrap(),
+                &CellValue::Number(BigDecimal::from(6))
+            );
+            assert_eq!(
+                array.get(0, 2).unwrap(),
+                &CellValue::Number(BigDecimal::from(3))
+            );
+            assert_eq!(
+                array.get(1, 2).unwrap(),
+                &CellValue::Number(BigDecimal::from(6))
+            );
+            assert_eq!(
+                array.get(2, 2).unwrap(),
+                &CellValue::Number(BigDecimal::from(9))
+            );
         } else {
             panic!("Expected array value");
         }

--- a/quadratic-files/Cargo.lock
+++ b/quadratic-files/Cargo.lock
@@ -2538,6 +2538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.3.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4100,6 +4119,7 @@ dependencies = [
  "quadratic-rust-shared",
  "rand 0.9.0",
  "regex",
+ "rstar",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -4700,6 +4720,17 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]

--- a/quadratic-multiplayer/Cargo.lock
+++ b/quadratic-multiplayer/Cargo.lock
@@ -2562,6 +2562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.3.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4120,6 +4139,7 @@ dependencies = [
  "quadratic-rust-shared",
  "rand 0.9.0",
  "regex",
+ "rstar",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -4721,6 +4741,17 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2845 

## Description
Fixes a bug where inserting a column to the left of a code table causes unexpected behavior.