### PR TITLE
feat: allow stop AI interaction via keyboard shortcut

### DIFF
--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -5,7 +5,7 @@ import { KeyboardSymbols } from '@/app/helpers/keyboardSymbols';
 import { AIContext } from '@/app/ui/components/AIContext';
 import { AIUsageExceeded } from '@/app/ui/components/AIUsageExceeded';
 import ConditionalWrapper from '@/app/ui/components/ConditionalWrapper';
-import { ArrowUpwardIcon, BackspaceIcon, EditIcon } from '@/shared/components/Icons';
+import { ArrowUpwardIcon, EditIcon } from '@/shared/components/Icons';
 import { Button } from '@/shared/shadcn/ui/button';
 import { Textarea } from '@/shared/shadcn/ui/textarea';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
@@ -261,6 +261,8 @@ export const AIUserMessageForm = memo(
                   setEditing(false);
                   bottomTextareaRef.current?.focus();
                 }
+              } else if (loading && event.shiftKey && event.metaKey && event.key === 'Backspace') {
+                abortPrompt();
               }
 
               if (loading || waitingOnMessageIndex !== undefined) return;
@@ -345,13 +347,18 @@ const CancelButton = memo(({ show, waitingOnMessageIndex, abortPrompt }: CancelB
     <Button
       size="sm"
       variant="outline"
-      className="absolute -top-10 right-1/2 z-10 translate-x-1/2 bg-background"
+      className="absolute -top-10 right-1/2 z-10 translate-x-1/2 gap-1 bg-background"
       onClick={(e) => {
         e.stopPropagation();
         abortPrompt();
       }}
     >
-      <BackspaceIcon className="mr-1" /> Cancel {waitingOnMessageIndex !== undefined ? 'sending' : 'generating'}
+      <span className="flex-shrink-0">Stop {waitingOnMessageIndex !== undefined ? 'sending' : 'generating'}</span>
+      <span className="text-xs text-muted-foreground">
+        ({KeyboardSymbols.Command}
+        {KeyboardSymbols.Shift}
+        {KeyboardSymbols.Delete})
+      </span>
     </Button>
   );
 });


### PR DESCRIPTION
## Description
When the user submits a prompt, allow them to use a keyboard shortcut to stop the chat (uses the same keyboard combo that cursor users).

![CleanShot 2025-05-05 at 16 20 27@2x](https://github.com/user-attachments/assets/03a5acb3-53ed-4c81-bfa7-e4128a4f1296)

It's worth noting that this is tied to the chat prompt having focus. I'm not sure if we want to make this a global thing? When you submit a prompt, your focus remains in the prompt, so if you move it this actually won't work. Maybe that's ok and is a worthy tradeoff to making it global.