### PR TITLE
Reduce webhook feedback message limit 

### DIFF
--- a/quadratic-api/src/routes/v0/feedback.POST.ts
+++ b/quadratic-api/src/routes/v0/feedback.POST.ts
@@ -48,7 +48,7 @@ async function handler(req: RequestWithUser, res: express.Response) {
 
   // Post to Slack
   // SLACK_FEEDBACK_URL is the Quadratic product feedback slack app webhook URL
-  // We filter out spammy feedback by requiring at least 30 characters
+   // We filter out spammy feedback by requiring at least 15 characters
   if (SLACK_FEEDBACK_URL && feedback.length >= 15) {
     const payload = {
       text: [

--- a/quadratic-api/src/routes/v0/feedback.POST.ts
+++ b/quadratic-api/src/routes/v0/feedback.POST.ts
@@ -49,7 +49,7 @@ async function handler(req: RequestWithUser, res: express.Response) {
   // Post to Slack
   // SLACK_FEEDBACK_URL is the Quadratic product feedback slack app webhook URL
   // We filter out spammy feedback by requiring at least 30 characters
-  if (SLACK_FEEDBACK_URL && feedback.length >= 30) {
+  if (SLACK_FEEDBACK_URL && feedback.length >= 15) {
     const payload = {
       text: [
         `📣 ${NODE_ENV === 'production' ? '' : '[STAGING]'} New product feedback`,


### PR DESCRIPTION
## Description 

We're likely filtering out a lot of great feedback by having the min be 30 characters. 

E.g. "Please build secrets!" wouldn't make it through as that's only 20 characters. 