### PR TITLE
feat: show browser message to users not on Blink

### DIFF
--- a/quadratic-client/src/shared/components/EmptyPage.tsx
+++ b/quadratic-client/src/shared/components/EmptyPage.tsx
@@ -20,7 +20,7 @@ type EmptyPageProps = Exclude<EmptyStateProps, 'isError'> & {
  * Will displays context on the logged in user (if applicable/available)
  */
 export function EmptyPage(props: EmptyPageProps) {
-  const { error, title, description, source, Icon, actions } = props;
+  const { error, title, description, source, Icon, actions, showLoggedInUser } = props;
   const [loggedInUser, setLoggedInUser] = useState<User | undefined>(undefined);
   const submit = useSubmit();
 
@@ -59,7 +59,7 @@ export function EmptyPage(props: EmptyPageProps) {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center">
       <EmptyState title={title} description={description} actions={actions} Icon={Icon} isError={Boolean(error)} />
-      {loggedInUser && (
+      {loggedInUser && showLoggedInUser && (
         <div className="mx-auto mt-12 max-w-96 border-t border-border pt-2">
           <div className="mx-auto flex items-center gap-2 rounded-md pt-2 text-left text-sm">
             <Avatar src={loggedInUser.picture} alt={`Avatar for ${loggedInUser.name}`} className="flex-shrink-0">


### PR DESCRIPTION
## Relevant issue(s)
#2914 

## Description
For users who land on the app (not the dashboard, just the app), if they're using a browser that's not a Chromium-based browser, they'll see a message educating them that the app works best in a Chromium browser (with a link to our docs page on the subject).

They have the option to continue anyway (or reach out to us and tell us why we should support their use case).

![CleanShot 2025-05-13 at 15 55 35@2x](https://github.com/user-attachments/assets/42de1f27-5009-4d22-ae22-32e6b64d706c)

##  Testing considerations

Open a file in various browsers and ensure you either do or don't see this message. 

Should see the message:

- Safari
- Firefox

Should not see the message:

- Chrome
- Arc
- Brave
- Edge


Here's a publicly-viewable link so you don't have to login: