### PR TITLE
Better ensure visible handling

### DIFF
--- a/quadratic-client/src/app/grid/sheet/Sheet.ts
+++ b/quadratic-client/src/app/grid/sheet/Sheet.ts
@@ -159,7 +159,7 @@ export class Sheet {
   }
 
   // @returns screen rectangle from a selection rectangle
-  getScreenRectangleFromRect(rect: Rectangle): Rectangle {
+  getScreenRectangleFromRectangle(rect: Rectangle): Rectangle {
     return this.getScreenRectangle(rect.x, rect.y, rect.width, rect.height);
   }
 

--- a/quadratic-client/src/app/gridGL/UI/boxCells.ts
+++ b/quadratic-client/src/app/gridGL/UI/boxCells.ts
@@ -43,7 +43,7 @@ export class BoxCells extends Graphics {
 
   private drawRectangle(): void {
     if (!this.gridRectangle) return;
-    const screenRectangle = sheets.sheet.getScreenRectangleFromRect(this.gridRectangle);
+    const screenRectangle = sheets.sheet.getScreenRectangleFromRectangle(this.gridRectangle);
     this.dirty = false;
     this.clear();
     this.lineStyle({
@@ -70,7 +70,7 @@ export class BoxCells extends Graphics {
     this.lineStyle(0);
     this.deleteRectangles?.forEach((rectangle) => {
       this.beginFill(colors.boxCellsDeleteColor, colors.boxCellsAlpha);
-      const screenRectangle = sheets.sheet.getScreenRectangleFromRect(rectangle);
+      const screenRectangle = sheets.sheet.getScreenRectangleFromRectangle(rectangle);
       screenRectangle.height++;
       this.drawShape(screenRectangle);
       this.endFill();

--- a/quadratic-client/src/app/gridGL/helpers/zoom.ts
+++ b/quadratic-client/src/app/gridGL/helpers/zoom.ts
@@ -38,7 +38,7 @@ function clampZoom(center: Point, scale: number) {
 export function zoomToFit() {
   const gridBounds = sheets.sheet.getBounds(false);
   if (gridBounds) {
-    const screenRectangle = sheets.sheet.getScreenRectangleFromRect(gridBounds);
+    const screenRectangle = sheets.sheet.getScreenRectangleFromRectangle(gridBounds);
     const { screenWidth, screenHeight } = pixiApp.viewport;
     const headingSize = pixiApp.headings.headingSize;
 
@@ -86,7 +86,7 @@ export function zoomTo100() {
 export function zoomToSelection(): void {
   const sheet = sheets.sheet;
   const rectangle = sheet.cursor.getLargestRectangle();
-  const screenRectangle = sheet.getScreenRectangleFromRect(rectangle);
+  const screenRectangle = sheet.getScreenRectangleFromRectangle(rectangle);
   const headingSize = pixiApp.headings.headingSize;
 
   // calc scale, and leave a little room on the top and sides

--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerAutoComplete.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerAutoComplete.ts
@@ -39,7 +39,7 @@ export class PointerAutoComplete {
     if (intersects.rectanglePoint(pixiApp.cursor.indicator, world)) {
       this.active = true;
       events.emit('cellMoving', true);
-      this.screenSelection = sheet.getScreenRectangleFromRect(this.selection);
+      this.screenSelection = sheet.getScreenRectangleFromRectangle(this.selection);
       cursor.changeBoxCells(true);
 
       return true;

--- a/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
+++ b/quadratic-client/src/app/gridGL/interaction/viewportHelper.ts
@@ -128,6 +128,20 @@ function ensureCellIsNotUnderTableHeader(coordinate: JsCoordinate, cell: Rectang
   return false;
 }
 
+export function ensureSelectionVisible() {
+  const selection = sheets.sheet.cursor.getLargestRectangle();
+  const selectionBounds = sheets.sheet.getScreenRectangleFromRectangle(selection);
+  const bounds = pixiApp.viewport.getVisibleBounds();
+
+  // if any part of the selection is visible
+  if (intersects.rectangleRectangle(bounds, selectionBounds)) {
+    return true;
+  }
+  cellVisible(sheets.sheet.cursor.position);
+  pixiApp.viewportChanged();
+  return false;
+}
+
 // Makes a cell visible in the viewport
 export function cellVisible(
   coordinate: JsCoordinate = {
@@ -196,8 +210,12 @@ export function cellVisible(
 
 // Ensures the cursor is always visible
 export function ensureVisible(visible: JsCoordinate | undefined) {
-  if (!cellVisible(visible)) {
-    pixiApp.viewportChanged();
+  if (visible) {
+    if (!cellVisible(visible)) {
+      pixiApp.viewportChanged();
+    }
+  } else {
+    ensureSelectionVisible();
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2990

## Description
- [x] ensureVisible checks the entire selection to check if in bounds; doesn't move the viewport if any part of the selection is visible
- [ ] better cursor behavior when expanding