### PR TITLE
fix: add empty component to file/create route

### DIFF
--- a/quadratic-client/src/routes/files.create.tsx
+++ b/quadratic-client/src/routes/files.create.tsx
@@ -37,3 +37,7 @@ export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   });
   return redirect(redirectUrl);
 };
+
+export const Component = () => {
+  return null;
+};


### PR DESCRIPTION
adds empty Component to silence sentry errors