### PR TITLE
fix: save 'other' data for onboarding questions

### DIFF
--- a/quadratic-client/src/dashboard/onboarding/Questions.tsx
+++ b/quadratic-client/src/dashboard/onboarding/Questions.tsx
@@ -39,16 +39,19 @@ const isValidFormAtom = atom<boolean>({
 
 export const OnboardingResponseV1Schema = z.object({
   __version: z.literal(1),
+  __createdAt: z.string().datetime(),
   use: z.enum(['work', 'personal', 'education']),
   'work-role': z.string().optional(),
   'work-role-other': z.string().optional(),
   'personal-uses[]': z.array(z.string()).optional(),
-  'personal-uses-other': z.string().optional(),
+  'personal-uses[]-other': z.string().optional(),
   'education-identity': z.string().optional(),
   'education-identity-other': z.string().optional(),
   'education-subjects[]': z.array(z.string()).optional(),
+  'education-subjects[]-other': z.string().optional(),
   'languages[]': z.array(z.string()).optional(),
   'goals[]': z.array(z.string()),
+  'goals[]-other': z.string().optional(),
 });
 
 export type OnboardingResponseV1 = z.infer<typeof OnboardingResponseV1Schema>;

--- a/quadratic-client/src/dashboard/onboarding/getPrompt.test.ts
+++ b/quadratic-client/src/dashboard/onboarding/getPrompt.test.ts
@@ -7,6 +7,7 @@ describe('getPrompt', () => {
   it('should return a generic prompt when a work response is "other"', () => {
     const data: OnboardingResponseV1 = {
       __version: 1,
+      __createdAt: new Date().toISOString(),
       use: 'work',
       'work-role': 'other',
       'languages[]': ['javascript'],
@@ -20,6 +21,7 @@ describe('getPrompt', () => {
   it('should return a custom prompt when a work use response is pre-canned', () => {
     const data: OnboardingResponseV1 = {
       __version: 1,
+      __createdAt: new Date().toISOString(),
       use: 'work',
       'work-role': 'product',
       'languages[]': ['javascript'],
@@ -31,6 +33,7 @@ describe('getPrompt', () => {
   it('should return a custom prompt when a personal use response is pre-canned', () => {
     const data: OnboardingResponseV1 = {
       __version: 1,
+      __createdAt: new Date().toISOString(),
       use: 'personal',
       'personal-uses[]': ['ai', 'other'],
       'goals[]': ['ai'],
@@ -41,6 +44,7 @@ describe('getPrompt', () => {
   it('should return a custom prompt when a education use response is pre-canned', () => {
     const data: OnboardingResponseV1 = {
       __version: 1,
+      __createdAt: new Date().toISOString(),
       use: 'education',
       'education-identity': 'university-student',
       'education-subjects[]': ['math', 'other'],

--- a/quadratic-client/src/routes/onboarding.tsx
+++ b/quadratic-client/src/routes/onboarding.tsx
@@ -94,7 +94,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   // Parse and validate the payload against the v1 schema
-  const result = OnboardingResponseV1Schema.safeParse({ __version: 1, ...formJson });
+  const result = OnboardingResponseV1Schema.safeParse({
+    __version: 1,
+    __createdAt: new Date().toISOString(),
+    ...formJson,
+  });
 
   // Save the responses to the server and mixpanel and log any errors
   const sentryPromises: Promise<unknown>[] = [];


### PR DESCRIPTION
## Description

After rolling out #2945 and working on [the initial analysis of the data](https://app.quadratichq.com/file/6b74e60f-4fd6-4fe7-aefc-74105b6297f9?sheet=5912fbaf-434c-4015-be49-d08e8fd16f33), I realized two things:

1. I didn't properly implement saving responses for multiple-choice "other" answers
2. I didn't add any metadata around when the data was saved

So this has fixes for these issues. See more details below:

### 1. Multiple choice "other" responses

Multiple-choice answers that include "other" answers were not being saved correctly, e.g. if you did this:

![CleanShot 2025-06-03 at 14 35 28@2x](https://github.com/user-attachments/assets/8ee7ef6b-250f-47f0-8144-3beb99698322)

and you typed in an answer, whatever that freeform answer was is not being saved to the db/mixpanel. This is happening for "Other" answers to the following questions:

- Personal use: "What are you planning to use Quadratic for?"
- Education use: "What subject areas are you working in?"
- All: "What are you looking to accomplish in Quadratic?"

The fact that the user chose "Other" is being recorded, but not what their actual answer was (if they put one in).

This is happening because the keys weren't properly specified in the v1 schema for the 'other' answers and since zod is parsing/validating the answers before sending them to the server, the correct keys were being removed.

### 2. When the answer was saved metadata

Along with `__version` I added a key for `__createdAt` which will save a timestamp when the answer is submitted to the server.

## To Test

Fill out an answer for each of the following, making sure to check multiple boxes when "other" is an option along with multiple answers.

- [ ] Personal use, "What are you planning to use Quadratic for?" check multiple options, including "Other" and fill in a value
- [ ] Education use, "What subject areas are you working in?" check multiple options, including "Other" and fill in a value. Also for "Goals" check multiple options and fill in a value for "Other"

Then, when you submit the survey, turn the devtools on and check "preserve log" in the network tab, and ensure that all the values you submitted (including the free form "other" answers) are being sent over the network.

![CleanShot 2025-06-03 at 14 41 16@2x](https://github.com/user-attachments/assets/66b119ab-dcd4-408b-b5c7-3a82ffa6ff06)

