### PR TITLE
fix: display of text in prev user ai message

### DIFF
--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -232,59 +232,51 @@ export const AIUserMessageForm = memo(
           textareaRef={textareaRef}
         />
 
-        {editing ? (
-          <Textarea
-            ref={textareaRef}
-            value={prompt}
-            className={cn(
-              'rounded-none border-none p-2 pb-0 shadow-none focus-visible:ring-0',
-              editing ? 'min-h-14' : 'pointer-events-none h-fit min-h-fit',
-              waitingOnMessageIndex !== undefined && 'pointer-events-none opacity-50'
-            )}
-            onChange={(event) => setPrompt(event.target.value)}
-            onKeyDown={(event) => {
-              event.stopPropagation();
+        <Textarea
+          ref={textareaRef}
+          value={prompt}
+          className={cn(
+            'pointer-events-none min-h-14 rounded-none border-none p-2 pb-0 shadow-none focus-visible:ring-0',
+            (waitingOnMessageIndex !== undefined || showAIUsageExceeded) && 'pointer-events-none opacity-50'
+          )}
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            event.stopPropagation();
 
-              if (event.key === 'Enter' && !(event.ctrlKey || event.shiftKey)) {
-                event.preventDefault();
-                if (loading || waitingOnMessageIndex !== undefined) return;
-
-                submit(prompt);
-
-                if (initialContent === undefined) {
-                  textareaRef.current?.focus();
-                } else {
-                  setEditing(false);
-                  bottomTextareaRef.current?.focus();
-                }
-              } else if (event.key === 'Escape') {
-                if (initialContent === undefined) {
-                  focusGrid();
-                } else {
-                  setEditing(false);
-                  bottomTextareaRef.current?.focus();
-                }
-              }
-
+            if (event.key === 'Enter' && !(event.ctrlKey || event.shiftKey)) {
+              event.preventDefault();
               if (loading || waitingOnMessageIndex !== undefined) return;
 
-              if (formOnKeyDown) {
-                formOnKeyDown(event);
+              submit(prompt);
+
+              if (initialContent === undefined) {
+                textareaRef.current?.focus();
+              } else {
+                setEditing(false);
+                bottomTextareaRef.current?.focus();
               }
-            }}
-            autoComplete="off"
-            placeholder={waitingOnMessageIndex !== undefined ? 'Waiting to send message...' : 'Ask a question...'}
-            autoHeight={true}
-            maxHeight={maxHeight}
-            disabled={waitingOnMessageIndex !== undefined}
-          />
-        ) : (
-          <div
-            className={cn('pointer-events-none whitespace-pre-wrap p-2 text-sm', showAIUsageExceeded && 'opacity-50')}
-          >
-            {prompt}
-          </div>
-        )}
+            } else if (event.key === 'Escape') {
+              if (initialContent === undefined) {
+                focusGrid();
+              } else {
+                setEditing(false);
+                bottomTextareaRef.current?.focus();
+              }
+            }
+
+            if (loading || waitingOnMessageIndex !== undefined) return;
+
+            if (formOnKeyDown) {
+              formOnKeyDown(event);
+            }
+          }}
+          autoComplete="off"
+          placeholder={waitingOnMessageIndex !== undefined ? 'Waiting to send message...' : 'Ask a question...'}
+          autoHeight={true}
+          maxHeight={maxHeight}
+          readOnly={!editing}
+          disabled={waitingOnMessageIndex !== undefined}
+        />
 
         <AIUsageExceeded show={showAIUsageExceeded} delaySeconds={delaySeconds} />
 


### PR DESCRIPTION
## Description

Today if you have some text that's really long and wraps, it messes up the overflow and scrolling of the sheet chat.

https://github.com/user-attachments/assets/51af991a-ad43-486d-852c-747d87a9f054

It looks like this was happening because we're conditionally rendering a `<textarea>` or a `<div>` depending on whether the box is currently being edited. But divs will wrap things differently than textarea, so my thought is to just always render a textarea and just conditionally make it editable/focusable based on the `editing` state we were using previously.

This should make it so text always wraps correctly inside the textarea, as the browser handles that kind of stuff by default for a textarea primitive.

![CleanShot 2025-06-03 at 15 37 35@2x](https://github.com/user-attachments/assets/b2c10c53-760d-4d5e-bf01-425e72efb635)
