### PR TITLE
Properly clips tables with table names

### DIFF
--- a/quadratic-core/src/grid/sheet/rendering/cells.rs
+++ b/quadratic-core/src/grid/sheet/rendering/cells.rs
@@ -131,15 +131,14 @@ impl Sheet {
                     None,
                 ));
             } else if let Some(intersection) = code_rect.intersection(render_rect) {
-                let code_rect_start_y = code_rect.min.y + data_table.y_adjustment(false);
+                let code_rect_start_y = code_rect.min.y; // + data_table.y_adjustment(false);
 
                 for y in intersection.y_range() {
                     let is_header = data_table.get_show_columns() && y == code_rect_start_y - 1;
 
-                    // We skip rendering the header rows because we render it separately.
-                    if y < code_rect_start_y && !is_header {
-                        continue;
-                    }
+                    // We now render the header row to ensure clipping works
+                    // properly to the left of the header since we rely on the
+                    // renderer for clipping purposes
 
                     for x in intersection.x_range() {
                         let pos = Pos {


### PR DESCRIPTION
## Relevant issue(s)
Fixes #3053 

Proper clipping:
![CleanShot 2025-06-10 at 10 54 13@2x](https://github.com/user-attachments/assets/355e2350-23cc-4c22-bf1e-43e775e51371)
