### PR TITLE
Limits text rendering to 1000 characters

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -49,6 +49,9 @@ interface CharRenderData {
   prevSpaces: number;
 }
 
+// Maximum number of characters to render per cell
+const MAX_CHAR_LENGTH = 1000;
+
 // magic numbers to make the WebGL rendering of OpenSans look similar to the HTML version
 export const OPEN_SANS_FIX = { x: 1.8, y: -1.8 };
 
@@ -141,22 +144,28 @@ export class CellLabel {
   private columnHeader: boolean;
 
   private getText = (cell: JsRenderCell) => {
+    let text = '';
     switch (cell?.special) {
       case 'SpillError':
-        return SPILL_ERROR_TEXT;
+        text = SPILL_ERROR_TEXT;
+        break;
       case 'RunError':
-        return RUN_ERROR_TEXT;
+        text = RUN_ERROR_TEXT;
+        break;
       case 'Chart':
-        return '';
+        text = '';
+        break;
       default:
         if (cell.value !== undefined && cell.number) {
           this.number = cell.number;
-          return convertNumber(cell.value, cell.number).toUpperCase();
+          text = convertNumber(cell.value, cell.number).toUpperCase();
         } else {
           this.number = undefined;
-          return cell?.value;
+          text = cell?.value;
         }
     }
+    text = text.substring(0, MAX_CHAR_LENGTH);
+    return text;
   };
 
   get textRectangle() {

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -164,7 +164,9 @@ export class CellLabel {
           text = cell?.value;
         }
     }
-    text = text.substring(0, MAX_CHAR_LENGTH - 1) + '…';
+    if (text.length > MAX_CHAR_LENGTH) {
+        text = text.substring(0, MAX_CHAR_LENGTH - 1) + '…';
+    }
     return text;
   };
 

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -164,7 +164,7 @@ export class CellLabel {
           text = cell?.value;
         }
     }
-    text = text.substring(0, MAX_CHAR_LENGTH);
+    text = text.substring(0, MAX_CHAR_LENGTH - 1) + '…';
     return text;
   };
 

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -165,7 +165,7 @@ export class CellLabel {
         }
     }
     if (text.length > MAX_CHAR_LENGTH) {
-        text = text.substring(0, MAX_CHAR_LENGTH - 1) + '…';
+      text = text.substring(0, MAX_CHAR_LENGTH - 1) + '…';
     }
     return text;
   };


### PR DESCRIPTION
## Relevant issue(s)
Fixes #3056

## Description
Limits rendering to 1,000 characters per cell (doesn't change the value that `getCells` receives)