### PR TITLE
Code in tables

### DIFF
--- a/quadratic-client/src/app/grid/actions/openCodeEditor.ts
+++ b/quadratic-client/src/app/grid/actions/openCodeEditor.ts
@@ -41,8 +41,8 @@ export const openCodeEditor = async () => {
         ...codeEditorState,
         escapePressed: true,
       });
-    } else if (codeCell.language === 'Import') {
-      pixiAppSettings.snackbar('Cannot create code cell inside table', { severity: 'error' });
+      // } else if (codeCell.language === 'Import') {
+      //   pixiAppSettings.snackbar('Cannot create code cell inside table', { severity: 'error' });
     } else {
       // if the code editor is not already open on the same cell, then open it
       // this will also open the save changes modal if there are unsaved changes

--- a/quadratic-client/src/app/grid/controller/Sheets.ts
+++ b/quadratic-client/src/app/grid/controller/Sheets.ts
@@ -431,8 +431,18 @@ export class Sheets {
     return A1SelectionToJsSelection(a1);
   };
 
-  cellRefRangeToRefRangeBounds = (cellRefRange: CellRefRange, isPython: boolean): RefRangeBounds => {
-    return cellRefRangeToRefRangeBounds(JSON.stringify(cellRefRange, bigIntReplacer), isPython, this.jsA1Context);
+  cellRefRangeToRefRangeBounds = (
+    cellRefRange: CellRefRange,
+    isPython: boolean,
+    sourceCell?: JsCoordinate
+  ): RefRangeBounds => {
+    return cellRefRangeToRefRangeBounds(
+      JSON.stringify(cellRefRange, bigIntReplacer),
+      isPython,
+      this.jsA1Context,
+      sourceCell?.x,
+      sourceCell?.y
+    );
   };
 
   selectionToSheetRect = (sheetId: string, selection: string): string => {

--- a/quadratic-client/src/app/grid/controller/Sheets.ts
+++ b/quadratic-client/src/app/grid/controller/Sheets.ts
@@ -5,6 +5,7 @@ import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import type {
   A1Selection,
   CellRefRange,
+  JsCoordinate,
   JsOffset,
   JsTableInfo,
   Rect,

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorFormula.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorFormula.ts
@@ -29,7 +29,7 @@ class InlineEditorFormula {
       this.clearDecorations();
       return;
     }
-    pixiApp.cellHighlights.fromCellsAccessed(parseResult.cells_accessed, false);
+    pixiApp.cellHighlights.fromCellsAccessed(location, parseResult.cells_accessed, false);
 
     const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
     const cellColorReferences = new Map<string, number>();

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
@@ -212,11 +212,11 @@ class InlineEditorHandler {
         }
       }
 
-      if (this.codeCell?.language === 'Import' && changeToFormula) {
-        pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
-        this.closeIfOpen();
-        return;
-      }
+      // if (this.codeCell?.language === 'Import' && changeToFormula) {
+      //   pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
+      //   this.closeIfOpen();
+      //   return;
+      // }
 
       if (cursorMode === undefined) {
         if (changeToFormula) {
@@ -396,11 +396,11 @@ class InlineEditorHandler {
     if (!pixiAppSettings.setInlineEditorState) {
       throw new Error('Expected pixiAppSettings.setInlineEditorState to be defined in InlineEditorHandler');
     }
-    if (this.codeCell?.language === 'Import' && formula) {
-      pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
-      this.closeIfOpen();
-      return;
-    }
+    // if (this.codeCell?.language === 'Import' && formula) {
+    //   pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
+    //   this.closeIfOpen();
+    //   return;
+    // }
     this.formula = formula;
     if (formula) {
       inlineEditorMonaco.setLanguage('Formula');

--- a/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
+++ b/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
@@ -6,7 +6,7 @@ import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import { drawDashedRectangle, drawDashedRectangleMarching } from '@/app/gridGL/UI/cellHighlights/cellHighlightsDraw';
 import { FILL_SELECTION_ALPHA } from '@/app/gridGL/UI/Cursor';
 import { convertColorStringToTint } from '@/app/helpers/convertColor';
-import type { CellRefRange, JsCellsAccessed, RefRangeBounds } from '@/app/quadratic-core-types';
+import type { CellRefRange, JsCellsAccessed, JsCoordinate, RefRangeBounds } from '@/app/quadratic-core-types';
 import { colors } from '@/app/theme/colors';
 import { Container, Graphics } from 'pixi.js';
 
@@ -56,10 +56,11 @@ export class CellHighlights extends Container {
 
   private convertCellRefRangeToRefRangeBounds(
     cellRefRange: CellRefRange,
-    isPython: boolean
+    isPython: boolean,
+    sourceCell: JsCoordinate
   ): RefRangeBounds | undefined {
     try {
-      return sheets.cellRefRangeToRefRangeBounds(cellRefRange, isPython);
+      return sheets.cellRefRangeToRefRangeBounds(cellRefRange, isPython, sourceCell);
     } catch (e) {
       console.log(`Error converting CellRefRange to RefRangeBounds: ${e}`);
     }

--- a/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
+++ b/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
@@ -7,7 +7,6 @@ import { drawDashedRectangle, drawDashedRectangleMarching } from '@/app/gridGL/U
 import { FILL_SELECTION_ALPHA } from '@/app/gridGL/UI/Cursor';
 import { convertColorStringToTint } from '@/app/helpers/convertColor';
 import type { CellRefRange, JsCellsAccessed, JsCoordinate, RefRangeBounds } from '@/app/quadratic-core-types';
-import type { SheetPosTS } from '@/app/shared/types/size';
 import { colors } from '@/app/theme/colors';
 import { Container, Graphics } from 'pixi.js';
 
@@ -23,7 +22,7 @@ export class CellHighlights extends Container {
   private march = 0;
   private marchLastTime = 0;
   private isPython = false;
-  private location?: SheetPosTS;
+  private location?: JsCoordinate;
 
   dirty = false;
 
@@ -59,7 +58,7 @@ export class CellHighlights extends Container {
   private convertCellRefRangeToRefRangeBounds(
     cellRefRange: CellRefRange,
     isPython: boolean,
-    sourceCell: JsCoordinate
+    sourceCell?: JsCoordinate
   ): RefRangeBounds | undefined {
     try {
       return sheets.cellRefRangeToRefRangeBounds(cellRefRange, isPython, sourceCell);
@@ -160,7 +159,7 @@ export class CellHighlights extends Container {
     return this.dirty || inlineEditorHandler.cursorIsMoving;
   };
 
-  fromCellsAccessed = (location: SheetPosTS, cellsAccessed: JsCellsAccessed[] | null, isPython: boolean) => {
+  fromCellsAccessed = (location: JsCoordinate, cellsAccessed: JsCellsAccessed[] | null, isPython: boolean) => {
     this.location = location;
     this.cellsAccessed = cellsAccessed ?? [];
     this.isPython = isPython;

--- a/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
+++ b/quadratic-client/src/app/gridGL/UI/cellHighlights/CellHighlights.ts
@@ -7,6 +7,7 @@ import { drawDashedRectangle, drawDashedRectangleMarching } from '@/app/gridGL/U
 import { FILL_SELECTION_ALPHA } from '@/app/gridGL/UI/Cursor';
 import { convertColorStringToTint } from '@/app/helpers/convertColor';
 import type { CellRefRange, JsCellsAccessed, JsCoordinate, RefRangeBounds } from '@/app/quadratic-core-types';
+import type { SheetPosTS } from '@/app/shared/types/size';
 import { colors } from '@/app/theme/colors';
 import { Container, Graphics } from 'pixi.js';
 
@@ -22,6 +23,7 @@ export class CellHighlights extends Container {
   private march = 0;
   private marchLastTime = 0;
   private isPython = false;
+  private location?: SheetPosTS;
 
   dirty = false;
 
@@ -78,7 +80,7 @@ export class CellHighlights extends Container {
       if (inlineEditorHandler.cursorIsMoving && index === this.selectedCellIndex) return;
 
       ranges.forEach((range, i) => {
-        const refRangeBounds = this.convertCellRefRangeToRefRangeBounds(range, this.isPython);
+        const refRangeBounds = this.convertCellRefRangeToRefRangeBounds(range, this.isPython, this.location);
         if (refRangeBounds) {
           drawDashedRectangle({
             g: this.highlights,
@@ -158,7 +160,8 @@ export class CellHighlights extends Container {
     return this.dirty || inlineEditorHandler.cursorIsMoving;
   };
 
-  fromCellsAccessed = (cellsAccessed: JsCellsAccessed[] | null, isPython: boolean) => {
+  fromCellsAccessed = (location: SheetPosTS, cellsAccessed: JsCellsAccessed[] | null, isPython: boolean) => {
+    this.location = location;
     this.cellsAccessed = cellsAccessed ?? [];
     this.isPython = isPython;
     this.dirty = true;

--- a/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
@@ -78,40 +78,39 @@ export async function doubleClickCell(options: {
       // editing inside data table
       else if (hasPermission && file_import) {
         // can't create formula inside data table
-        if (cell?.startsWith('=')) {
-          pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
-        }
+        // if (cell?.startsWith('=')) {
+        //   pixiAppSettings.snackbar('Cannot create formula inside table', { severity: 'error' });
+        // }
 
         // check column header or table value
-        else {
-          const isSpillOrError =
-            codeCell.spill_error || codeCell.state === 'RunError' || codeCell.state === 'SpillError';
-          const isTableName = codeCell.show_name && row === codeCell.y;
-          const isColumnHeader = codeCell.show_columns && row === codeCell.y + (codeCell.show_name ? 1 : 0);
+        // else {
+        const isSpillOrError = codeCell.spill_error || codeCell.state === 'RunError' || codeCell.state === 'SpillError';
+        const isTableName = codeCell.show_name && row === codeCell.y;
+        const isColumnHeader = codeCell.show_columns && row === codeCell.y + (codeCell.show_name ? 1 : 0);
 
-          if (isSpillOrError) {
-            return;
-          } else if (isTableName) {
-            events.emit('contextMenu', {
-              type: ContextMenuType.Table,
-              table: codeCell,
-              rename: true,
-              column: codeCell.x,
-              row: codeCell.y,
-            });
-          } else if (isColumnHeader) {
-            const contextMenu = {
-              type: ContextMenuType.TableColumn,
-              rename: true,
-              table: codeCell,
-              selectedColumn: Math.max(0, column - codeCell.x),
-              initialValue: cell,
-            };
-            events.emit('contextMenu', contextMenu);
-          } else {
-            pixiAppSettings.changeInput(true, cell, cursorMode);
-          }
+        if (isSpillOrError) {
+          return;
+        } else if (isTableName) {
+          events.emit('contextMenu', {
+            type: ContextMenuType.Table,
+            table: codeCell,
+            rename: true,
+            column: codeCell.x,
+            row: codeCell.y,
+          });
+        } else if (isColumnHeader) {
+          const contextMenu = {
+            type: ContextMenuType.TableColumn,
+            rename: true,
+            table: codeCell,
+            selectedColumn: Math.max(0, column - codeCell.x),
+            initialValue: cell,
+          };
+          events.emit('contextMenu', contextMenu);
+        } else {
+          pixiAppSettings.changeInput(true, cell, cursorMode);
         }
+        // }
       } else {
         pixiAppSettings.setCodeEditorState({
           ...pixiAppSettings.codeEditorState,

--- a/quadratic-client/src/app/quadratic-core-types/index.d.ts
+++ b/quadratic-client/src/app/quadratic-core-types/index.d.ts
@@ -173,7 +173,7 @@ start: number,
  * The byte index after the last character.
  */
 end: number, };
-export type TableRef = { table_name: string, data: boolean, headers: boolean, totals: boolean, col_range: ColRange, };
+export type TableRef = { table_name: string, data: boolean, headers: boolean, totals: boolean, col_range: ColRange, this_row: boolean, };
 export type TextCase = { "CaseInsensitive": Array<string> } | { "CaseSensitive": Array<string> };
 export type TextMatch = { "Exactly": TextCase } | { "Contains": TextCase } | { "NotContains": TextCase } | { "TextLength": { min: number | null, max: number | null, } };
 export type TransactionName = "Unknown" | "ResizeColumn" | "ResizeRow" | "ResizeRows" | "ResizeColumns" | "Autocomplete" | "SetBorders" | "SetCells" | "SetFormats" | "SetDataTableAt" | "CutClipboard" | "PasteClipboard" | "SetCode" | "RunCode" | "FlattenDataTable" | "SwitchDataTableKind" | "GridToDataTable" | "DataTableMeta" | "DataTableMutations" | "DataTableFirstRowAsHeader" | "DataTableAddDataTable" | "Import" | "SetSheetMetadata" | "SheetAdd" | "SheetDelete" | "DuplicateSheet" | "MoveCells" | "Validation" | "ManipulateColumnRow";

--- a/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useEditorCellHighlights.ts
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useEditorCellHighlights.ts
@@ -65,7 +65,11 @@ export const useEditorCellHighlights = (
         codeCell.language === 'Javascript' ||
         codeCellIsAConnection(codeCell.language)
       ) {
-        pixiApp.cellHighlights.fromCellsAccessed(unsavedChanges ? null : cellsAccessed, codeCell.language === 'Python');
+        pixiApp.cellHighlights.fromCellsAccessed(
+          codeCell.pos,
+          unsavedChanges ? null : cellsAccessed,
+          codeCell.language === 'Python'
+        );
       } else if (codeCell.language === 'Formula') {
         let parsed: JsFormulaParseResult;
         try {
@@ -75,7 +79,7 @@ export const useEditorCellHighlights = (
           return;
         }
 
-        pixiApp.cellHighlights.fromCellsAccessed(parsed.cells_accessed, false);
+        pixiApp.cellHighlights.fromCellsAccessed(codeCell.pos, parsed.cells_accessed, false);
 
         parsed.spans.forEach((span, index) => {
           const cellRef = parsed.cells_accessed[index];
@@ -121,6 +125,7 @@ export const useEditorCellHighlights = (
   }, [
     cellsAccessed,
     codeCell.language,
+    codeCell.pos,
     codeCell.pos.x,
     codeCell.pos.y,
     codeCell.sheetId,

--- a/quadratic-core/src/a1/a1_selection/create.rs
+++ b/quadratic-core/src/a1/a1_selection/create.rs
@@ -88,6 +88,7 @@ impl A1Selection {
                     headers: false,
                     totals: false,
                     col_range: ColRange::All,
+                    this_row: false,
                 },
             }],
         }
@@ -151,6 +152,7 @@ impl A1Selection {
                             headers: false,
                             totals: false,
                             col_range: range,
+                            this_row: false,
                         },
                     })
                     .collect(),

--- a/quadratic-core/src/a1/a1_selection/exclude.rs
+++ b/quadratic-core/src/a1/a1_selection/exclude.rs
@@ -108,7 +108,7 @@ impl A1Selection {
             }
             CellRefRange::Table { range } => {
                 if let Some(table_range) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     ranges.extend(A1Selection::find_excluded_rects(table_range, exclude_rect));
                 }

--- a/quadratic-core/src/a1/a1_selection/intersects.rs
+++ b/quadratic-core/src/a1/a1_selection/intersects.rs
@@ -38,7 +38,7 @@ impl A1Selection {
             }
             CellRefRange::Table { range } => {
                 if let Some(range) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     other
                         .ranges

--- a/quadratic-core/src/a1/a1_selection/query.rs
+++ b/quadratic-core/src/a1/a1_selection/query.rs
@@ -203,7 +203,7 @@ impl A1Selection {
                 CellRefRange::Table { range } => {
                     let name = range.table_name.clone();
                     if let Some(range) =
-                        range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                        range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                     {
                         if self.cursor.x == range.end.col() && self.cursor.y == range.end.row() {
                             // we adjust the y to step over the table name so we
@@ -491,7 +491,7 @@ impl A1Selection {
                     }
                 }
                 CellRefRange::Table { range } => {
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 }
             })
             .collect()
@@ -624,8 +624,8 @@ impl A1Selection {
             .filter_map(|range| match range {
                 CellRefRange::Table { range: table_range } => {
                     if table_range.table_name == *table_name {
-                        if let Some(new_range) =
-                            table_range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                        if let Some(new_range) = table_range
+                            .convert_to_ref_range_bounds(false, a1_context, false, false, None)
                         {
                             found = true;
                             Some(CellRefRange::Sheet { range: new_range })
@@ -657,7 +657,7 @@ impl A1Selection {
             .iter()
             .filter_map(|range| match range {
                 CellRefRange::Table { range } => range
-                    .convert_to_ref_range_bounds(false, a1_context, false, true)
+                    .convert_to_ref_range_bounds(false, a1_context, false, true, None)
                     .map(|range| CellRefRange::Sheet { range }),
                 _ => Some(range.clone()),
             })

--- a/quadratic-core/src/a1/a1_selection/select.rs
+++ b/quadratic-core/src/a1/a1_selection/select.rs
@@ -410,7 +410,7 @@ impl A1Selection {
                     }
                     if let Some(mut range_converted) = range
                         .clone()
-                        .convert_to_ref_range_bounds(false, a1_context, false, false)
+                        .convert_to_ref_range_bounds(false, a1_context, false, false, None)
                     {
                         // if cursor is at the end of the table, then reverse the selection
                         if self.cursor.x == range_converted.end.col()
@@ -459,7 +459,7 @@ impl A1Selection {
             CellRefRange::Sheet { range } => *range,
             CellRefRange::Table { range } => {
                 if let Some(range) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     range
                 } else {
@@ -486,7 +486,7 @@ impl A1Selection {
             CellRefRange::Sheet { range } => *range,
             CellRefRange::Table { range } => {
                 if let Some(range) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     range
                 } else {

--- a/quadratic-core/src/a1/a1_selection/select_table.rs
+++ b/quadratic-core/src/a1/a1_selection/select_table.rs
@@ -39,6 +39,7 @@ impl A1Selection {
                                     headers: false,
                                     totals: false,
                                     col_range: ColRange::ColRange(start.clone(), col.clone()),
+                                    this_row: false,
                                 };
                                 self.ranges.push(CellRefRange::Table { range: table_ref });
                                 return;
@@ -69,6 +70,7 @@ impl A1Selection {
                                     } else {
                                         ColRange::ColRange(existing_col.clone(), col.clone())
                                     },
+                                    this_row: false,
                                 };
                                 self.ranges.push(CellRefRange::Table { range: table_ref });
                                 return;
@@ -84,6 +86,7 @@ impl A1Selection {
                                         headers: false,
                                         totals: false,
                                         col_range: ColRange::Col(col.clone()),
+                                        this_row: false,
                                     };
                                     self.ranges.push(CellRefRange::Table { range: table_ref });
                                     return;
@@ -97,6 +100,7 @@ impl A1Selection {
                                             existing_col.clone(),
                                             col.clone(),
                                         ),
+                                        this_row: false,
                                     };
                                     self.ranges.push(CellRefRange::Table { range: table_ref });
                                     return;
@@ -190,6 +194,7 @@ impl A1Selection {
             headers,
             totals: false,
             col_range,
+            this_row: false,
         };
         let table_ref = CellRefRange::Table { range: table_ref };
 
@@ -260,6 +265,7 @@ mod tests {
             headers: false,
             totals: false,
             col_range: ColRange::Col("Col1".to_string()),
+            this_row: false,
         };
         assert_eq!(
             selection.ranges[0],
@@ -332,6 +338,7 @@ mod tests {
             headers: false,
             totals: false,
             col_range: ColRange::All,
+            this_row: false,
         };
         assert_eq!(selection.ranges.len(), 2);
         assert_eq!(

--- a/quadratic-core/src/a1/cell_ref_range/query.rs
+++ b/quadratic-core/src/a1/cell_ref_range/query.rs
@@ -68,7 +68,7 @@ impl CellRefRange {
                 }
             }
             Self::Table { range } => range
-                .convert_to_ref_range_bounds(false, a1_context, false, false)
+                .convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 .is_some_and(|range| {
                     if let Some(p2) = p2 {
                         range.start.is_pos(p1) && range.end.is_pos(p2)

--- a/quadratic-core/src/a1/cell_ref_range/to_table_ref.rs
+++ b/quadratic-core/src/a1/cell_ref_range/to_table_ref.rs
@@ -56,6 +56,7 @@ impl CellRefRange {
                             data: true,
                             headers: false,
                             totals: false,
+                            this_row: false,
                         },
                     });
                 }
@@ -68,6 +69,7 @@ impl CellRefRange {
                             data: true,
                             headers: false,
                             totals: false,
+                            this_row: false,
                         },
                     });
                 }
@@ -103,6 +105,7 @@ impl CellRefRange {
                             data: true,
                             headers: false,
                             totals: false,
+                            this_row: false,
                         },
                     });
                 }
@@ -116,6 +119,7 @@ impl CellRefRange {
                             data: true,
                             headers: false,
                             totals: false,
+                            this_row: false,
                         },
                     });
                 }
@@ -132,6 +136,7 @@ impl CellRefRange {
                             data: true,
                             headers: true,
                             totals: false,
+                            this_row: false,
                         },
                     });
                 }
@@ -165,6 +170,7 @@ mod tests {
                     data: true,
                     headers: true,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -190,6 +196,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -215,6 +222,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -233,6 +241,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -258,6 +267,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -283,6 +293,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );
@@ -363,6 +374,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 },
             })
         );

--- a/quadratic-core/src/a1/js_selection/query.rs
+++ b/quadratic-core/src/a1/js_selection/query.rs
@@ -114,7 +114,13 @@ impl JsSelection {
                     {
                         return None;
                     }
-                    range.convert_to_ref_range_bounds(false, context.get_context(), false, true)
+                    range.convert_to_ref_range_bounds(
+                        false,
+                        context.get_context(),
+                        false,
+                        true,
+                        None,
+                    )
                 }
             })
             .collect::<Vec<_>>();

--- a/quadratic-core/src/a1/ref_range_bounds/delete.rs
+++ b/quadratic-core/src/a1/ref_range_bounds/delete.rs
@@ -23,7 +23,7 @@ impl RefRangeBounds {
             CellRefRange::Sheet { range } => self.delete_ref_range_bounds(range),
             CellRefRange::Table { range } => {
                 if let Some(bounds) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     self.delete_ref_range_bounds(&bounds)
                 } else {

--- a/quadratic-core/src/a1/table_ref/delete.rs
+++ b/quadratic-core/src/a1/table_ref/delete.rs
@@ -10,7 +10,9 @@ impl TableRef {
     ) -> Vec<CellRefRange> {
         // first return self if there is no overlap (or we can't calculate the
         // rect)
-        if let Some(bounds) = self.convert_to_ref_range_bounds(false, a1_context, false, false) {
+        if let Some(bounds) =
+            self.convert_to_ref_range_bounds(false, a1_context, false, false, None)
+        {
             if bounds.intersection(to_delete).is_some() {
                 let remaining =
                     A1Selection::find_excluded_rects(bounds, to_delete.to_rect_unbounded());
@@ -48,7 +50,7 @@ impl TableRef {
             CellRefRange::Sheet { range } => self.delete_ref_range_bounds(range, a1_context),
             CellRefRange::Table { range } => {
                 if let Some(range) =
-                    range.convert_to_ref_range_bounds(false, a1_context, false, false)
+                    range.convert_to_ref_range_bounds(false, a1_context, false, false, None)
                 {
                     self.delete_ref_range_bounds(&range, a1_context)
                 } else {
@@ -120,6 +122,7 @@ mod tests {
                 data: true,
                 headers: false,
                 totals: false,
+                this_row: false,
             }
         );
     }
@@ -140,6 +143,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 }
             }
         );
@@ -152,6 +156,7 @@ mod tests {
                     data: true,
                     headers: false,
                     totals: false,
+                    this_row: false,
                 }
             }
         );
@@ -191,6 +196,7 @@ mod tests {
                 data: true,
                 headers: false,
                 totals: false,
+                this_row: false,
             }
         );
     }

--- a/quadratic-core/src/a1/table_ref/display.rs
+++ b/quadratic-core/src/a1/table_ref/display.rs
@@ -33,6 +33,9 @@ impl fmt::Display for TableRef {
                 if self.totals {
                     entries.push("[#TOTALS]".to_string());
                 }
+                if self.this_row {
+                    entries.push("[#THIS ROW]".to_string());
+                }
             }
         }
         if entries.is_empty() && matches!(self.col_range, ColRange::Col(_)) {
@@ -80,6 +83,7 @@ mod tests {
             "Table1[[#HEADERS],[Column 3]:[Column 4]]",
             "Table1[[#HEADERS],[Column 3]:]",
             "Table1[[#DATA],[#HEADERS],[Column 1]]",
+            "Table1[[#THIS ROW],[Column 1]]",
         ];
 
         for test in tests {
@@ -87,5 +91,21 @@ mod tests {
                 .unwrap_or_else(|e| panic!("Failed to parse {}: {}", test, e));
             assert_eq!(table_ref.to_string(), test, "{}", test);
         }
+    }
+
+    #[test]
+    fn test_to_string_this_row() {
+        let context = A1Context::test(
+            &[],
+            &[(
+                "Table1",
+                &["Column 1", "Column 2", "Column 3", "Column 4"],
+                Rect::test_a1("A1"),
+            )],
+        );
+
+        let table_ref = TableRef::parse("Table1[@Column 1]", &context)
+            .unwrap_or_else(|e| panic!("Failed to parse Table1[@Column 1]: {}", e));
+        assert_eq!(table_ref.to_string(), "Table1[[#THIS ROW],[Column 1]]");
     }
 }

--- a/quadratic-core/src/a1/table_ref/intersects.rs
+++ b/quadratic-core/src/a1/table_ref/intersects.rs
@@ -50,6 +50,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
         // Intersecting rectangle
@@ -68,6 +69,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
         // Position within column A

--- a/quadratic-core/src/a1/table_ref/mod.rs
+++ b/quadratic-core/src/a1/table_ref/mod.rs
@@ -17,10 +17,8 @@
 //! - Table1[[#HEADERS], [#DATA]] - table headers and data across entire table
 //! - Table1 or Table1[#DATA] - table data without headers or totals
 //! - Table1[[Column1]:] - column 1 onward (Excel does not have this)
+//! - Table1[@Column1] or Table1[[#This Row],[Column 1]] or Table1[[@],[Column 1]]- this row for Column 1
 //! - (not yet supported) Table1[[#TOTALS], [Column 1]] - reference the total line
-//!
-//! Note Table1[#THIS ROW] and Table1[@Column 1] are not supported (supported in
-//! Excel but not Google Sheets either)
 //!
 //! For purposes of data frames, we'll probably ignore #DATA, since we want to
 //! define the data frame with the headers.
@@ -70,6 +68,7 @@ pub struct TableRef {
     pub headers: bool,
     pub totals: bool,
     pub col_range: ColRange,
+    pub this_row: bool,
 }
 
 impl TableRef {
@@ -80,6 +79,7 @@ impl TableRef {
             headers: false,
             totals: false,
             col_range: ColRange::All,
+            this_row: false,
         }
     }
 
@@ -120,6 +120,7 @@ mod tests {
                 headers: false,
                 totals: false,
                 col_range: ColRange::All,
+                this_row: false,
             }
         );
     }

--- a/quadratic-core/src/a1/table_ref/parse.rs
+++ b/quadratic-core/src/a1/table_ref/parse.rs
@@ -41,6 +41,7 @@ impl TableRef {
                 headers: false,
                 totals: false,
                 col_range: ColRange::All,
+                this_row: false,
             });
         }
 
@@ -48,6 +49,7 @@ impl TableRef {
         let mut data = None;
         let mut headers = false;
         let mut totals = false;
+        let mut this_row = false;
 
         for token in Self::tokenize(remaining)? {
             match token {
@@ -118,6 +120,7 @@ impl TableRef {
             headers,
             totals,
             col_range: col_range.unwrap_or(ColRange::All),
+            this_row: false,
         })
     }
 }

--- a/quadratic-core/src/a1/table_ref/query.rs
+++ b/quadratic-core/src/a1/table_ref/query.rs
@@ -205,7 +205,7 @@ impl TableRef {
 
     /// Tries to convert the TableRef to a Pos.
     pub fn try_to_pos(&self, a1_context: &A1Context) -> Option<Pos> {
-        let range = self.convert_to_ref_range_bounds(false, a1_context, false, false)?;
+        let range = self.convert_to_ref_range_bounds(false, a1_context, false, false, None)?;
         range.try_to_pos()
     }
 
@@ -302,6 +302,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
         let cols = table_ref.selected_cols(1, 3, &context);
@@ -317,6 +318,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols(1, 3, &context);
 
@@ -343,6 +345,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(!table_ref.is_multi_cursor(&context));
 
@@ -361,6 +364,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_multi_cursor(&context));
 
@@ -371,6 +375,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_multi_cursor(&context));
 
@@ -381,6 +386,7 @@ mod tests {
             data: false,
             headers: true,
             totals: false,
+            this_row: false,
         };
         assert!(!table_ref.is_multi_cursor(&context));
     }
@@ -394,6 +400,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
         let rect = table_ref.to_largest_rect(&context);
@@ -418,9 +425,10 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
-        let ranges = table_ref.convert_to_ref_range_bounds(false, &context, false, false);
+        let ranges = table_ref.convert_to_ref_range_bounds(false, &context, false, false, None);
         assert_eq!(ranges, Some(RefRangeBounds::test_a1("B3:B4")));
 
         // Column to end
@@ -430,9 +438,10 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
-        let ranges = table_ref.convert_to_ref_range_bounds(false, &context, false, false);
+        let ranges = table_ref.convert_to_ref_range_bounds(false, &context, false, false, None);
         assert_eq!(ranges, Some(RefRangeBounds::test_a1("B3:C4")));
     }
 
@@ -445,6 +454,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(!table_ref.is_two_dimensional());
 
@@ -455,6 +465,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_two_dimensional());
 
@@ -465,6 +476,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_two_dimensional());
     }
@@ -478,6 +490,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert_eq!(table_ref.try_to_pos(&context), Some(pos![B3]));
     }
@@ -491,6 +504,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert_eq!(table_ref.cursor_pos_from_last_range(&context), pos![A2]);
 
@@ -517,6 +531,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
 
         // Test all columns
@@ -530,6 +545,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.table_column_selection("test_table", &context);
         assert_eq!(cols, Some(vec![1]));
@@ -541,6 +557,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.table_column_selection("test_table", &context);
         assert_eq!(cols, Some(vec![0, 1]));
@@ -552,6 +569,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.table_column_selection("test_table", &context);
         assert_eq!(cols, Some(vec![1, 2]));
@@ -563,6 +581,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.table_column_selection("different_table", &context);
         assert_eq!(cols, None);
@@ -579,6 +598,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols_finite(&context);
         assert_eq!(cols, vec![1, 2, 3]);
@@ -590,6 +610,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols_finite(&context);
         assert_eq!(cols, vec![2]);
@@ -601,6 +622,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols_finite(&context);
         assert_eq!(cols, vec![1, 2]);
@@ -615,6 +637,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
 
         // Test normal range
@@ -628,6 +651,7 @@ mod tests {
             data: false,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let rows = table_ref.selected_rows(1, 5, &context);
         assert_eq!(rows, vec![2]);
@@ -639,6 +663,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let rows = table_ref.selected_rows(10, 15, &context);
         assert_eq!(rows, Vec::<i64>::new());
@@ -655,6 +680,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let rows = table_ref.selected_rows_finite(&context);
         assert_eq!(rows, vec![3]);
@@ -666,6 +692,7 @@ mod tests {
             data: false,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let rows = table_ref.selected_rows_finite(&context);
         assert_eq!(rows, vec![2]);
@@ -682,6 +709,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols(4, 6, &context); // Beyond table bounds
         assert_eq!(cols, Vec::<i64>::new());
@@ -693,6 +721,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols(1, 3, &context);
         assert_eq!(cols, Vec::<i64>::new());
@@ -704,6 +733,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let cols = table_ref.selected_cols(1, 3, &context);
         assert_eq!(cols, Vec::<i64>::new());
@@ -727,6 +757,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_multi_cursor(&context));
 
@@ -744,6 +775,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.is_multi_cursor(&context));
 
@@ -758,6 +790,7 @@ mod tests {
             data: false,
             headers: true,
             totals: false,
+            this_row: false,
         };
         assert!(!table_ref.is_multi_cursor(&context));
     }
@@ -773,6 +806,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let rect = table_ref.to_largest_rect(&context);
         assert_eq!(rect.unwrap(), Rect::test_a1("B3:C3"));
@@ -785,6 +819,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         let rect = table_ref.to_largest_rect(&context);
         assert_eq!(rect.unwrap(), Rect::test_a1("A3:C3"));
@@ -796,6 +831,7 @@ mod tests {
             data: true,
             headers: false,
             totals: false,
+            this_row: false,
         };
         assert!(table_ref.to_largest_rect(&context).is_none());
     }
@@ -809,6 +845,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
 
         // Test when show_ui is false
@@ -840,6 +877,7 @@ mod tests {
             data: true,
             headers: true,
             totals: false,
+            this_row: false,
         };
         let table = context.table_map.try_table_mut("test_table").unwrap();
         table.show_columns = true;

--- a/quadratic-core/src/a1/table_ref/tokenize.rs
+++ b/quadratic-core/src/a1/table_ref/tokenize.rs
@@ -126,6 +126,7 @@ impl TableRef {
                 "#TOTALS" => tokens.push(Token::Totals),
                 "#ALL" => tokens.push(Token::All),
                 "#THIS ROW" => tokens.push(Token::ThisRow),
+                // TODO: START HERE ***
                 ":" => return Err(A1Error::InvalidTableRef("Unexpected colon".into())),
                 _ => {
                     let s = entry.as_str();

--- a/quadratic-core/src/a1/table_ref/tokenize.rs
+++ b/quadratic-core/src/a1/table_ref/tokenize.rs
@@ -11,6 +11,7 @@ pub(crate) enum Token {
     Column(String),
     ColumnRange(String, String),
     ColumnToEnd(String),
+    ThisRow,
 }
 
 impl TableRef {
@@ -124,6 +125,7 @@ impl TableRef {
                 "#DATA" => tokens.push(Token::Data),
                 "#TOTALS" => tokens.push(Token::Totals),
                 "#ALL" => tokens.push(Token::All),
+                "#THIS ROW" => tokens.push(Token::ThisRow),
                 ":" => return Err(A1Error::InvalidTableRef("Unexpected colon".into())),
                 _ => {
                     let s = entry.as_str();

--- a/quadratic-core/src/a1/table_ref/tokenize.rs
+++ b/quadratic-core/src/a1/table_ref/tokenize.rs
@@ -125,8 +125,9 @@ impl TableRef {
                 "#DATA" => tokens.push(Token::Data),
                 "#TOTALS" => tokens.push(Token::Totals),
                 "#ALL" => tokens.push(Token::All),
-                "#THIS ROW" => tokens.push(Token::ThisRow),
-                // TODO: START HERE ***
+
+                // we strip spaces, so we check for "THISROW" instead of "THIS ROW"
+                "#THISROW" => tokens.push(Token::ThisRow),
                 ":" => return Err(A1Error::InvalidTableRef("Unexpected colon".into())),
                 _ => {
                     let s = entry.as_str();

--- a/quadratic-core/src/controller/active_transactions/pending_transaction.rs
+++ b/quadratic-core/src/controller/active_transactions/pending_transaction.rs
@@ -59,8 +59,9 @@ pub struct PendingTransaction {
     /// save code_cell info for async calls
     pub current_sheet_pos: Option<SheetPos>,
 
-    /// whether we are awaiting an async call
-    pub waiting_for_async: Option<CodeCellValue>,
+    /// whether we are awaiting an async call -- storing the code cell value and
+    /// the in_table Option<Pos>
+    pub waiting_for_async: Option<(CodeCellValue, Option<Pos>)>,
 
     /// whether transaction is complete
     pub complete: bool,
@@ -691,6 +692,7 @@ mod tests {
             Some(true),
             Some(true),
             None,
+            None,
         );
         transaction.add_from_code_run(sheet_id, pos, data_table.is_image(), data_table.is_html());
         assert_eq!(transaction.code_cells.len(), 1);
@@ -716,6 +718,7 @@ mod tests {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         transaction.add_from_code_run(sheet_id, pos, data_table.is_image(), data_table.is_html());

--- a/quadratic-core/src/controller/dependencies.rs
+++ b/quadratic-core/src/controller/dependencies.rs
@@ -85,6 +85,7 @@ mod test {
                 Some(true),
                 Some(true),
                 None,
+                None,
             )),
             None,
         );

--- a/quadratic-core/src/controller/execution/auto_resize_row_heights.rs
+++ b/quadratic-core/src/controller/execution/auto_resize_row_heights.rs
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(transaction.has_async, 1);
         let transaction_id = transaction.id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             cells,
             JsCellsA1Response {

--- a/quadratic-core/src/controller/execution/auto_resize_row_heights.rs
+++ b/quadratic-core/src/controller/execution/auto_resize_row_heights.rs
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(transaction.has_async, 1);
         let transaction_id = transaction.id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(
             cells,
             JsCellsA1Response {

--- a/quadratic-core/src/controller/execution/control_transaction.rs
+++ b/quadratic-core/src/controller/execution/control_transaction.rs
@@ -249,6 +249,7 @@ impl GridController {
                         None,
                         None,
                         None,
+                        None,
                     );
 
                     self.finalize_data_table(

--- a/quadratic-core/src/controller/execution/execute_operation/execute_code.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_code.rs
@@ -158,20 +158,25 @@ impl GridController {
                 _ => return,
             };
 
+            dbg!(&sheet.data_tables);
+            dbg!(&sheet.data_table_that_contains(pos));
+            let in_table = sheet.check_in_data_table(pos);
+            dbg!(&in_table);
+
             match language {
                 CodeCellLanguage::Python => {
-                    self.run_python(transaction, sheet_pos, code);
+                    self.run_python(transaction, sheet_pos, code, in_table);
                 }
                 CodeCellLanguage::Formula => {
-                    self.run_formula(transaction, sheet_pos, code);
+                    self.run_formula(transaction, sheet_pos, code, in_table);
                 }
                 CodeCellLanguage::Connection { kind, id } => {
                     self.run_connection(transaction, sheet_pos, code, kind, id);
                 }
                 CodeCellLanguage::Javascript => {
-                    self.run_javascript(transaction, sheet_pos, code);
+                    self.run_javascript(transaction, sheet_pos, code, in_table);
                 }
-                CodeCellLanguage::Import => {} // no-op
+                CodeCellLanguage::Import => (), // no-op
             }
         }
     }

--- a/quadratic-core/src/controller/execution/execute_operation/execute_code.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_code.rs
@@ -151,17 +151,14 @@ impl GridController {
             let pos: Pos = sheet_pos.into();
 
             // We need to get the corresponding CellValue::Code
-            let (language, code) = match sheet.cell_value(pos) {
+            let (language, code) = match sheet.code_value(pos) {
                 Some(CellValue::Code(value)) => (value.language, value.code),
 
                 // handles the case where the ComputeCode operation is running on a non-code cell (maybe changed b/c of a MP operation?)
                 _ => return,
             };
 
-            dbg!(&sheet.data_tables);
-            dbg!(&sheet.data_table_that_contains(pos));
             let in_table = sheet.check_in_data_table(pos);
-            dbg!(&in_table);
 
             match language {
                 CodeCellLanguage::Python => {

--- a/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_col_rows.rs
@@ -460,6 +460,7 @@ mod tests {
             Some(false),
             Some(false),
             None,
+            None,
         );
         let transaction = &mut PendingTransaction::default();
         gc.finalize_data_table(transaction, sheet_pos, Some(data_table), None);
@@ -544,6 +545,7 @@ mod tests {
             false,
             Some(false),
             Some(false),
+            None,
             None,
         );
         let transaction = &mut PendingTransaction::default();

--- a/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
@@ -2213,6 +2213,7 @@ mod tests {
             Some(true),
             Some(true),
             None,
+            None,
         );
 
         let mut gc = GridController::test();

--- a/quadratic-core/src/controller/execution/receive_multiplayer.rs
+++ b/quadratic-core/src/controller/execution/receive_multiplayer.rs
@@ -876,8 +876,7 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert!(result.values.is_some());
 
         let result = gc.calculation_complete(JsCodeResult {
@@ -903,8 +902,7 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
         assert!(result.values.is_some());
 
         let result = gc.calculation_complete(JsCodeResult {

--- a/quadratic-core/src/controller/execution/receive_multiplayer.rs
+++ b/quadratic-core/src/controller/execution/receive_multiplayer.rs
@@ -876,7 +876,8 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert!(result.values.is_some());
 
         let result = gc.calculation_complete(JsCodeResult {
@@ -902,7 +903,8 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
         assert!(result.values.is_some());
 
         let result = gc.calculation_complete(JsCodeResult {

--- a/quadratic-core/src/controller/execution/run_code/get_cells.rs
+++ b/quadratic-core/src/controller/execution/run_code/get_cells.rs
@@ -2,7 +2,7 @@ use ts_rs::TS;
 use uuid::Uuid;
 
 use crate::{
-    CellValue, Pos, a1::CellRefRange, controller::GridController, error_core::CoreError,
+    CellValue, a1::CellRefRange, controller::GridController, error_core::CoreError,
     grid::CodeCellLanguage,
 };
 use serde::{Deserialize, Serialize};
@@ -44,9 +44,6 @@ impl GridController {
         &mut self,
         transaction_id: String,
         a1: String,
-
-        // used by #this row selections
-        source_cell: Option<Pos>,
     ) -> JsCellsA1Response {
         let map_error = |e: CoreError| JsCellsA1Response {
             values: None,
@@ -120,7 +117,7 @@ impl GridController {
             false,
             true,
             &self.a1_context,
-            source_cell,
+            transaction.current_sheet_pos.map(|p| p.into()),
         );
         if rects.len() > 1 {
             return map_error(CoreError::A1Error(
@@ -203,7 +200,7 @@ mod test {
         let mut gc = GridController::test();
 
         let result =
-            gc.calculation_get_cells_a1("bad transaction id".to_string(), "A1".to_string(), None);
+            gc.calculation_get_cells_a1("bad transaction id".to_string(), "A1".to_string());
         assert!(result.error.is_some());
     }
 
@@ -211,8 +208,7 @@ mod test {
     fn test_calculation_get_cells_no_transaction() {
         let mut gc = GridController::test();
 
-        let result =
-            gc.calculation_get_cells_a1(Uuid::new_v4().to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(Uuid::new_v4().to_string(), "A1".to_string());
         assert!(result.error.is_some());
     }
 
@@ -235,7 +231,7 @@ mod test {
         let transactions = gc.transactions.async_transactions_mut();
         transactions[0].current_sheet_pos = None;
         let transaction_id = transactions[0].id.to_string();
-        let result = gc.calculation_get_cells_a1(transaction_id, "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id, "A1".to_string());
         assert!(result.error.is_some());
     }
 
@@ -259,7 +255,6 @@ mod test {
         let result = gc.calculation_get_cells_a1(
             transaction_id.to_string(),
             "'bad sheet name'!A1".to_string(),
-            None,
         );
         assert!(result.error.is_some());
         gc.calculation_complete(JsCodeResult {
@@ -311,8 +306,7 @@ mod test {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert!(result.error.is_none());
 
         let sheet = gc.sheet(sheet_id);
@@ -357,8 +351,7 @@ mod test {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             result,
             JsCellsA1Response {
@@ -438,8 +431,7 @@ mod test {
         );
 
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1:A".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1:A".to_string());
         assert_eq!(
             result,
             JsCellsA1Response {
@@ -512,8 +504,7 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             result,
             JsCellsA1Response {
@@ -560,26 +551,22 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "B:".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B:".to_string());
         assert!(result.values.unwrap().two_dimensional);
 
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B".to_string());
         assert!(!result.values.unwrap().two_dimensional);
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "2:".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "2:".to_string());
         assert!(result.values.unwrap().two_dimensional);
 
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "2".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "2".to_string());
         assert!(!result.values.unwrap().two_dimensional);
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "D5:E5".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "D5:E5".to_string());
         assert!(!result.values.unwrap().two_dimensional);
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "D5:".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "D5:".to_string());
         assert!(result.values.unwrap().two_dimensional);
     }
 
@@ -609,11 +596,8 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(
-            transaction_id.to_string(),
-            "Table1[[#HEADERS]]".to_string(),
-            None,
-        );
+        let result = gc
+            .calculation_get_cells_a1(transaction_id.to_string(), "Table1[[#HEADERS]]".to_string());
         assert_eq!(
             result,
             JsCellsA1Response {
@@ -671,11 +655,8 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(
-            transaction_id.to_string(),
-            "Table1[[#ALL]]".to_string(),
-            None,
-        );
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "Table1[[#ALL]]".to_string());
         assert_eq!(
             result,
             JsCellsA1Response {
@@ -734,8 +715,7 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "Table1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "Table1".to_string());
         assert!(result.values.is_some());
     }
 
@@ -761,8 +741,7 @@ mod test {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "Table1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "Table1".to_string());
         assert!(result.values.is_some());
     }
 }

--- a/quadratic-core/src/controller/execution/run_code/mod.rs
+++ b/quadratic-core/src/controller/execution/run_code/mod.rs
@@ -252,7 +252,7 @@ impl GridController {
             None => {
                 return Err(CoreError::TransactionNotFound("Expected transaction to be waiting_for_async to be defined in transaction::complete".into()));
             }
-            Some(code_cell) => {
+            Some((code_cell, in_table)) => {
                 if !code_cell.language.is_code_language() {
                     return Err(CoreError::UnhandledLanguage(
                         "Transaction.complete called for an unhandled language".into(),
@@ -265,6 +265,7 @@ impl GridController {
                     current_sheet_pos,
                     code_cell.language.clone(),
                     code_cell.code.clone(),
+                    *in_table,
                 );
 
                 self.finalize_data_table(
@@ -291,6 +292,7 @@ impl GridController {
         &mut self,
         transaction: &mut PendingTransaction,
         error: &RunError,
+        in_table: Option<Pos>,
     ) -> Result<()> {
         let sheet_pos = match transaction.current_sheet_pos {
             Some(sheet_pos) => sheet_pos,
@@ -366,6 +368,7 @@ impl GridController {
             None,
             None,
             None,
+            in_table,
         );
 
         self.finalize_data_table(transaction, sheet_pos, Some(new_data_table), None);
@@ -381,6 +384,7 @@ impl GridController {
         start: SheetPos,
         language: CodeCellLanguage,
         code: String,
+        in_table: Option<Pos>,
     ) -> DataTable {
         let table_name = match language {
             CodeCellLanguage::Formula => "Formula1",
@@ -418,6 +422,7 @@ impl GridController {
                 None,
                 None,
                 None,
+                in_table,
             );
         };
 
@@ -500,6 +505,7 @@ impl GridController {
             None,
             None,
             chart_output,
+            in_table,
         );
 
         // If no headers were returned, we want column headers: [0, 1, 2, 3, ...etc]
@@ -570,6 +576,7 @@ mod test {
             Some(true),
             Some(true),
             None,
+            None,
         );
         gc.finalize_data_table(transaction, sheet_pos, Some(new_data_table.clone()), None);
         assert_eq!(transaction.forward_operations.len(), 1);
@@ -609,6 +616,7 @@ mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         new_data_table.column_headers = None;

--- a/quadratic-core/src/controller/execution/run_code/run_connection.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_connection.rs
@@ -98,7 +98,7 @@ impl GridController {
                         msg: RunErrorMsg::CodeRunError(std::borrow::Cow::Owned(msg.to_string())),
                     };
                     transaction.current_sheet_pos = Some(sheet_pos);
-                    let _ = self.code_cell_sheet_error(transaction, &error);
+                    let _ = self.code_cell_sheet_error(transaction, &error, None);
 
                     // not ideal to clone the transaction, but we need to close it
                     self.finalize_transaction(transaction.clone());
@@ -113,7 +113,7 @@ impl GridController {
             language: CodeCellLanguage::Connection { kind, id },
             code,
         };
-        transaction.waiting_for_async = Some(code_cell);
+        transaction.waiting_for_async = Some((code_cell, None));
         self.transactions.add_async_transaction(transaction);
     }
 }

--- a/quadratic-core/src/controller/execution/run_code/run_formula.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_formula.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::{
-    SheetPos,
+    Pos, SheetPos,
     controller::{GridController, active_transactions::pending_transaction::PendingTransaction},
     formulas::{Ctx, find_cell_references, parse_formula},
     grid::{CellsAccessed, CodeCellLanguage, CodeRun, DataTable, DataTableKind},
@@ -13,6 +13,7 @@ impl GridController {
         transaction: &mut PendingTransaction,
         sheet_pos: SheetPos,
         code: String,
+        in_table: Option<Pos>,
     ) {
         let mut eval_ctx = Ctx::new(self, sheet_pos);
         let parse_ctx = self.a1_context();
@@ -42,11 +43,12 @@ impl GridController {
                     None,
                     None,
                     None,
+                    in_table,
                 );
                 self.finalize_data_table(transaction, sheet_pos, Some(new_data_table), None);
             }
             Err(error) => {
-                let _ = self.code_cell_sheet_error(transaction, &error);
+                let _ = self.code_cell_sheet_error(transaction, &error, in_table);
             }
         }
     }
@@ -80,6 +82,7 @@ impl GridController {
             name,
             "".into(),
             false,
+            None,
             None,
             None,
             None,
@@ -290,6 +293,7 @@ mod test {
             sheet_pos,
             CodeCellLanguage::Javascript,
             r#"return "12";"#.to_string(),
+            None,
         );
         let code_run = CodeRun {
             language: CodeCellLanguage::Javascript,
@@ -308,6 +312,7 @@ mod test {
                 None,
                 None,
                 None,
+                None
             )
             .with_last_modified(result.last_modified)
         );
@@ -377,6 +382,7 @@ mod test {
             sheet_pos,
             CodeCellLanguage::Javascript,
             r#"return [[1.1, 0.2], [3, "Hello"]];"#.to_string(),
+            None,
         );
         let code_run = CodeRun {
             language: CodeCellLanguage::Javascript,
@@ -391,6 +397,7 @@ mod test {
             "JavaScript1",
             array.into(),
             false,
+            None,
             None,
             None,
             None,

--- a/quadratic-core/src/controller/execution/run_code/run_javascript.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_javascript.rs
@@ -145,7 +145,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells request from javascript
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -208,7 +208,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells to populate dependencies
-        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         // mock the calculation_complete
         gc.calculation_complete(JsCodeResult {
             transaction_id: transaction_id.to_string(),
@@ -226,7 +226,7 @@ mod tests {
 
         let transaction_id = gc.async_transactions()[0].id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -336,7 +336,7 @@ mod tests {
             transaction_id: transaction_id.to_string(),
             success: true,
             output_value: Some(JsCellValueResult("".into(), 0)),
-            cancel_compute: Some(true),
+            // cancel_compute: Some(true),
             ..Default::default()
         };
         gc.calculation_complete(result).unwrap();
@@ -469,8 +469,7 @@ mod tests {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],
@@ -500,8 +499,7 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],

--- a/quadratic-core/src/controller/execution/run_code/run_javascript.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_javascript.rs
@@ -145,7 +145,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells request from javascript
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -208,7 +208,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells to populate dependencies
-        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         // mock the calculation_complete
         gc.calculation_complete(JsCodeResult {
             transaction_id: transaction_id.to_string(),
@@ -226,7 +226,7 @@ mod tests {
 
         let transaction_id = gc.async_transactions()[0].id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -469,7 +469,8 @@ mod tests {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],
@@ -499,7 +500,8 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],

--- a/quadratic-core/src/controller/execution/run_code/run_javascript.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_javascript.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SheetPos,
+    Pos, SheetPos,
     controller::{GridController, active_transactions::pending_transaction::PendingTransaction},
     grid::{CodeCellLanguage, CodeCellValue},
 };
@@ -10,6 +10,7 @@ impl GridController {
         transaction: &mut PendingTransaction,
         sheet_pos: SheetPos,
         code: String,
+        in_table: Option<Pos>,
     ) {
         if (cfg!(target_family = "wasm") || cfg!(test)) && !transaction.is_server() {
             crate::wasm_bindings::js::jsRunJavascript(
@@ -26,7 +27,7 @@ impl GridController {
             language: CodeCellLanguage::Javascript,
             code,
         };
-        transaction.waiting_for_async = Some(code_cell);
+        transaction.waiting_for_async = Some((code_cell, in_table));
         self.transactions.add_async_transaction(transaction);
     }
 }

--- a/quadratic-core/src/controller/execution/run_code/run_python.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_python.rs
@@ -154,7 +154,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells request from python
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -221,7 +221,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells to populate dependencies
-        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         // mock the calculation_complete
         gc.calculation_complete(JsCodeResult {
             transaction_id: transaction_id.to_string(),
@@ -237,7 +237,7 @@ mod tests {
 
         let transaction_id = gc.async_transactions()[0].id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -498,7 +498,8 @@ mod tests {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],
@@ -528,7 +529,8 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
+        let result =
+            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],

--- a/quadratic-core/src/controller/execution/run_code/run_python.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_python.rs
@@ -1,5 +1,5 @@
 use crate::{
-    SheetPos,
+    Pos, SheetPos,
     controller::{GridController, active_transactions::pending_transaction::PendingTransaction},
     grid::{CodeCellLanguage, CodeCellValue},
 };
@@ -10,6 +10,7 @@ impl GridController {
         transaction: &mut PendingTransaction,
         sheet_pos: SheetPos,
         code: String,
+        in_table: Option<Pos>,
     ) {
         if (cfg!(target_family = "wasm") || cfg!(test)) && !transaction.is_server() {
             crate::wasm_bindings::js::jsRunPython(
@@ -26,7 +27,7 @@ impl GridController {
             language: CodeCellLanguage::Python,
             code,
         };
-        transaction.waiting_for_async = Some(code_cell);
+        transaction.waiting_for_async = Some((code_cell, in_table));
         self.transactions.add_async_transaction(transaction);
     }
 }

--- a/quadratic-core/src/controller/execution/run_code/run_python.rs
+++ b/quadratic-core/src/controller/execution/run_code/run_python.rs
@@ -154,7 +154,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells request from python
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -221,7 +221,7 @@ mod tests {
         let transaction_id = gc.async_transactions()[0].id;
 
         // mock the get_cells to populate dependencies
-        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         // mock the calculation_complete
         gc.calculation_complete(JsCodeResult {
             transaction_id: transaction_id.to_string(),
@@ -237,7 +237,7 @@ mod tests {
 
         let transaction_id = gc.async_transactions()[0].id;
 
-        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let cells = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(
             cells,
             JsCellsA1Response {
@@ -498,8 +498,7 @@ mod tests {
         );
         let transaction_id = gc.last_transaction().unwrap().id;
 
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "A1".to_string());
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],
@@ -529,8 +528,7 @@ mod tests {
             None,
         );
         let transaction_id = gc.last_transaction().unwrap().id;
-        let result =
-            gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string(), None);
+        let result = gc.calculation_get_cells_a1(transaction_id.to_string(), "B1".to_string());
         assert_eq!(result.values.as_ref().unwrap().cells.len(), 1);
         assert_eq!(
             result.values.unwrap().cells[0],

--- a/quadratic-core/src/controller/execution/spills.rs
+++ b/quadratic-core/src/controller/execution/spills.rs
@@ -382,6 +382,7 @@ mod tests {
             Some(true),
             Some(true),
             None,
+            None,
         );
         let pos = Pos { x: 0, y: 0 };
         let sheet = gc.sheet_mut(sheet_id);

--- a/quadratic-core/src/controller/operations/borders.rs
+++ b/quadratic-core/src/controller/operations/borders.rs
@@ -435,7 +435,7 @@ impl GridController {
                 CellRefRange::Table { range } => {
                     if let Some(table) = context.try_table(&range.table_name) {
                         if let Some(range) =
-                            range.convert_to_ref_range_bounds(true, context, false, false)
+                            range.convert_to_ref_range_bounds(true, context, false, false, None)
                         {
                             add_table_ops(range, table, &mut sheet_borders, &mut tables_borders);
                         }

--- a/quadratic-core/src/controller/operations/cell_value.rs
+++ b/quadratic-core/src/controller/operations/cell_value.rs
@@ -181,6 +181,7 @@ impl GridController {
                 force_table_bounds,
                 true,
                 &self.a1_context,
+                None,
             );
 
             // reverse the order to delete from right to left

--- a/quadratic-core/src/controller/operations/clipboard.rs
+++ b/quadratic-core/src/controller/operations/clipboard.rs
@@ -1303,6 +1303,7 @@ mod test {
             headers: false,
             totals: false,
             col_range: ColRange::Col("city".to_string()),
+            this_row: false,
         };
         let (selection, context) =
             simple_csv_selection(sheet_id, table_ref, Rect::test_a1("A1:D11"));
@@ -1337,6 +1338,7 @@ mod test {
             headers: false,
             totals: false,
             col_range: ColRange::ColRange("city".to_string(), "region".to_string()),
+            this_row: false,
         };
         let (selection, context) =
             simple_csv_selection(sheet_id, table_ref, Rect::test_a1("A1:D11"));
@@ -1371,6 +1373,7 @@ mod test {
             headers: false,
             totals: false,
             col_range: ColRange::ColRange("country".to_string(), "population".to_string()),
+            this_row: false,
         };
         let (selection, context) =
             simple_csv_selection(sheet_id, table_ref, Rect::test_a1("A1:D11"));

--- a/quadratic-core/src/controller/operations/code_cell.rs
+++ b/quadratic-core/src/controller/operations/code_cell.rs
@@ -24,13 +24,17 @@ impl GridController {
             _ => code,
         };
 
-        let mut ops = vec![
-            Operation::SetCellValues {
-                sheet_pos,
-                values: CellValues::from(CellValue::Code(CodeCellValue { language, code })),
-            },
-            Operation::ComputeCode { sheet_pos },
-        ];
+        let Some(sheet) = self.try_sheet(sheet_pos.sheet_id) else {
+            return vec![];
+        };
+        let mut ops = vec![];
+        let values = CellValues::from(CellValue::Code(CodeCellValue { language, code }));
+        if sheet.check_in_data_table(sheet_pos.into()).is_some() {
+            ops.push(Operation::SetDataTableAt { sheet_pos, values })
+        } else {
+            ops.push(Operation::SetCellValues { sheet_pos, values });
+        }
+        ops.push(Operation::ComputeCode { sheet_pos });
 
         // change the code cell name if it is provided and the code cell doesn't already have a name
         if let Some(code_cell_name) = code_cell_name {

--- a/quadratic-core/src/controller/operations/data_table.rs
+++ b/quadratic-core/src/controller/operations/data_table.rs
@@ -304,6 +304,7 @@ impl GridController {
             Some(true),
             Some(true),
             None,
+            None,
         );
         data_table
             .formats

--- a/quadratic-core/src/controller/test_util.rs
+++ b/quadratic-core/src/controller/test_util.rs
@@ -78,6 +78,7 @@ impl GridController {
             Some(false),
             Some(false),
             None,
+            None,
         );
 
         let op = Operation::AddDataTable {
@@ -111,6 +112,7 @@ impl GridController {
             header_is_first_row,
             show_name,
             show_columns,
+            None,
             None,
         );
 

--- a/quadratic-core/src/controller/user_actions/data_table.rs
+++ b/quadratic-core/src/controller/user_actions/data_table.rs
@@ -207,6 +207,7 @@ mod tests {
             Some(true),
             Some(true),
             None,
+            None,
         );
 
         let mut gc = GridController::test();

--- a/quadratic-core/src/controller/user_actions/formats.rs
+++ b/quadratic-core/src/controller/user_actions/formats.rs
@@ -173,7 +173,7 @@ impl GridController {
         for table_ref in table_ranges {
             if let Some(table) = context.try_table(&table_ref.table_name) {
                 if let Some(range) =
-                    table_ref.convert_to_ref_range_bounds(true, context, false, true)
+                    table_ref.convert_to_ref_range_bounds(true, context, false, true, None)
                 {
                     add_table_ops(range, table, &mut ops);
                 }
@@ -491,8 +491,8 @@ mod test {
     use crate::controller::operations::operation::Operation;
     use crate::grid::CellWrap;
     use crate::grid::formats::{FormatUpdate, SheetFormatUpdates};
-    use crate::{Pos, a1::A1Selection};
     use crate::test_util::*;
+    use crate::{Pos, a1::A1Selection};
 
     #[test]
     fn test_set_align_selection() {

--- a/quadratic-core/src/controller/user_actions/import.rs
+++ b/quadratic-core/src/controller/user_actions/import.rs
@@ -86,7 +86,7 @@ pub(crate) mod tests {
     use std::str::FromStr;
 
     use crate::{
-        CellValue, RunError, RunErrorMsg, Span,
+        CellValue, Rect, RunError, RunErrorMsg, Span,
         grid::{CodeCellLanguage, CodeCellValue},
         test_util::*,
         wasm_bindings::js::clear_js_calls,

--- a/quadratic-core/src/formulas/ctx.rs
+++ b/quadratic-core/src/formulas/ctx.rs
@@ -59,7 +59,7 @@ impl<'ctx> Ctx<'ctx> {
             .ok_or(RunErrorMsg::BadCellReference.with_span(span))?;
 
         let a1_context = self.grid_controller.a1_context();
-
+        dbg!(&range);
         let rect = match &range.cells {
             CellRefRange::Sheet { range } => {
                 sheet.ref_range_bounds_to_rect(range, ignore_formatting)

--- a/quadratic-core/src/formulas/ctx.rs
+++ b/quadratic-core/src/formulas/ctx.rs
@@ -65,7 +65,7 @@ impl<'ctx> Ctx<'ctx> {
                 sheet.ref_range_bounds_to_rect(range, ignore_formatting)
             }
             CellRefRange::Table { range } => sheet
-                .table_ref_to_rect(range, false, false, a1_context)
+                .table_ref_to_rect(range, false, false, a1_context, Some(self.sheet_pos.into()))
                 .ok_or(RunErrorMsg::BadCellReference.with_span(span))?,
         };
 

--- a/quadratic-core/src/formulas/lexer.rs
+++ b/quadratic-core/src/formulas/lexer.rs
@@ -81,6 +81,9 @@ const A1_CELL_REFERENCE_OR_TABLE_NAME_PATTERN: &str = r"[\p{Letter}\$_][\p{Lette
 
 /// Contents of the inner square brackets of a table reference.
 ///
+/// For now, we handle the @ prefix without tokenizing it. (When refactoring, we
+/// should be tokenizing it.)
+///
 /// ```ignored
 ///           |                  either of ...
 /// #[a-zA-Z]*                     #header, #data, #all, #totals, etc.
@@ -89,7 +92,7 @@ const A1_CELL_REFERENCE_OR_TABLE_NAME_PATTERN: &str = r"[\p{Letter}\$_][\p{Lette
 ///             '.                     a character escaped using '.
 ///                [^'\[\]]            any character other than a single quote or square bracket
 /// ```
-const TABLE_BRACKETS_SEGMENT_CONTENTS_PATTERN: &str = r"#[a-zA-Z]*|('.|[^'\[\]])*";
+const TABLE_BRACKETS_SEGMENT_CONTENTS_PATTERN: &str = r"@?#[a-zA-Z]*|('.|[^'\[\]])*";
 
 lazy_static! {
     /// Inner square brackets of a table reference.

--- a/quadratic-core/src/formulas/parser/mod.rs
+++ b/quadratic-core/src/formulas/parser/mod.rs
@@ -55,7 +55,6 @@ pub fn find_cell_references(
     let tokens = lexer::tokenize(source)
         .filter(|t| !t.inner.is_skip())
         .collect_vec();
-
     let mut p = Parser::new(source, &tokens, ctx, pos);
 
     while !p.is_done() {

--- a/quadratic-core/src/formulas/parser/rules/table_ref.rs
+++ b/quadratic-core/src/formulas/parser/rules/table_ref.rs
@@ -189,7 +189,7 @@ impl SyntaxRule for TableReference {
                             _ => return Err(RunErrorMsg::BadCellReference),
                         }
                     }
-                    let t = TableRef {
+                    Ok(TableRef {
                         table_name: table_name.to_owned(),
                         data: if this_row {
                             false
@@ -200,9 +200,7 @@ impl SyntaxRule for TableReference {
                         totals,
                         col_range: col_range.unwrap_or(ColRange::All),
                         this_row,
-                    };
-                    dbg!(&t);
-                    Ok(t)
+                    })
                 })()
             }
         }

--- a/quadratic-core/src/formulas/parser/rules/table_ref.rs
+++ b/quadratic-core/src/formulas/parser/rules/table_ref.rs
@@ -166,7 +166,7 @@ impl SyntaxRule for TableReference {
                         match parse_segment_contents(&mut chars)? {
                             TableRefToken::ThisRow(c) => {
                                 this_row = true;
-                                col_range = Some(ColRange::Col(c))
+                                col_range = Some(ColRange::Col(c.chars().skip(1).collect()))
                             }
                             TableRefToken::Column(c) => col_range = Some(ColRange::Col(c)),
                             TableRefToken::Special(s) => special_segments.push(s),
@@ -193,7 +193,6 @@ impl SyntaxRule for TableReference {
                             _ => return Err(RunErrorMsg::BadCellReference),
                         }
                     }
-
                     Ok(TableRef {
                         table_name: table_name.to_owned(),
                         data: data || (!headers && !totals),

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -563,6 +563,9 @@ fn test_table_this_row() {
     );
 
     print_first_sheet(&gc);
+
+    assert_display_cell_value(&gc, sheet_id, 5, 3, "0");
+    assert_display_cell_value(&gc, sheet_id, 5, 4, "");
 }
 
 #[test]
@@ -581,4 +584,7 @@ fn test_table_this_row_short() {
     );
 
     print_first_sheet(&gc);
+
+    assert_display_cell_value(&gc, sheet_id, 5, 3, "0");
+    assert_display_cell_value(&gc, sheet_id, 5, 4, "");
 }

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -557,7 +557,25 @@ fn test_table_this_row() {
     gc.set_code_cell(
         pos![sheet_id!E3],
         CodeCellLanguage::Formula,
-        "test_table[@B]".to_string(),
+        "test_table[[#this row],[Column 1]]".to_string(),
+        None,
+        None,
+    );
+
+    print_first_sheet(&gc);
+}
+
+#[test]
+fn test_table_this_row_short() {
+    let mut gc = test_create_gc();
+    let sheet_id = first_sheet_id(&gc);
+
+    test_create_data_table(&mut gc, sheet_id, pos![A1], 3, 3);
+
+    gc.set_code_cell(
+        pos![sheet_id!E3],
+        CodeCellLanguage::Formula,
+        "test_table[@Column 1]".to_string(),
         None,
         None,
     );

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -6,7 +6,9 @@ use itertools::Itertools;
 pub(crate) use super::*;
 use crate::a1::{CellRefCoord, CellRefRange, SheetCellRefRange};
 use crate::controller::GridController;
+use crate::grid::CodeCellLanguage;
 pub(crate) use crate::grid::Grid;
+use crate::test_util::*;
 pub(crate) use crate::values::*;
 pub(crate) use crate::{CodeResult, RunError, RunErrorMsg, Spanned, array};
 use crate::{CoerceInto, Pos, SheetPos};
@@ -543,4 +545,22 @@ fn test_syntax_check_ok() {
     assert_check_syntax_succeeds(&g, "{1, 2; 3, 4}");
     assert_check_syntax_succeeds(&g, "XLOOKUP(\"zebra\", A1:Z1, A4:Z6)");
     assert_check_syntax_succeeds(&g, "ABS(({1, 2; 3, 4}, A1:C10))");
+}
+
+#[test]
+fn test_table_this_row() {
+    let mut gc = test_create_gc();
+    let sheet_id = first_sheet_id(&gc);
+
+    test_create_data_table(&mut gc, sheet_id, pos![A1], 3, 3);
+
+    gc.set_code_cell(
+        pos![sheet_id!E3],
+        CodeCellLanguage::Formula,
+        "test_table[@B]".to_string(),
+        None,
+        None,
+    );
+
+    print_first_sheet(&gc);
 }

--- a/quadratic-core/src/grid/data_table/column_header.rs
+++ b/quadratic-core/src/grid/data_table/column_header.rs
@@ -310,6 +310,7 @@ pub mod test {
             chart_pixel_output: None,
             spill_value: false,
             spill_data_table: false,
+            in_table: false,
         };
         sheet.set_cell_value(
             pos,
@@ -368,6 +369,7 @@ pub mod test {
             chart_pixel_output: None,
             spill_value: false,
             spill_data_table: false,
+            in_table: false,
         };
         t.apply_default_header();
         sheet.set_cell_value(

--- a/quadratic-core/src/grid/data_table/column_header.rs
+++ b/quadratic-core/src/grid/data_table/column_header.rs
@@ -312,6 +312,7 @@ pub mod test {
             spill_value: false,
             spill_data_table: false,
             in_table: None,
+            has_code: Default::default(),
         };
         sheet.set_cell_value(
             pos,
@@ -371,6 +372,7 @@ pub mod test {
             spill_value: false,
             spill_data_table: false,
             in_table: None,
+            has_code: Default::default(),
         };
         t.apply_default_header();
         sheet.set_cell_value(

--- a/quadratic-core/src/grid/data_table/column_header.rs
+++ b/quadratic-core/src/grid/data_table/column_header.rs
@@ -310,7 +310,7 @@ pub mod test {
             chart_pixel_output: None,
             spill_value: false,
             spill_data_table: false,
-            in_table: false,
+            in_table: None,
         };
         sheet.set_cell_value(
             pos,
@@ -369,7 +369,7 @@ pub mod test {
             chart_pixel_output: None,
             spill_value: false,
             spill_data_table: false,
-            in_table: false,
+            in_table: None,
         };
         t.apply_default_header();
         sheet.set_cell_value(

--- a/quadratic-core/src/grid/data_table/column_header.rs
+++ b/quadratic-core/src/grid/data_table/column_header.rs
@@ -236,6 +236,7 @@ pub mod test {
             Some(true),
             Some(true),
             None,
+            None,
         )
         .with_last_modified(data_table.last_modified);
 

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -3,6 +3,7 @@
 //! This lives in sheet.data_tables. CodeRun is optional within sheet.data_tables for
 //! any given CellValue::Code type (ie, if it doesn't exist then a run hasn't been
 //! performed yet).
+use crate::grid::data_table::table_code_cache::TableCodeCache;
 use crate::util::is_false;
 
 pub mod column;
@@ -12,6 +13,7 @@ pub mod formats;
 pub mod row;
 pub mod send_render;
 pub mod sort;
+mod table_code_cache;
 
 use std::num::NonZeroU32;
 
@@ -144,8 +146,13 @@ pub struct DataTable {
     pub value: Value,
     pub last_modified: DateTime<Utc>,
 
+    // whether this is a code table that is in a data table
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub in_table: Option<Pos>,
+
+    // all code tables that may live in this (if it is a data table)
+    #[serde(skip)]
+    has_code: TableCodeCache,
 
     #[serde(skip_serializing_if = "is_false", default)]
     pub header_is_first_row: bool,
@@ -245,6 +252,7 @@ impl DataTable {
             chart_pixel_output: None,
             chart_output,
             in_table,
+            has_code: Default::default(),
         };
 
         if header_is_first_row {
@@ -277,6 +285,7 @@ impl DataTable {
             chart_pixel_output: self.chart_pixel_output,
             chart_output: self.chart_output,
             in_table: self.in_table,
+            has_code: Default::default(),
         }
     }
 
@@ -800,6 +809,20 @@ impl DataTable {
         }
 
         rows
+    }
+
+    // todo...
+    /// Returns the position of a a nested code cell within a data table.
+    pub fn inner_code_cell_value(&self, _data_table_pos: Pos, _cell_value_pos: Pos) -> Option<Pos> {
+        if !self.is_data_table() {
+            return None;
+        }
+
+        // has_code.get(Pos::new(
+        //     (cell_value_pos.x - data_table_pos.x + 1) as i64,
+        //     (cell_value_pos.y - data_table_pos.y + 1) as i64,
+        // ))
+        None
     }
 }
 

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -143,7 +143,9 @@ pub struct DataTable {
     pub name: CellValue,
     pub value: Value,
     pub last_modified: DateTime<Utc>,
-    pub in_table: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub in_table: Option<Pos>,
 
     #[serde(skip_serializing_if = "is_false", default)]
     pub header_is_first_row: bool,
@@ -240,7 +242,7 @@ impl DataTable {
             show_columns,
             chart_pixel_output: None,
             chart_output,
-            in_table: false,
+            in_table: None,
         };
 
         if header_is_first_row {

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -205,6 +205,7 @@ impl From<(Import, Array, &A1Context)> for DataTable {
             None,
             None,
             None,
+            None,
         )
     }
 }
@@ -222,6 +223,7 @@ impl DataTable {
         show_name: Option<bool>,
         show_columns: Option<bool>,
         chart_output: Option<(u32, u32)>,
+        in_table: Option<Pos>,
     ) -> Self {
         let mut data_table = DataTable {
             kind,
@@ -242,7 +244,7 @@ impl DataTable {
             show_columns,
             chart_pixel_output: None,
             chart_output,
-            in_table: None,
+            in_table,
         };
 
         if header_is_first_row {
@@ -295,6 +297,13 @@ impl DataTable {
     pub fn with_column_headers(mut self, column_headers: Vec<DataTableColumnHeader>) -> Self {
         self.column_headers = Some(column_headers);
         self
+    }
+
+    pub fn is_data_table(&self) -> bool {
+        match &self.kind {
+            DataTableKind::CodeRun(_) => false,
+            DataTableKind::Import(_) => true,
+        }
     }
 
     pub fn is_code(&self) -> bool {
@@ -843,6 +852,7 @@ pub mod test {
             None,
             None,
             None,
+            None,
         )
         .with_last_modified(data_table.last_modified);
 
@@ -880,6 +890,7 @@ pub mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
 
         assert_eq!(data_table.output_size(), ArraySize::_1X1);
@@ -914,6 +925,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
 
@@ -953,6 +965,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         data_table.spill_value = true;
@@ -999,6 +1012,7 @@ pub mod test {
             Some(true),
             Some(true),
             None,
+            None,
         );
         assert!(!data_table.is_single_column());
 
@@ -1011,6 +1025,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         assert!(data_table.is_single_column());
@@ -1025,6 +1040,7 @@ pub mod test {
             Some(true),
             Some(true),
             None,
+            None,
         );
         assert!(!data_table.is_single_column());
 
@@ -1037,6 +1053,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         assert!(data_table.is_single_column());
@@ -1052,6 +1069,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
 
@@ -1083,6 +1101,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
 
@@ -1122,6 +1141,7 @@ pub mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
         assert_eq!(data_table.output_size(), ArraySize::_1X1);
 
@@ -1133,6 +1153,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         // Height should be 3 (1 for value + 1 for name + 1 for columns)
@@ -1322,6 +1343,7 @@ pub mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
 

--- a/quadratic-core/src/grid/data_table/mod.rs
+++ b/quadratic-core/src/grid/data_table/mod.rs
@@ -143,6 +143,7 @@ pub struct DataTable {
     pub name: CellValue,
     pub value: Value,
     pub last_modified: DateTime<Utc>,
+    pub in_table: bool,
 
     #[serde(skip_serializing_if = "is_false", default)]
     pub header_is_first_row: bool,
@@ -239,6 +240,7 @@ impl DataTable {
             show_columns,
             chart_pixel_output: None,
             chart_output,
+            in_table: false,
         };
 
         if header_is_first_row {
@@ -270,6 +272,7 @@ impl DataTable {
             show_columns: self.show_columns,
             chart_pixel_output: self.chart_pixel_output,
             chart_output: self.chart_output,
+            in_table: self.in_table,
         }
     }
 

--- a/quadratic-core/src/grid/data_table/table_code_cache.rs
+++ b/quadratic-core/src/grid/data_table/table_code_cache.rs
@@ -1,0 +1,192 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Pos, Value,
+    grid::{Contiguous2D, DataTable, Sheet},
+};
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TableCodeCache {
+    cache: Option<Contiguous2D<Option<Pos>>>,
+}
+
+impl TableCodeCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new InnerCodeValuesCache from an array.
+    ///
+    /// Note: this needs to be built after all data tables are already loaded
+    /// since it relies on knowing the inner code table's size.
+    pub fn from_data_table(sheet: &Sheet, data_table_pos: Pos, data_table: &DataTable) -> Self {
+        if data_table.is_code() {
+            return Self::new();
+        }
+
+        match &data_table.value {
+            Value::Single(_) | Value::Tuple(_) => Self::default(),
+            Value::Array(array) => {
+                let width = array.width();
+
+                let mut cache = Contiguous2D::new();
+
+                for (i, value) in array.values_iter().enumerate() {
+                    dbg!(&value);
+                    if value.is_code() {
+                        let x = i % width as usize;
+                        let y = i / width as usize;
+                        let code_table_pos =
+                            Pos::new(data_table_pos.x + x as i64, data_table_pos.y + y as i64);
+                        dbg!(&code_table_pos);
+                        if let Some(code_table) = sheet.data_table_at(&code_table_pos) {
+                            dbg!(&code_table);
+                            let output_size = code_table.output_rect(code_table_pos, false);
+                            cache.set_rect(
+                                1 + x as i64,
+                                1 + y as i64,
+                                Some(1 + x as i64 + output_size.width() as i64),
+                                Some(1 + y as i64 + output_size.height() as i64),
+                                Some(code_table_pos),
+                            );
+                        }
+                    }
+                }
+
+                if cache.is_all_default() {
+                    Self::default()
+                } else {
+                    Self { cache: Some(cache) }
+                }
+            }
+        }
+    }
+
+    //     let width = array.width();
+
+    //     // collect all the code cells
+    //     let mut code = Vec::<Pos>::new();
+    //     for (i, value) in values.iter().enumerate() {
+    //         if value.is_code() {
+    //             let x = i % width;
+    //             let y = i / width;
+    //             if let Some(data_table)
+    //         }
+    //     }
+
+    //     // if there are no empty cells, we don't need to store the cache
+    //     if code.is_empty() {
+    //         return Self::new();
+    //     }
+
+    //     let height = array_size.h.get();
+
+    //     let mut cache = Contiguous2D::new();
+
+    //     // mark all cells (array rect) as Some(None) -> non-empty
+    //     cache.set_rect(1, 1, Some(width as i64), Some(height as i64), Some(None));
+
+    //     // then mark empty cells as Some(Some(true))
+    //     for pos in empty {
+    //         cache.set(pos.translate(1, 1, 1, 1), Some(Some(true)));
+    //     }
+
+    //     Self { cache: Some(cache) }
+    // }
+    // }
+
+    // /// Returns a clone of the cache, this needs to be translated to sheet coordinates
+    // /// before can be applied to the SheetDataTablesCache
+    // /// Hidden columns and sorted rows are handled in the SheetDataTablesCache
+    // pub fn get_cache_owned(&self) -> Option<Contiguous2D<Option<Option<bool>>>> {
+    //     self.cache.clone()
+    // }
+
+    // /// Updates cache for a single value change in array
+    // /// Checks and removes the cache if all cells are non-empty
+    // pub fn set_value(&mut self, array_size: &ArraySize, pos: Pos, blank: bool) {
+    //     // required only in app for client side interactions
+    //     if !cfg!(target_family = "wasm") && !cfg!(test) {
+    //         self.cache = None;
+    //         return;
+    //     }
+
+    //     if !blank && self.cache.is_none() {
+    //         return;
+    //     }
+
+    //     if let Some(cache) = self.cache.as_mut() {
+    //         let val = if blank { Some(Some(true)) } else { Some(None) };
+    //         cache.set(pos.translate(1, 1, 1, 1), val);
+    //     } else {
+    //         let width = array_size.w.get() as i64;
+    //         let height = array_size.h.get() as i64;
+
+    //         let mut cache = Contiguous2D::new();
+    //         cache.set_rect(1, 1, Some(width), Some(height), Some(None));
+    //         cache.set(pos.translate(1, 1, 1, 1), Some(Some(true)));
+    //         self.cache = Some(cache);
+    //     }
+
+    //     self.check_and_remove_cache(array_size);
+    // }
+
+    // /// Removes a row from the cache
+    // /// Checks and removes the cache if all cells are non-empty
+    // pub fn remove_row(&mut self, array_size: &ArraySize, row: i64) {
+    //     // required only in app for client side interactions
+    //     if !cfg!(target_family = "wasm") && !cfg!(test) {
+    //         self.cache = None;
+    //         return;
+    //     }
+
+    //     self.cache.as_mut().map(|cache| cache.remove_row(row + 1));
+
+    //     self.check_and_remove_cache(array_size);
+    // }
+
+    // /// Checks and removes the cache if all cells are non-empty
+    // fn check_and_remove_cache(&mut self, array_size: &ArraySize) {
+    //     let width = array_size.w.get() as i64;
+    //     let height = array_size.h.get() as i64;
+
+    //     let can_remove = self.cache.as_ref().is_some_and(|cache| {
+    //         cache
+    //             .unique_values_in_rect(Rect::new(1, 1, width, height))
+    //             .iter()
+    //             .all(|val| val == &Some(None))
+    //     });
+
+    //     if can_remove {
+    //         self.cache = None;
+    //     }
+    // }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{grid::CodeCellLanguage, test_util::*};
+
+    #[test]
+    fn test_create_from_data_table() {
+        let mut gc = test_create_gc();
+        let sheet_id = first_sheet_id(&gc);
+
+        test_create_data_table(&mut gc, sheet_id, pos![A1], 3, 3);
+
+        gc.set_code_cell(
+            pos![sheet_id!a3],
+            CodeCellLanguage::Formula,
+            "1 + 1".to_string(),
+            None,
+            None,
+        );
+
+        let data_table = gc.sheet(sheet_id).data_table_at(&pos![A1]).unwrap();
+
+        let cache = TableCodeCache::from_data_table(&gc.sheet(sheet_id), pos![A1], data_table);
+
+        dbg!(&cache);
+    }
+}

--- a/quadratic-core/src/grid/file/serialize/data_table.rs
+++ b/quadratic-core/src/grid/file/serialize/data_table.rs
@@ -340,6 +340,7 @@ pub(crate) fn import_data_table_builder(
             chart_pixel_output: data_table.chart_pixel_output,
             chart_output: data_table.chart_output,
             in_table: data_table.in_table.map(|pos| Pos { x: pos.x, y: pos.y }),
+            has_code: Default::default(),
         };
 
         new_data_tables.insert(Pos { x: pos.x, y: pos.y }, data_table);

--- a/quadratic-core/src/grid/file/serialize/data_table.rs
+++ b/quadratic-core/src/grid/file/serialize/data_table.rs
@@ -339,6 +339,7 @@ pub(crate) fn import_data_table_builder(
             borders: data_table.borders.map(import_borders),
             chart_pixel_output: data_table.chart_pixel_output,
             chart_output: data_table.chart_output,
+            in_table: data_table.in_table,
         };
 
         new_data_tables.insert(Pos { x: pos.x, y: pos.y }, data_table);
@@ -567,6 +568,7 @@ pub(crate) fn export_data_tables(
                 borders,
                 chart_pixel_output: data_table.chart_pixel_output,
                 chart_output: data_table.chart_output,
+                in_table: data_table.in_table,
             };
 
             (current::PosSchema::from(pos), data_table)

--- a/quadratic-core/src/grid/file/serialize/data_table.rs
+++ b/quadratic-core/src/grid/file/serialize/data_table.rs
@@ -339,7 +339,7 @@ pub(crate) fn import_data_table_builder(
             borders: data_table.borders.map(import_borders),
             chart_pixel_output: data_table.chart_pixel_output,
             chart_output: data_table.chart_output,
-            in_table: data_table.in_table,
+            in_table: data_table.in_table.map(|pos| Pos { x: pos.x, y: pos.y }),
         };
 
         new_data_tables.insert(Pos { x: pos.x, y: pos.y }, data_table);
@@ -568,7 +568,9 @@ pub(crate) fn export_data_tables(
                 borders,
                 chart_pixel_output: data_table.chart_pixel_output,
                 chart_output: data_table.chart_output,
-                in_table: data_table.in_table,
+                in_table: data_table
+                    .in_table
+                    .map(|pos| current::PosSchema { x: pos.x, y: pos.y }),
             };
 
             (current::PosSchema::from(pos), data_table)

--- a/quadratic-core/src/grid/file/serialize/data_table.rs
+++ b/quadratic-core/src/grid/file/serialize/data_table.rs
@@ -52,6 +52,7 @@ fn import_table_ref(table_ref: current::TableRefSchema) -> TableRef {
         headers: table_ref.headers,
         totals: table_ref.totals,
         col_range: import_col_range(table_ref.col_range),
+        this_row: table_ref.this_row,
     }
 }
 
@@ -216,6 +217,7 @@ pub(crate) fn export_cell_ref_range(range: CellRefRange) -> current::CellRefRang
                 headers: range.headers,
                 totals: range.totals,
                 col_range: export_col_range(range.col_range),
+                this_row: range.this_row,
             })
         }
     }

--- a/quadratic-core/src/grid/file/v1_10/schema.rs
+++ b/quadratic-core/src/grid/file/v1_10/schema.rs
@@ -83,6 +83,9 @@ pub struct DataTableSchema {
 
     pub value: OutputValueSchema,
 
+    #[serde(default)]
+    pub in_table: bool,
+
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_modified: Option<DateTime<Utc>>,
 

--- a/quadratic-core/src/grid/file/v1_10/schema.rs
+++ b/quadratic-core/src/grid/file/v1_10/schema.rs
@@ -84,7 +84,7 @@ pub struct DataTableSchema {
     pub value: OutputValueSchema,
 
     #[serde(default)]
-    pub in_table: bool,
+    pub in_table: Option<PosSchema>,
 
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_modified: Option<DateTime<Utc>>,

--- a/quadratic-core/src/grid/file/v1_7_1/a1_selection_schema.rs
+++ b/quadratic-core/src/grid/file/v1_7_1/a1_selection_schema.rs
@@ -57,4 +57,7 @@ pub struct TableRefSchema {
     pub headers: bool,
     pub totals: bool,
     pub col_range: ColRangeSchema,
+
+    #[serde(default)]
+    pub this_row: bool,
 }

--- a/quadratic-core/src/grid/file/v1_9/upgrade.rs
+++ b/quadratic-core/src/grid/file/v1_9/upgrade.rs
@@ -39,6 +39,7 @@ fn upgrade_data_tables(data_tables: current::DataTablesSchema) -> v1_10::DataTab
                     borders,
                     chart_pixel_output: data_table.chart_pixel_output,
                     chart_output: data_table.chart_output,
+                    in_table: false,
                 },
             )
         })

--- a/quadratic-core/src/grid/file/v1_9/upgrade.rs
+++ b/quadratic-core/src/grid/file/v1_9/upgrade.rs
@@ -39,7 +39,7 @@ fn upgrade_data_tables(data_tables: current::DataTablesSchema) -> v1_10::DataTab
                     borders,
                     chart_pixel_output: data_table.chart_pixel_output,
                     chart_output: data_table.chart_output,
-                    in_table: false,
+                    in_table: None,
                 },
             )
         })

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -289,10 +289,29 @@ impl Sheet {
         rect_values
     }
 
-    /// Returns the cell_value at the Pos in column.values. This does not check or return results within code_runs.
+    /// Returns the cell_value at the Pos in column.values. This does not check
+    /// or return results within code_runs.
     pub fn cell_value(&self, pos: Pos) -> Option<CellValue> {
         let column = self.get_column(pos.x)?;
         column.values.get(&pos.y).cloned()
+    }
+
+    /// Returns the code value at the Pos either in column.values or in a data
+    /// table.
+    pub fn code_value(&self, pos: Pos) -> Option<CellValue> {
+        if let Some(column) = self.get_column(pos.x) {
+            if let Some(cell_value) = column.values.get(&pos.y) {
+                if let CellValue::Code(_) = cell_value {
+                    return Some(cell_value.clone());
+                }
+            }
+        }
+        if let Some(cell_value) = self.get_code_cell_value(pos) {
+            if let CellValue::Code(_) = cell_value {
+                return Some(cell_value.clone());
+            }
+        }
+        None
     }
 
     /// Returns the ref of the cell_value at the Pos in column.values. This does

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -1072,6 +1072,7 @@ mod test {
             Some(true),
             Some(true),
             None,
+            None,
         );
         sheet.data_table_insert_full(&pos, dt.clone());
         assert!(sheet.has_content(pos));
@@ -1319,6 +1320,7 @@ mod test {
             Some(true),
             Some(true),
             None,
+            None,
         );
         sheet.data_table_insert_full(&anchor_pos, dt);
 
@@ -1346,6 +1348,7 @@ mod test {
             false,
             Some(false),
             Some(false),
+            None,
             None,
         );
         dt_no_ui.show_name = Some(false);
@@ -1388,6 +1391,7 @@ mod test {
             false,
             Some(true),
             Some(true),
+            None,
             None,
         );
         sheet.data_table_insert_full(&pos, dt.clone());

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -571,7 +571,7 @@ impl Sheet {
                     Some(self.ref_range_bounds_to_rect(range, ignore_formatting))
                 }
                 CellRefRange::Table { range } => {
-                    self.table_ref_to_rect(range, false, false, a1_context)
+                    self.table_ref_to_rect(range, false, false, a1_context, None)
                 }
             } {
                 let rows = self.get_rows_with_wrap_in_rect(&rect, include_blanks);

--- a/quadratic-core/src/grid/sheet/ai_context.rs
+++ b/quadratic-core/src/grid/sheet/ai_context.rs
@@ -404,6 +404,7 @@ mod tests {
                 Some(false),
                 Some(false),
                 None,
+                None,
             )),
         );
 
@@ -437,6 +438,7 @@ mod tests {
                 true,
                 Some(false),
                 Some(false),
+                None,
                 None,
             )),
         );
@@ -475,6 +477,7 @@ mod tests {
                 true,
                 Some(false),
                 Some(false),
+                None,
                 None,
             )),
         );

--- a/quadratic-core/src/grid/sheet/ai_context.rs
+++ b/quadratic-core/src/grid/sheet/ai_context.rs
@@ -42,7 +42,8 @@ impl Sheet {
         a1_context: &A1Context,
     ) -> Vec<JsCellValuePosContext> {
         let mut data_rects = Vec::new();
-        let selection_rects = self.selection_to_rects(selection, false, false, true, a1_context);
+        let selection_rects =
+            self.selection_to_rects(selection, false, false, true, a1_context, None);
         let tabular_data_rects =
             self.find_tabular_data_rects_in_selection_rects(selection_rects, max_rects);
         for tabular_data_rect in tabular_data_rects {
@@ -65,7 +66,8 @@ impl Sheet {
         a1_context: &A1Context,
     ) -> Vec<JsCodeCell> {
         let mut code_cells = Vec::new();
-        let selection_rects = self.selection_to_rects(selection, false, false, true, a1_context);
+        let selection_rects =
+            self.selection_to_rects(selection, false, false, true, a1_context, None);
         for selection_rect in selection_rects {
             for x in selection_rect.x_range() {
                 if let Some(column) = self.get_column(x) {
@@ -99,7 +101,8 @@ impl Sheet {
         a1_context: &A1Context,
     ) -> Vec<JsTableSummaryContext> {
         let mut tables_summary = Vec::new();
-        let selection_rects = self.selection_to_rects(selection, false, false, true, a1_context);
+        let selection_rects =
+            self.selection_to_rects(selection, false, false, true, a1_context, None);
         let mut seen_tables = HashSet::new();
         for rect in selection_rects {
             let tables_summary_in_rect = self
@@ -137,7 +140,8 @@ impl Sheet {
         a1_context: &A1Context,
     ) -> Vec<JsChartSummaryContext> {
         let mut charts_summary = Vec::new();
-        let selection_rects = self.selection_to_rects(selection, false, false, true, a1_context);
+        let selection_rects =
+            self.selection_to_rects(selection, false, false, true, a1_context, None);
         let mut seen_tables = HashSet::new();
         for rect in selection_rects {
             let charts_summary_in_rect = self

--- a/quadratic-core/src/grid/sheet/bounds/traverse.rs
+++ b/quadratic-core/src/grid/sheet/bounds/traverse.rs
@@ -243,6 +243,7 @@ mod test {
             Some(true),
             // make the chart take up 5x5 cells
             Some((5, 5)),
+            None,
         );
         dt.show_name = Some(false);
         dt

--- a/quadratic-core/src/grid/sheet/code.rs
+++ b/quadratic-core/src/grid/sheet/code.rs
@@ -311,6 +311,7 @@ mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
         sheet.set_data_table(Pos { x: 1, y: 1 }, Some(data_table.clone()));
         let sheet = gc.sheet(sheet_id);
@@ -417,6 +418,7 @@ mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
         sheet.set_data_table(Pos { x: 1, y: 1 }, Some(data_table.clone()));
         sheet.set_data_table(Pos { x: 2, y: 2 }, Some(data_table.clone()));
@@ -455,6 +457,7 @@ mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
         sheet.set_data_table(Pos { x: 1, y: 1 }, Some(data_table.clone()));
         sheet.set_data_table(Pos { x: 2, y: 2 }, Some(data_table.clone()));
@@ -481,6 +484,7 @@ mod test {
             false,
             Some(false),
             Some(false),
+            None,
             None,
         );
         dt.chart_output = Some((2, 2));

--- a/quadratic-core/src/grid/sheet/data_table.rs
+++ b/quadratic-core/src/grid/sheet/data_table.rs
@@ -36,6 +36,12 @@ impl Sheet {
         })
     }
 
+    /// Returns position if a location is in a data table (for use in code cells).
+    pub fn check_in_data_table(&self, pos: Pos) -> Option<Pos> {
+        self.data_table_that_contains(pos)
+            .and_then(|(pos, table)| table.is_data_table().then_some(pos))
+    }
+
     /// Returns the (Pos, DataTable) that intersects a position
     pub fn data_table_that_contains(&self, pos: Pos) -> Option<(Pos, &DataTable)> {
         self.data_tables.get_contains(pos)
@@ -552,6 +558,7 @@ mod test {
             "Table 1",
             Value::Single(CellValue::Number(BigDecimal::from(2))),
             false,
+            None,
             None,
             None,
             None,

--- a/quadratic-core/src/grid/sheet/data_tables/mod.rs
+++ b/quadratic-core/src/grid/sheet/data_tables/mod.rs
@@ -14,7 +14,7 @@ use anyhow::{Result, anyhow};
 pub mod cache;
 use cache::SheetDataTablesCache;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SheetDataTables {
     #[serde(with = "crate::util::indexmap_serde")]
     data_tables: IndexMap<Pos, DataTable>,
@@ -534,6 +534,18 @@ impl SheetDataTables {
     }
 }
 
+// Custom Debug implementation for SheetDataTables
+impl std::fmt::Debug for SheetDataTables {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "SheetDataTables {{")?;
+        writeln!(f, "  data_tables:")?;
+        for (pos, table) in &self.data_tables {
+            writeln!(f, "    {:?}: {:?}", pos, table)?;
+        }
+        writeln!(f, "}}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{grid::CodeCellLanguage, test_util::*};
@@ -552,7 +564,5 @@ mod tests {
             None,
             None,
         );
-
-        print_first_sheet(&gc);
     }
 }

--- a/quadratic-core/src/grid/sheet/rendering/cells.rs
+++ b/quadratic-core/src/grid/sheet/rendering/cells.rs
@@ -367,6 +367,7 @@ mod tests {
                 Some(true),
                 Some(true),
                 None,
+                None,
             )),
         );
         assert!(sheet.has_render_cells(rect));

--- a/quadratic-core/src/grid/sheet/rendering/cells.rs
+++ b/quadratic-core/src/grid/sheet/rendering/cells.rs
@@ -150,6 +150,14 @@ impl Sheet {
                         let value = data_table.cell_value_at(pos.x as u32, pos.y as u32);
 
                         if let Some(value) = value {
+                            if value.is_code() {
+                                dbgjs!(&value);
+                                dbgjs!(&Pos { x, y });
+                                dbgjs!(&self.data_tables);
+                                if let Some(code_table) = self.data_table_at(&Pos { x, y }) {
+                                    dbgjs!(&code_table);
+                                }
+                            }
                             let mut format = if is_header {
                                 // column headers are always clipped and bold
                                 Format {

--- a/quadratic-core/src/grid/sheet/rendering/code.rs
+++ b/quadratic-core/src/grid/sheet/rendering/code.rs
@@ -311,6 +311,7 @@ mod tests {
             Some(false),
             Some(false),
             None,
+            None,
         );
 
         let context = A1Context::default();
@@ -374,6 +375,7 @@ mod tests {
             Some(false),
             Some(false),
             None,
+            None,
         );
         let code_cells = sheet.get_render_code_cells(
             &code_cell,
@@ -420,6 +422,7 @@ mod tests {
             "Table 1",
             Value::Single(CellValue::Number(2.into())),
             false,
+            None,
             None,
             None,
             None,
@@ -490,6 +493,7 @@ mod tests {
             Some(false),
             Some(false),
             None,
+            None,
         );
         sheet.set_data_table(pos, Some(data_table));
         sheet.set_cell_value(pos, code);
@@ -529,6 +533,7 @@ mod tests {
                 false,
                 Some(true),
                 Some(true),
+                None,
                 None,
             )),
         );

--- a/quadratic-core/src/grid/sheet/search.rs
+++ b/quadratic-core/src/grid/sheet/search.rs
@@ -544,6 +544,7 @@ mod test {
             Some(false),
             Some(false),
             None,
+            None,
         );
         sheet.set_data_table(Pos { x: 1, y: 2 }, Some(data_table));
 
@@ -592,6 +593,7 @@ mod test {
             false,
             Some(false),
             Some(false),
+            None,
             None,
         );
         sheet.set_data_table(Pos { x: 1, y: 2 }, Some(data_table));

--- a/quadratic-core/src/grid/sheet/sheet_test.rs
+++ b/quadratic-core/src/grid/sheet/sheet_test.rs
@@ -77,6 +77,7 @@ impl Sheet {
                 Some(false),
                 Some(false),
                 None,
+                None,
             )),
         );
     }
@@ -138,6 +139,7 @@ impl Sheet {
                 Some(false),
                 Some(false),
                 None,
+                None,
             )),
         );
         let a1_context = self.expensive_make_a1_context();
@@ -188,6 +190,7 @@ impl Sheet {
                 Some(false),
                 Some(false),
                 None,
+                None,
             )),
         );
     }
@@ -222,6 +225,7 @@ impl Sheet {
                 Some(true),
                 Some(true),
                 Some((w, h)),
+                None,
             )),
         );
     }
@@ -256,6 +260,7 @@ impl Sheet {
                 Some(true),
                 Some(true),
                 Some((w, h)),
+                None,
             )),
         );
     }
@@ -288,6 +293,7 @@ impl Sheet {
                 header_is_first_row,
                 show_name,
                 show_columns,
+                None,
                 None,
             )),
         );

--- a/quadratic-core/src/test_util/create_code_table.rs
+++ b/quadratic-core/src/test_util/create_code_table.rs
@@ -76,6 +76,7 @@ pub fn test_create_code_table_with_values(
         Some(false),
         Some(false),
         None,
+        None,
     );
 
     let op = Operation::AddDataTable {

--- a/quadratic-core/src/values/array.rs
+++ b/quadratic-core/src/values/array.rs
@@ -251,6 +251,10 @@ impl Array {
                 .collect()
         })
     }
+    /// Returns an iterator over the values in the array.
+    pub fn values_iter(&self) -> impl Iterator<Item = &CellValue> {
+        self.values.iter()
+    }
     /// Constructs an array from rows (if `axis` is `Axis::Y`) or columns (if
     /// `axis` is `Axis::X`). All rows/columns must have the same length, or
     /// else the result is undefined. Returns `None` if `slices` is empty or if

--- a/quadratic-core/src/values/cellvalue.rs
+++ b/quadratic-core/src/values/cellvalue.rs
@@ -1444,7 +1444,5 @@ mod test {
             value,
             CellValue::Number(BigDecimal::from_str("-123.123").unwrap())
         );
-
-
     }
 }

--- a/quadratic-core/src/wasm_bindings/a1.rs
+++ b/quadratic-core/src/wasm_bindings/a1.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use crate::{
+    Pos,
     a1::{A1Selection, CellRefRange, RefRangeBounds, js_selection::JsSelection},
     grid::SheetId,
 };
@@ -73,15 +74,26 @@ pub fn cell_ref_range_to_ref_range_bounds(
     cell_ref_range: String,
     show_table_headers_for_python: bool,
     context: &JsA1Context,
+    source_cell_x: Option<i32>,
+    source_cell_y: Option<i32>,
 ) -> Result<JsValue, String> {
     let cell_ref_range =
         serde_json::from_str::<CellRefRange>(&cell_ref_range).map_err(|e| e.to_string())?;
     let ref_range_bounds = match cell_ref_range {
         CellRefRange::Sheet { range } => range,
         CellRefRange::Table { range } => {
+            let source_cell = if let (Some(x), Some(y)) = (source_cell_x, source_cell_y) {
+                Some(Pos {
+                    x: x as i64,
+                    y: y as i64,
+                })
+            } else {
+                None
+            };
             match range.convert_cells_accessed_to_ref_range_bounds(
                 show_table_headers_for_python,
                 context.get_context(),
+                source_cell,
             ) {
                 Some(ref_range_bounds) => ref_range_bounds,
                 None => {

--- a/quadratic-core/src/wasm_bindings/controller/code.rs
+++ b/quadratic-core/src/wasm_bindings/controller/code.rs
@@ -23,8 +23,17 @@ impl GridController {
         &mut self,
         transaction_id: String,
         a1: String,
+        source_x: i32,
+        source_y: i32,
     ) -> Result<Vec<u8>, String> {
-        let response = self.calculation_get_cells_a1(transaction_id, a1);
+        let response = self.calculation_get_cells_a1(
+            transaction_id,
+            a1,
+            Some(Pos {
+                x: source_x as i64,
+                y: source_y as i64,
+            }),
+        );
         match serde_json::to_vec(&response) {
             Ok(vec) => Ok(vec),
             Err(e) => {

--- a/quadratic-core/src/wasm_bindings/controller/code.rs
+++ b/quadratic-core/src/wasm_bindings/controller/code.rs
@@ -23,17 +23,8 @@ impl GridController {
         &mut self,
         transaction_id: String,
         a1: String,
-        source_x: i32,
-        source_y: i32,
     ) -> Result<Vec<u8>, String> {
-        let response = self.calculation_get_cells_a1(
-            transaction_id,
-            a1,
-            Some(Pos {
-                x: source_x as i64,
-                y: source_y as i64,
-            }),
-        );
+        let response = self.calculation_get_cells_a1(transaction_id, a1);
         match serde_json::to_vec(&response) {
             Ok(vec) => Ok(vec),
             Err(e) => {


### PR DESCRIPTION
## Relevant issue(s)
Closes #2469

- [x] implement this row: `Table[@Column 1]` or `Table[[#this row],[Column 1]]` or `Table[[@Column 1]]`
- [ ] allow code w/single cell output within data tables