### PR TITLE
fix: put return type error on a single line

### DIFF
--- a/quadratic-client/src/app/ui/menus/CodeEditor/ReturnTypeInspector.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/ReturnTypeInspector.tsx
@@ -48,9 +48,9 @@ export const ReturnTypeInspector = memo(() => {
   if (consoleOutput?.stdErr) {
     hasError = true;
     message = (
-      <p>
+      <span>
         Returned <ReturnType isError>error</ReturnType>{' '}
-      </p>
+      </span>
     );
     action = (
       <Button
@@ -76,9 +76,9 @@ export const ReturnTypeInspector = memo(() => {
   } else if (spillError) {
     hasError = true;
     message = (
-      <p>
+      <span>
         Returned <ReturnType isError>error</ReturnType> (spill)
-      </p>
+      </span>
     );
     action = <FixSpillError codeCell={codeCellRecoil} evaluationResult={evaluationResult ?? {}} />;
   } else if (mode === 'Python') {


### PR DESCRIPTION
## Description
How it looks today:
![CleanShot 2025-07-02 at 14 03 25@2x](https://github.com/user-attachments/assets/57de9af6-750a-47f7-9d1b-7cfeaf8fce7f)

How it should look:

![CleanShot 2025-07-02 at 14 05 08@2x](https://github.com/user-attachments/assets/344474da-b677-4164-84f6-e5756a5e8105)