### PR TITLE
render the column rename only after update has completed

### DIFF
--- a/quadratic-client/src/app/events/events.ts
+++ b/quadratic-client/src/app/events/events.ts
@@ -129,6 +129,10 @@ interface EventTypes {
 
   // use this only if you need to immediately get the viewport's value (ie, from React)
   viewportChangedReady: () => void;
+
+  // use this to get the viewport's value after an update is complete
+  viewportReadyAfterUpdate: () => void;
+
   hashContentChanged: (sheetId: string, hashX: number, hashY: number) => void;
 
   recentFiles: (url: string, name: string, loaded: boolean) => void;

--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
@@ -62,9 +62,9 @@ export const TableColumnHeaderRename = () => {
 
   useEffect(() => {
     updatePosition();
-    events.on('viewportChanged', updatePosition);
+    events.on('viewportReadyAfterUpdate', updatePosition);
     return () => {
-      events.off('viewportChanged', updatePosition);
+      events.off('viewportReadyAfterUpdate', updatePosition);
     };
   }, [updatePosition]);
 

--- a/quadratic-client/src/app/gridGL/cells/tables/TableColumnHeader.ts
+++ b/quadratic-client/src/app/gridGL/cells/tables/TableColumnHeader.ts
@@ -100,24 +100,24 @@ export class TableColumnHeader extends Container {
     this.sortIcon.scale.y = this.sortIcon.scale.x;
   };
 
-  private updateSortButton = (width: number, height: number, sort: DataTableSort | undefined) => {
-    this.sortButtonStart = this.columnHeaderBounds.right - SORT_BUTTON_RADIUS * 2 - SORT_BUTTON_PADDING * 2;
-    if (!this.sortButton) {
-      throw new Error('Expected sortButton to be defined in updateSortButton');
-    }
-    this.sortButton.position.set(width - SORT_BUTTON_RADIUS - SORT_BUTTON_PADDING, height / 2);
-    this.updateSortButtonVisibility(this.sortButton.visible);
+  // private updateSortButton = (width: number, height: number, sort: DataTableSort | undefined) => {
+  //   this.sortButtonStart = this.columnHeaderBounds.right - SORT_BUTTON_RADIUS * 2 - SORT_BUTTON_PADDING * 2;
+  //   if (!this.sortButton) {
+  //     throw new Error('Expected sortButton to be defined in updateSortButton');
+  //   }
+  //   this.sortButton.position.set(width - SORT_BUTTON_RADIUS - SORT_BUTTON_PADDING, height / 2);
+  //   this.updateSortButtonVisibility(this.sortButton.visible);
 
-    if (!this.sortIcon) {
-      throw new Error('Expected sortIcon to be defined in updateSortButton');
-    }
-    this.sortIcon.position = this.sortButton.position;
-    this.sortIcon.texture = sort
-      ? Texture.from(sort.direction === 'Descending' ? 'sort-descending' : 'sort-ascending')
-      : Texture.EMPTY;
-    this.sortIcon.width = SORT_ICON_SIZE;
-    this.sortIcon.scale.y = this.sortIcon.scale.x;
-  };
+  //   if (!this.sortIcon) {
+  //     throw new Error('Expected sortIcon to be defined in updateSortButton');
+  //   }
+  //   this.sortIcon.position = this.sortButton.position;
+  //   this.sortIcon.texture = sort
+  //     ? Texture.from(sort.direction === 'Descending' ? 'sort-descending' : 'sort-ascending')
+  //     : Texture.EMPTY;
+  //   this.sortIcon.width = SORT_ICON_SIZE;
+  //   this.sortIcon.scale.y = this.sortIcon.scale.x;
+  // };
 
   updateSortButtonVisibility = (visible: boolean) => {
     if (!this.sortButton) {

--- a/quadratic-client/src/app/gridGL/pixiApp/Update.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/Update.ts
@@ -152,6 +152,7 @@ export class Update {
       debugRendererLight(true);
       debugShowChildren(pixiApp.stage, 'stage');
       thumbnail.rendererBusy();
+      events.emit('viewportReadyAfterUpdate');
     } else {
       debugRendererLight(false);
       thumbnail.check();


### PR DESCRIPTION
## Relevant issue(s)
Fixes #3099

## Description
Properly positioned column rename when hovering on first use.