### PR TITLE
Ensures GridSettings are loaded before app starts

### DIFF
--- a/quadratic-client/src/app/gridGL/pixiApp/PixiAppSettings.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/PixiAppSettings.ts
@@ -103,6 +103,9 @@ export class PixiAppSettings {
   }
 
   private getSettings = (): void => {
+    // need to wait until pixiApp is initialized before we can set it
+    if (!pixiApp?.initialized) return;
+
     const settings = localStorage.getItem('viewSettings');
     if (settings) {
       this.settings = JSON.parse(settings) as GridSettings;

--- a/quadratic-client/src/app/ui/QuadraticApp.tsx
+++ b/quadratic-client/src/app/ui/QuadraticApp.tsx
@@ -4,6 +4,7 @@ import {
   editorInteractionStatePermissionsAtom,
   editorInteractionStateUserAtom,
 } from '@/app/atoms/editorInteractionStateAtom';
+import { gridSettingsAtom } from '@/app/atoms/gridSettingsAtom';
 import { events } from '@/app/events/events';
 import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import QuadraticUIContext from '@/app/ui/QuadraticUIContext';
@@ -25,6 +26,9 @@ export function QuadraticApp() {
   const fileUuid = useRecoilValue(editorInteractionStateFileUuidAtom);
   const [searchParams] = useSearchParams();
   const checkpointId = useMemo(() => searchParams.get(SEARCH_PARAMS.CHECKPOINT.KEY), [searchParams]);
+
+  // ensure GridSettings are loaded before app starts
+  useRecoilValue(gridSettingsAtom);
 
   // Loading states
   const [offlineLoading, setOfflineLoading] = useState(true);

--- a/quadratic-client/src/app/ui/QuadraticApp.tsx
+++ b/quadratic-client/src/app/ui/QuadraticApp.tsx
@@ -16,19 +16,19 @@ import { SEARCH_PARAMS } from '@/shared/constants/routes';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useSearchParams } from 'react-router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 } from 'uuid';
 
 export function QuadraticApp() {
+  // ensure GridSettings are loaded before app starts
+  useSetRecoilState(gridSettingsAtom);
+
   const didMount = useRef<boolean>(false);
   const permissions = useRecoilValue(editorInteractionStatePermissionsAtom);
   const loggedInUser = useRecoilValue(editorInteractionStateUserAtom);
   const fileUuid = useRecoilValue(editorInteractionStateFileUuidAtom);
   const [searchParams] = useSearchParams();
   const checkpointId = useMemo(() => searchParams.get(SEARCH_PARAMS.CHECKPOINT.KEY), [searchParams]);
-
-  // ensure GridSettings are loaded before app starts
-  useRecoilValue(gridSettingsAtom);
 
   // Loading states
   const [offlineLoading, setOfflineLoading] = useState(true);


### PR DESCRIPTION
This fixes a timing bug, where the app may load before the grid settings (eg, Show AI on Startup) finishes loading.