### PR TITLE
Fixes placement of table headers when generating thumbnail

### DIFF
--- a/quadratic-client/src/app/gridGL/cells/tables/Tables.ts
+++ b/quadratic-client/src/app/gridGL/cells/tables/Tables.ts
@@ -85,6 +85,7 @@ export class Tables extends Container<Table> {
     events.off('updateCodeCells', this.updateCodeCells);
 
     events.off('cursorPosition', this.cursorPosition);
+    events.off('a1ContextUpdated', this.cursorPosition);
     events.off('sheetOffsets', this.sheetOffsets);
 
     events.off('contextMenu', this.contextMenu);
@@ -259,8 +260,8 @@ export class Tables extends Container<Table> {
   };
 
   /// Returns the tables that are visible in the viewport.
-  private getVisibleTables = (): Table[] => {
-    const bounds = pixiApp.viewport.getVisibleBounds();
+  private getVisibleTables = (forceBounds?: Rectangle): Table[] => {
+    const bounds = forceBounds ?? pixiApp.viewport.getVisibleBounds();
     const cellBounds = sheets.sheet.getRectangleFromScreen(bounds);
     const tables = this.dataTablesCache?.getLargeTablesInRect(
       cellBounds.x,
@@ -277,6 +278,13 @@ export class Tables extends Container<Table> {
         return [];
       }) ?? []
     );
+  };
+
+  /// Forces an update of all tables to the given bounds (used by thumbnail generation)
+  forceUpdate = (bounds: Rectangle) => {
+    const gridHeading = pixiApp.headings.headingSize.unscaledHeight;
+    const visibleTables = this.getVisibleTables(bounds);
+    visibleTables?.forEach((table) => table.update(bounds, gridHeading));
   };
 
   update = (dirtyViewport: boolean) => {

--- a/quadratic-client/src/app/gridGL/pixiApp/PixiApp.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/PixiApp.ts
@@ -313,6 +313,7 @@ export class PixiApp {
     cull: Rectangle;
     gridLines?: boolean;
     ai?: boolean;
+    thumbnail?: boolean;
   }): Promise<Container> => {
     // this is expensive, so we do it first, before blocking the canvas renderer
     await this.htmlPlaceholders.prepare({ sheetId: options.sheetId, cull: options.cull });
@@ -329,6 +330,9 @@ export class PixiApp {
     this.cellsSheets.toggleOutlines(false);
     this.copy.visible = false;
     this.cellsSheets.cull(options.cull);
+    if (options.thumbnail) {
+      this.cellsSheet().tables.forceUpdate(options.cull);
+    }
     return this.viewportContents;
   };
 
@@ -342,7 +346,9 @@ export class PixiApp {
     this.htmlPlaceholders.hide();
     this.cellsSheets.toggleOutlines();
     this.copy.visible = true;
-    this.cellsSheets.cull(this.viewport.getVisibleBounds());
+    const bounds = this.viewport.getVisibleBounds();
+    this.cellsSheets.cull(bounds);
+    this.cellsSheet().tables.forceUpdate(bounds);
     this.copying = false;
   };
 

--- a/quadratic-client/src/app/gridGL/pixiApp/thumbnail.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/thumbnail.ts
@@ -71,7 +71,7 @@ class Thumbnail {
   private generate = async (): Promise<Blob | null> => {
     const sheetId = sheets.getFirst().id;
     const rectangle = new Rectangle(0, 0, imageWidth, imageHeight);
-    await pixiApp.prepareForCopying({ sheetId, cull: rectangle, gridLines: true });
+    await pixiApp.prepareForCopying({ sheetId, cull: rectangle, gridLines: true, thumbnail: true });
     pixiApp.gridLines.update(rectangle, undefined, true);
     this.renderer.render(pixiApp.viewportContents);
     pixiApp.cleanUpAfterCopying();


### PR DESCRIPTION
When viewport is scrolled, the floating table headers may be misplaced during thumbnail generation.

Old:
![CleanShot 2025-07-08 at 07 03 17@2x](https://github.com/user-attachments/assets/e2c6742b-6d14-4c0a-9298-6e93a0dcd73c)

New:
![CleanShot 2025-07-08 at 07 25 12@2x](https://github.com/user-attachments/assets/1b03b5ca-90c2-4ed3-96fe-e82677c3614a)
