### PR TITLE
fix: model router for tool calls

### DIFF
--- a/quadratic-api/src/ai/helpers/modelRouter.helper.ts
+++ b/quadratic-api/src/ai/helpers/modelRouter.helper.ts
@@ -23,6 +23,10 @@ export const getModelKey = async (
   exceededBillingLimit: boolean
 ): Promise<AIModelKey> => {
   try {
+    if (!['AIAnalyst', 'AIAssistant'].includes(inputArgs.source)) {
+      return modelKey;
+    }
+
     if (!isOnPaidPlan) {
       return DEFAULT_MODEL_FREE;
     }


### PR DESCRIPTION
## Relevant issue(s)
fixes: free users use `DEFAULT_MODEL_FREE` for everything, ignoring tool call models