### PR TITLE
Convert f64 into RustDecimal in formulas

### DIFF
--- a/quadratic-core/Cargo.toml
+++ b/quadratic-core/Cargo.toml
@@ -113,7 +113,7 @@ quadratic-rust-shared = { path = "../quadratic-rust-shared", default-features = 
 ] }
 prost = { version = "0.13.5", default-features = false }
 encoding_rs_io = "0.1.7"
-rust_decimal = "1.37.2"
+rust_decimal = { version = "1.37.2", features = ["maths"] }
 zstd = "0.13.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/quadratic-core/proptest-regressions/formulas/functions/mathematics.txt
+++ b/quadratic-core/proptest-regressions/formulas/functions/mathematics.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 46f6d308889981a49c43098fe29f52576244dc93b72f5bce639a10d50511a5ad # shrinks to n = 0.0, d = 0.0
+cc 1549da59fb71956fa92da7a1fe24b783cb879b360f91aaeb68714b97f9d13d66 # shrinks to n = -7.725432810687621

--- a/quadratic-core/src/formulas/functions/statistics.rs
+++ b/quadratic-core/src/formulas/functions/statistics.rs
@@ -1,3 +1,5 @@
+use rust_decimal::prelude::*;
+
 use super::*;
 
 pub const CATEGORY: FormulaFunctionCategory = FormulaFunctionCategory {
@@ -13,7 +15,7 @@ fn get_functions() -> Vec<FormulaFunction> {
         formula_fn!(
             /// Returns the arithmetic mean of all values.
             #[examples("AVERAGE(A1:A6)", "AVERAGE(A1, A3, A5, B1:B6)")]
-            fn AVERAGE(span: Span, numbers: (Iter<f64>)) {
+            fn AVERAGE(span: Span, numbers: (Iter<Decimal>)) {
                 CellValue::average(span, numbers)
             }
         ),
@@ -37,8 +39,8 @@ fn get_functions() -> Vec<FormulaFunction> {
                 numbers_range: (Option<Spanned<Array>>),
             ) {
                 let criteria = Criterion::try_from(*criteria)?;
-                let numbers =
-                    criteria.iter_matching_coerced::<f64>(eval_range, numbers_range.as_ref())?;
+                let numbers = criteria
+                    .iter_matching_coerced::<Decimal>(eval_range, numbers_range.as_ref())?;
                 CellValue::average(*span, numbers)
             }
         ),

--- a/quadratic-core/src/formulas/functions/trigonometry.rs
+++ b/quadratic-core/src/formulas/functions/trigonometry.rs
@@ -135,6 +135,7 @@ mod tests {
 
     use crate::util::assert_f64_approx_eq;
     use crate::{controller::GridController, formulas::tests::*};
+    use rust_decimal::prelude::*;
 
     fn test_trig_fn(name: &str, input_output_pairs: &[(f64, f64)]) {
         let g = GridController::new();
@@ -143,7 +144,7 @@ mod tests {
             assert_f64_approx_eq(
                 expected_output,
                 eval_to_string(&g, &format!("{name}({input})"))
-                    .parse::<f64>()
+                    .parse::<Decimal>()
                     .unwrap(),
                 &format!("Testing {name}({input})"),
             );
@@ -159,7 +160,7 @@ mod tests {
         assert_f64_approx_eq(
             -4.0,
             eval_to_string(&g, "RADIANS(-720) / PI()")
-                .parse::<f64>()
+                .parse::<Decimal>()
                 .unwrap(),
             "Testing RADIANS(-720) / PI()",
         );
@@ -167,7 +168,7 @@ mod tests {
         assert_f64_approx_eq(
             -720.0,
             eval_to_string(&g, "DEGREES(-PI() * 4)")
-                .parse::<f64>()
+                .parse::<Decimal>()
                 .unwrap(),
             "Testing DEGREES(-PI() * 4)",
         );
@@ -510,8 +511,21 @@ mod tests {
     }
 
     #[test]
-    fn test_acos_degrees() {
+    fn test_precision() {
         let g = GridController::new();
+
+        // assert_eq!("5", eval_to_string(&g, "ABS(-5)"));
+        // assert_eq!("3.16227766016838", eval_to_string(&g, "SQRT(10)"));
+        // assert_eq!("100", eval_to_string(&g, "POWER(10, 2)"));
+        // assert_eq!("3", eval_to_string(&g, "CEILING(2.718, 1)"));
+        // assert_eq!("2", eval_to_string(&g, "FLOOR(2.718, 1)"));
+        // assert_eq!("2", eval_to_string(&g, "INT(2.718)"));
+        // assert_eq!("2.71828182845904", eval_to_string(&g, "EXP(1)"));
+        assert_eq!("1", eval_to_string(&g, "LN(EXP(1))"));
+        assert_eq!("2", eval_to_string(&g, "LOG(100)"));
+        assert_eq!("2", eval_to_string(&g, "LOG10(100)"));
+        assert_eq!("179.90874767108", eval_to_string(&g, "DEGREES(3.14)"));
+
         assert_eq!("60", eval_to_string(&g, "DEGREES(ACOS(0.5))"));
     }
 }

--- a/quadratic-core/src/formulas/parser/rules/atoms.rs
+++ b/quadratic-core/src/formulas/parser/rules/atoms.rs
@@ -1,3 +1,5 @@
+use rust_decimal::prelude::*;
+
 use crate::{
     RefError,
     a1::{A1Error, SheetCellRefRange},
@@ -37,7 +39,7 @@ impl SyntaxRule for NumericLiteral {
     fn consume_match(&self, p: &mut Parser<'_>) -> CodeResult<Self::Output> {
         match p.next() {
             Some(Token::NumericLiteral) => {
-                let Ok(n) = p.token_str().parse::<f64>() else {
+                let Ok(n) = p.token_str().parse::<Decimal>() else {
                     return Err(RunErrorMsg::BadNumber.with_span(p.span()));
                 };
                 Ok(AstNode {

--- a/quadratic-core/src/formulas/tests.rs
+++ b/quadratic-core/src/formulas/tests.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use itertools::Itertools;
-use rust_decimal::prelude::*;
 
 pub(crate) use super::*;
 use crate::a1::{CellRefCoord, CellRefRange, SheetCellRefRange};
@@ -81,14 +80,11 @@ pub(crate) fn check_syntax_to_err(grid: &GridController, s: &str) -> RunError {
 #[track_caller]
 pub(crate) fn assert_f64_eval(grid: &GridController, expected: f64, s: &str) {
     let output = eval(grid, s).into_cell_value().unwrap();
+
     let CellValue::Number(n) = output else {
         panic!("expected number; got {output}");
     };
-    crate::util::assert_f64_approx_eq(
-        expected,
-        n.to_f64().unwrap(),
-        &format!("wrong result for formula {s:?}"),
-    );
+    crate::util::assert_f64_approx_eq(expected, n, &format!("wrong result for formula {s:?}"));
 }
 
 /// Parses a date from a string such as `2024-12-31`.

--- a/quadratic-core/src/formulas/util.rs
+++ b/quadratic-core/src/formulas/util.rs
@@ -1,10 +1,15 @@
+use rust_decimal::Decimal;
+
 use crate::{CodeResult, RunErrorMsg, Span};
 
 /// Divides one number by another, return an error in case of division by zero.
-pub fn checked_div(span: impl Into<Span>, dividend: f64, divisor: f64) -> CodeResult<f64> {
-    let result = dividend / divisor;
-    match result.is_finite() {
-        true => Ok(result),
-        false => Err(RunErrorMsg::DivideByZero.with_span(span)),
+pub fn checked_div(
+    span: impl Into<Span>,
+    dividend: Decimal,
+    divisor: Decimal,
+) -> CodeResult<Decimal> {
+    match Decimal::checked_div(dividend, divisor) {
+        Some(result) => Ok(result),
+        None => Err(RunErrorMsg::DivideByZero.with_span(span)),
     }
 }

--- a/quadratic-core/src/util.rs
+++ b/quadratic-core/src/util.rs
@@ -6,6 +6,9 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 
+#[cfg(test)]
+use rust_decimal::prelude::*;
+
 use crate::RefError;
 use crate::a1::UNBOUNDED;
 
@@ -417,11 +420,12 @@ macro_rules! print_first_sheet {
 
 #[cfg(test)]
 #[track_caller]
-pub(crate) fn assert_f64_approx_eq(expected: f64, actual: f64, message: &str) {
-    const EPSILON: f64 = 0.0001;
+pub(crate) fn assert_f64_approx_eq(expected: f64, actual: Decimal, message: &str) {
+    let epsilon = Decimal::from_f64(0.0001).unwrap();
+    let expected_decimal = Decimal::from_f64(expected).unwrap();
 
     assert!(
-        (expected - actual).abs() < EPSILON,
+        (expected_decimal - actual).abs() < epsilon,
         "{message}: expected {expected} but got {actual}"
     );
 }

--- a/quadratic-core/src/values/cellvalue.rs
+++ b/quadratic-core/src/values/cellvalue.rs
@@ -1014,11 +1014,7 @@ impl CellValue {
 
         let v = match (&a, &b) {
             (CellValue::Number(n1), CellValue::Number(n2)) => {
-                CellValue::from(crate::formulas::util::checked_div(
-                    span,
-                    n1.to_f64().unwrap_or(0.0),
-                    n2.to_f64().unwrap_or(0.0),
-                )?)
+                CellValue::from(crate::formulas::util::checked_div(span, *n1, *n2)?)
             }
             (CellValue::Duration(d), CellValue::Number(n)) => {
                 let recip = n.to_f64().unwrap_or(1.0).recip();
@@ -1046,17 +1042,17 @@ impl CellValue {
     /// there are no values. Ignores blank values.
     pub fn average(
         span: Span,
-        values: impl IntoIterator<Item = CodeResult<f64>>,
-    ) -> CodeResult<f64> {
+        values: impl IntoIterator<Item = CodeResult<Decimal>>,
+    ) -> CodeResult<Decimal> {
         // This may someday be generalized to work with dates as well, but it's
         // important that it still ignores blanks.
-        let mut sum = 0.0;
-        let mut count = 0;
+        let mut sum = Decimal::zero();
+        let mut count = Decimal::zero();
         for n in values {
             sum += n?;
-            count += 1;
+            count += Decimal::one();
         }
-        crate::formulas::util::checked_div(span, sum, count as f64)
+        crate::formulas::util::checked_div(span, sum, count)
     }
 
     pub fn code_cell_value(&self) -> Option<CodeCellValue> {

--- a/quadratic-core/src/values/convert.rs
+++ b/quadratic-core/src/values/convert.rs
@@ -46,10 +46,15 @@ impl From<Decimal> for CellValue {
 }
 impl From<f64> for CellValue {
     fn from(value: f64) -> Self {
+        println!("value: {}", value);
         match Decimal::try_from(value) {
             Ok(n) => CellValue::Number(if n.scale() > F64_DECIMAL_PRECISION {
-                round(n, F64_DECIMAL_PRECISION as i64 + 1)
+                println!("n: {}", n);
+                println!("n.scale(): {}", n.scale());
+                round(n, F64_DECIMAL_PRECISION as i64)
             } else {
+                println!("n: {}", n);
+                println!("n.scale(): {}", n.scale());
                 n
             }),
             // TODO: add span information
@@ -306,6 +311,7 @@ macro_rules! impl_try_from_cell_value_for {
 impl_try_from_cell_value_for!(f64);
 impl_try_from_cell_value_for!(i64);
 impl_try_from_cell_value_for!(bool);
+impl_try_from_cell_value_for!(Decimal);
 
 impl<'a> TryFrom<&'a Value> for &'a CellValue {
     type Error = RunErrorMsg;
@@ -344,6 +350,7 @@ impl_try_from_value_for!(String);
 impl_try_from_value_for!(f64);
 impl_try_from_value_for!(i64);
 impl_try_from_value_for!(bool);
+impl_try_from_value_for!(Decimal);
 
 /// Coercion from `Value` or `CellValue` into a particular Rust type.
 pub trait CoerceInto: Sized + Unspan


### PR DESCRIPTION
Converts f64 into RustDecimal for forumlas.

Rather than directly merge into number-types-poc branch, I'm keeping this separate since it's a lot of noixe.
