### PR TITLE
Fix EmptyPage's mixpanel 

### DIFF
--- a/quadratic-client/src/shared/components/EmptyPage.tsx
+++ b/quadratic-client/src/shared/components/EmptyPage.tsx
@@ -43,7 +43,15 @@ export function EmptyPage(props: EmptyPageProps) {
       mixpanel.track('[Empty].error', {
         title: sourceTitle,
         description,
-        error: JSON.stringify(error),
+        error:
+          error instanceof Error
+            ? {
+                name: error.name,
+                message: error.message,
+                stack: error.stack,
+              }
+            : error,
+        from: source,
       });
       Sentry.captureException(new Error('error-page'), {
         extra: {


### PR DESCRIPTION
Fixes the error information sent via EmptyPage to mixpanel (currently it's blank(.