### PR TITLE
fix: underline underlines empty cells in tables

### DIFF
--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -411,7 +411,7 @@ export class CellLabel {
     const chars = [];
     const lineWidths: number[] = [];
     const lineSpaces: number[] = [];
-    const displayText = originalText.replace(/(?:\r\n|\r)/g, '\n') || ' ';
+    const displayText = originalText.replace(/(?:\r\n|\r)/g, '\n') || '';
     const charsInput = splitTextToCharacters(displayText);
     const scale = this.fontSize / data.size;
     const maxWidth = this.maxWidth;


### PR DESCRIPTION
## Relevant issue(s)
closes #3249 