### PR TITLE
Fix second durations

### DIFF
--- a/quadratic-core/src/controller/user_actions/cells.rs
+++ b/quadratic-core/src/controller/user_actions/cells.rs
@@ -63,7 +63,7 @@ impl GridController {
 #[cfg(test)]
 mod test {
     use crate::{
-        CellValue, Pos, Rect, SheetPos,
+        CellValue, Duration, Pos, Rect, SheetPos,
         a1::A1Selection,
         controller::{GridController, user_actions::import::tests::simple_csv_at},
         grid::{NumericFormat, SheetId, formats::FormatUpdate, sort::SortDirection},
@@ -821,5 +821,32 @@ mod test {
             1,
             CellValue::Number(decimal_from_str("0.1").unwrap()),
         );
+    }
+
+    #[test]
+    fn test_set_cell_value_5s() {
+        let mut gc = test_create_gc();
+        let sheet_id = first_sheet_id(&gc);
+
+        gc.set_cell_value(pos![sheet_id!A1], "5s".to_string(), None);
+        assert_cell_value(
+            &gc,
+            sheet_id,
+            1,
+            1,
+            CellValue::Duration(Duration::from_seconds(5.0)),
+        );
+
+        assert_display_cell_value_pos(&gc, sheet_id, pos![A1], "5s");
+
+        let gc = test_export_and_import(&gc);
+        assert_cell_value(
+            &gc,
+            sheet_id,
+            1,
+            1,
+            CellValue::Duration(Duration::from_seconds(5.0)),
+        );
+        assert_display_cell_value_pos(&gc, sheet_id, pos![A1], "5s");
     }
 }

--- a/quadratic-core/src/grid/file/serialize/cell_value.rs
+++ b/quadratic-core/src/grid/file/serialize/cell_value.rs
@@ -1,6 +1,6 @@
 use super::current;
 use crate::{
-    CellValue,
+    CellValue, Duration,
     cellvalue::Import,
     grid::{CodeCellLanguage, CodeCellValue, ConnectionKind},
     number::decimal_from_str,
@@ -107,7 +107,7 @@ pub fn import_cell_value(value: current::CellValueSchema) -> CellValue {
             CellValue::Instant(serde_json::from_str(&instant).unwrap_or_default())
         }
         current::CellValueSchema::Duration(duration) => {
-            CellValue::Duration(serde_json::from_str(&duration).unwrap_or_default())
+            CellValue::Duration(Duration::from_str(&duration).unwrap_or_default())
         }
         current::CellValueSchema::Date(date) => CellValue::Date(date),
         current::CellValueSchema::Time(time) => CellValue::Time(time),

--- a/quadratic-core/src/test_util/get_sheets.rs
+++ b/quadratic-core/src/test_util/get_sheets.rs
@@ -35,6 +35,15 @@ pub fn first_sheet_id(gc: &GridController) -> SheetId {
 }
 
 #[cfg(test)]
+pub fn test_export_and_import(gc: &GridController) -> GridController {
+    use crate::grid::file::{export, import};
+
+    let exported = export(gc.grid().clone()).unwrap();
+    let grid = import(exported).unwrap();
+    GridController::from_grid(grid, 0)
+}
+
+#[cfg(test)]
 mod tests {
     use crate::grid::SheetId;
 

--- a/quadratic-core/src/values/time.rs
+++ b/quadratic-core/src/values/time.rs
@@ -711,4 +711,10 @@ mod tests {
             27.0,
         );
     }
+
+    #[test]
+    fn test_duration_to_string() {
+        assert_eq!(Duration::from_seconds(5.0).to_string(), "5s");
+        assert_eq!(Duration::from_str("5s").unwrap().to_string(), "5s");
+    }
 }


### PR DESCRIPTION
## Relevant issue(s)
Fixes #3275 

## Description
Fixes bug where entering a duration like "5s" would not properly save.
