### PR TITLE
Fix hard-coded biqquery dataset in Query Selected Table

### DIFF
--- a/quadratic-rust-shared/src/sql/bigquery_connection.rs
+++ b/quadratic-rust-shared/src/sql/bigquery_connection.rs
@@ -235,7 +235,6 @@ impl<'a> Connection<'a> for BigqueryConnection {
         let project_id = self.project_id.to_owned();
         let dataset = self.dataset.to_owned();
 
-        let dataset_id = "all_native_data_types".to_owned();
         let sql = format!(
             "
             SELECT 
@@ -271,7 +270,7 @@ impl<'a> Connection<'a> for BigqueryConnection {
             .map_err(schema_error)?;
 
         let mut schema = DatabaseSchema {
-            database: dataset_id.to_owned(),
+            database: dataset.to_owned(),
             tables: BTreeMap::new(),
         };
 
@@ -290,7 +289,7 @@ impl<'a> Connection<'a> for BigqueryConnection {
                 .entry(table_name.to_owned())
                 .or_insert_with(|| SchemaTable {
                     name: table_name,
-                    schema: dataset_id.to_owned(),
+                    schema: dataset.to_owned(),
                     columns: vec![],
                 })
                 .columns


### PR DESCRIPTION
## Relevant issue(s)
Fixes https://github.com/quadratichq/quadratic/issues/3281

## Description
When selecting the Query Selected Table button in the UI, the test Dataset was hard-coded rather than being pulled from the connection config. With this PR, selecting the Query Selected Table button should show the correct Dataset in the query.

## (Optional) Testing considerations
1. Create BigQuery connection
1. With a cell highlighted, open connections and select BigQuery connection
1. For any table, click on the Query Selected Table button
1. The correct dataset should display in the window

