### PR TITLE
fix: inserting columns can create duplicate table column names

### DIFF
--- a/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/execute_data_table.rs
@@ -835,8 +835,11 @@ impl GridController {
                             let column_name = sanitize_column_name(new_column.name.to_string());
 
                             let data_table = self.grid.data_table_at(sheet_id, &data_table_pos)?;
-                            let unique_column_name =
-                                data_table.unique_column_header_name(Some(&column_name), index);
+                            let unique_column_name = data_table.unique_column_header_name(
+                                Some(&column_name),
+                                index,
+                                Some(index),
+                            );
 
                             new_column.name = CellValue::Text(unique_column_name);
 
@@ -2851,5 +2854,23 @@ mod tests {
         assert_validation_id(&gc, checkbox_pos, None);
 
         assert_validation_count(&gc, sheet_id, 0);
+    }
+
+    #[test]
+    fn test_execute_unique_column_header_name_on_insert_column() {
+        let mut gc = test_create_gc();
+        let sheet_id = first_sheet_id(&gc);
+        let sheet_pos = pos![sheet_id!E5];
+
+        test_create_data_table(&mut gc, sheet_id, sheet_pos.into(), 5, 25);
+
+        gc.data_table_insert_columns(sheet_pos, vec![2], false, None, None, None);
+
+        let data_table = gc.sheet(sheet_id).data_table_at(&sheet_pos.into()).unwrap();
+        assert_eq!(data_table.column_headers.as_ref().unwrap().len(), 6);
+        assert_eq!(
+            data_table.column_headers.as_ref().unwrap()[2].name,
+            CellValue::Text("Column 6".to_string())
+        );
     }
 }

--- a/quadratic-core/src/grid/data_table/column.rs
+++ b/quadratic-core/src/grid/data_table/column.rs
@@ -57,7 +57,7 @@ impl DataTable {
         values: Option<Vec<CellValue>>,
     ) -> Result<()> {
         let column_name = self
-            .unique_column_header_name(column_header.as_deref(), column_index)
+            .unique_column_header_name(column_header.as_deref(), column_index, None)
             .to_string();
 
         let array = self.mut_value_as_array()?;

--- a/quadratic-core/src/grid/data_table/column_header.rs
+++ b/quadratic-core/src/grid/data_table/column_header.rs
@@ -139,7 +139,12 @@ impl DataTable {
     }
 
     /// Create a unique column header name.
-    pub fn unique_column_header_name(&self, name: Option<&str>, index: usize) -> String {
+    pub fn unique_column_header_name(
+        &self,
+        name: Option<&str>,
+        index: usize,
+        skip_index: Option<usize>,
+    ) -> String {
         let default_name = format!("Column {}", index + 1);
         let name = name.unwrap_or(&default_name);
 
@@ -147,7 +152,7 @@ impl DataTable {
             let all_names = columns
                 .iter()
                 .enumerate()
-                .filter(|(i, _)| *i != index)
+                .filter(|(i, _)| skip_index.is_none_or(|skip_index| *i != skip_index))
                 .map(|(_, c)| c.name.to_string())
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Relevant issue(s)
closes #3292