### PR TITLE
fix: renaming table column on single click overwrites first entered character

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/PixiRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/PixiRename.tsx
@@ -35,7 +35,6 @@ export const PixiRename = (props: Props) => {
       if (node) {
         getElement?.(node);
         setTimeout(() => {
-          node.select();
           node.focus();
           waitingForOpenRef.current = false;
         });

--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableRename.tsx
@@ -72,6 +72,7 @@ export const TableRename = () => {
   return (
     <PixiRename
       defaultValue={contextMenu.table.name}
+      initialValue={contextMenu.initialValue}
       width={width}
       className="reverse-selection origin-bottom-left bg-primary px-3 text-sm font-bold text-primary-foreground"
       styles={{

--- a/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/doubleClickCell.ts
@@ -97,6 +97,7 @@ export async function doubleClickCell(options: {
               rename: true,
               column: codeCell.x,
               row: codeCell.y,
+              initialValue: cell,
             });
           } else if (isColumnHeader) {
             const contextMenu = {


### PR DESCRIPTION
## Relevant issue(s)
closes #3147 