### PR TITLE
feat: deep link to new connection

### DIFF
--- a/quadratic-client/src/routes/team.$.ts
+++ b/quadratic-client/src/routes/team.$.ts
@@ -6,11 +6,15 @@ import { redirect, type LoaderFunctionArgs } from 'react-router';
  * Shortcut route to get to a route for whatever the 'active' team is, e.g.
  *
  * /team/settings -> /teams/:teamUuid/settings
+ * /team/connections?initial-connection-type=MYSQL -> /teams/:teamUuid/connections?initial-connection-type=MYSQL
  */
 export const loader = async (loaderArgs: LoaderFunctionArgs) => {
   const { activeTeamUuid } = await requireAuth();
   const { params } = loaderArgs;
-  return redirect(ROUTES.TEAM(activeTeamUuid) + '/' + params['*']);
+  const path = params['*'];
+  const { search } = new URL(loaderArgs.request.url);
+  const newPath = `${ROUTES.TEAM(activeTeamUuid)}/${path}${search}`;
+  return redirect(newPath);
 };
 
 export const Component = () => {

--- a/quadratic-client/src/shared/components/connections/Connections.tsx
+++ b/quadratic-client/src/shared/components/connections/Connections.tsx
@@ -227,18 +227,21 @@ function getInitialConnectionState(searchParams: URLSearchParams): ConnectionSta
   const type = searchParams.get('initial-connection-type');
   const uuid = searchParams.get('initial-connection-uuid');
   if (
-    uuid &&
-    (type === 'MYSQL' ||
-      type === 'POSTGRES' ||
-      type === 'MSSQL' ||
-      type === 'SNOWFLAKE' ||
-      type === 'COCKROACHDB' ||
-      type === 'BIGQUERY' ||
-      type === 'MARIADB' ||
-      type === 'SUPABASE' ||
-      type === 'NEON')
+    type === 'MYSQL' ||
+    type === 'POSTGRES' ||
+    type === 'MSSQL' ||
+    type === 'SNOWFLAKE' ||
+    type === 'COCKROACHDB' ||
+    type === 'BIGQUERY' ||
+    type === 'MARIADB' ||
+    type === 'SUPABASE' ||
+    type === 'NEON'
   ) {
-    return { view: 'edit', uuid, type };
+    if (uuid) {
+      return { view: 'edit', uuid, type };
+    }
+    return { view: 'create', type };
   }
+
   return { view: 'list' };
 }


### PR DESCRIPTION
## Relevant issue(s)

Supports https://github.com/quadratichq/quadratic-website/pull/353

## Description

Support deep linking to creating a new connection type

## To test

- [ ] Visit `/teams/connections` and see that you're redirected to the list of connections (`/teams/:uuid/connections`)
- [ ] Visit `/team/connections?initial-connection-type=MYSQL` and see that you're redirected to the creation of a new MYSQL connection