### PR TITLE
Fix column header rename

### DIFF
--- a/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/contextMenus/TableColumnHeaderRename.tsx
@@ -47,7 +47,7 @@ export const TableColumnHeaderRename = () => {
       );
       if (!bounds || !inputElement.current) return;
       inputElement.current.style.top = `${bounds.y - 1}px`;
-      inputElement.current.style.left = `${bounds.x + 1}px`;
+      inputElement.current.style.left = `${bounds.x}px`;
       inputElement.current.style.height = `${bounds.height}px`;
     }
   }, [contextMenu, inputElement]);
@@ -121,12 +121,13 @@ export const TableColumnHeaderRename = () => {
       defaultValue={defaultValue}
       initialValue={contextMenu.initialValue}
       width={width}
-      className="darker-selection origin-bottom-left border-none p-0 text-sm font-bold text-primary-foreground outline-none"
+      className="darker-selection origin-bottom-left border-none text-sm text-primary-foreground outline-none"
       styles={{
         fontFamily: 'OpenSans-Bold, sans-serif',
         fontSize: FONT_SIZE,
         color: 'var(--primary-foreground)',
         backgroundColor: 'var(--accent)',
+        padding: '0 2px',
       }}
       onSave={handleSave}
       onClose={() => events.emit('contextMenu', {})}

--- a/quadratic-client/src/app/gridGL/cells/tables/Tables.ts
+++ b/quadratic-client/src/app/gridGL/cells/tables/Tables.ts
@@ -514,12 +514,23 @@ export class Tables extends Container<Table> {
   isInTableHeader = (cell: JsCoordinate): boolean => {
     const table = this.getTableIntersects(cell);
     if (!table) return false;
-    return (
-      table.codeCell.show_name &&
-      cell.x >= table.codeCell.x &&
-      cell.x < table.codeCell.x + table.codeCell.w &&
-      cell.y === table.codeCell.y
-    );
+
+    // outside the table
+    if (cell.x < table.codeCell.x || cell.x > table.codeCell.x + table.codeCell.w) {
+      return false;
+    }
+
+    // in name row
+    if (table.codeCell.show_name && cell.y === table.codeCell.y) {
+      return true;
+    }
+
+    // in column header row
+    if (table.codeCell.show_columns && cell.y === table.codeCell.y + (table.codeCell.show_name ? 1 : 0)) {
+      return true;
+    }
+
+    return false;
   };
 
   // Checks whether we're hovering a code cell with either an error or peek

--- a/quadratic-client/src/app/gridGL/pixiApp/Update.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/Update.ts
@@ -121,8 +121,6 @@ export class Update {
     debugTimeCheck('[Update] headings');
     pixiApp.boxCells.update();
     debugTimeCheck('[Update] boxCells');
-    pixiApp.cursor.update(pixiApp.viewport.dirty);
-    debugTimeCheck('[Update] cursor');
     pixiApp.cellHighlights.update();
     debugTimeCheck('[Update] cellHighlights');
     pixiApp.multiplayerCursor.update(pixiApp.viewport.dirty);
@@ -133,6 +131,8 @@ export class Update {
     debugTimeCheck('[Update] cellMoving');
     pixiApp.cellsSheets.update(pixiApp.viewport.dirty);
     debugTimeCheck('[Update] cellsSheets');
+    pixiApp.cursor.update(pixiApp.viewport.dirty);
+    debugTimeCheck('[Update] cursor');
     pixiApp.validations.update(pixiApp.viewport.dirty);
     debugTimeCheck('[Update] validations');
     pixiApp.background.update(pixiApp.viewport.dirty);


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2402 

- [x] improved placement of column name rename Input box
- [x] fixed bug with cursor moving when over a column name in a hovering table name 