### PR TITLE
fix: mixpanel identity tracking

### DIFF
--- a/quadratic-client/src/app/actions/fileActionsSpec.ts
+++ b/quadratic-client/src/app/actions/fileActionsSpec.ts
@@ -9,7 +9,7 @@ import { isEmbed } from '@/app/helpers/isEmbed';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { FileRenameIcon, HistoryIcon, PersonAddIcon } from '@/shared/components/Icons';
 import { ROUTES } from '@/shared/constants/routes';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 type FileActionSpec = Pick<
   ActionSpecRecord,
@@ -53,7 +53,7 @@ export const fileActionsSpec: FileActionSpec = {
     isAvailable: isAvailableBecauseLoggedIn,
     run: async ({ name, uuid }: FileActionArgs[Action.FileDownload]) => {
       if (!pixiAppSettings.setEditorInteractionState) return;
-      mixpanel.track('[Files].downloadFile', { id: uuid });
+      trackEvent('[Files].downloadFile', { id: uuid });
       pixiAppSettings.setEditorInteractionState((prev) => ({ ...prev, isRunningAsyncAction: true }));
       const data = await quadraticCore.export();
       downloadQuadraticFile(name, data);
@@ -68,7 +68,7 @@ export const fileActionsSpec: FileActionSpec = {
     run: async ({ name, uuid }: FileActionArgs[Action.FileDownloadExcel]) => {
       try {
         if (!pixiAppSettings.setEditorInteractionState) return;
-        mixpanel.track('[Files].exportExcel', { id: uuid });
+        trackEvent('[Files].exportExcel', { id: uuid });
         pixiAppSettings.setEditorInteractionState((prev) => ({ ...prev, isRunningAsyncAction: true }));
         const data = await quadraticCore.exportExcel();
         downloadExcelFile(name, data);
@@ -89,7 +89,7 @@ export const fileActionsSpec: FileActionSpec = {
     run: async ({ name, uuid }: FileActionArgs[Action.FileDownloadCsv]) => {
       try {
         if (!pixiAppSettings.setEditorInteractionState) return;
-        mixpanel.track('[Files].exportCsv', { id: uuid });
+        trackEvent('[Files].exportCsv', { id: uuid });
         pixiAppSettings.setEditorInteractionState((prev) => ({ ...prev, isRunningAsyncAction: true }));
         const sheetBounds = sheets.sheet.boundsWithoutFormatting;
 

--- a/quadratic-client/src/app/ai/components/SelectAIModelMenu.tsx
+++ b/quadratic-client/src/app/ai/components/SelectAIModelMenu.tsx
@@ -15,8 +15,8 @@ import { RadioGroup, RadioGroupItem } from '@/shared/shadcn/ui/radio-group';
 import { Toggle } from '@/shared/shadcn/ui/toggle';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { CaretDownIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import { MODELS_CONFIGURATION } from 'quadratic-shared/ai/models/AI_MODELS';
 import type { AIModelConfig, AIModelKey, ModelMode } from 'quadratic-shared/typesAndSchemasAI';
 import { memo, useCallback, useMemo } from 'react';
@@ -159,7 +159,7 @@ export const SelectAIModelMenu = memo(({ loading, textareaRef }: SelectAIModelMe
                 key={key}
                 checked={selectedModel === key}
                 onCheckedChange={() => {
-                  mixpanel.track('[AI].model.change', { model: modelConfig.model });
+                  trackEvent('[AI].model.change', { model: modelConfig.model });
                   setSelectedModel(key);
                 }}
               >

--- a/quadratic-client/src/app/ai/toolCards/UpdateCodeCell.tsx
+++ b/quadratic-client/src/app/ai/toolCards/UpdateCodeCell.tsx
@@ -7,8 +7,8 @@ import { CollapseIcon, CopyIcon, ExpandIcon, SaveAndRunIcon } from '@/shared/com
 import { LanguageIcon } from '@/shared/components/LanguageIcon';
 import { Button } from '@/shared/shadcn/ui/button';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { Editor } from '@monaco-editor/react';
-import mixpanel from 'mixpanel-browser';
 import { AITool, aiToolsSpec } from 'quadratic-shared/ai/specs/aiToolsSpec';
 import type { AIToolCall } from 'quadratic-shared/typesAndSchemasAI';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -31,7 +31,7 @@ export const UpdateCodeCell = memo(
           return;
         }
 
-        mixpanel.track('[AI].UpdateCodeCell.copy', { language: getLanguage(codeCell.language) });
+        trackEvent('[AI].UpdateCodeCell.copy', { language: getLanguage(codeCell.language) });
         navigator.clipboard.writeText(toolArgs.data.code_string);
       },
       [codeCell.language, toolArgs?.data]

--- a/quadratic-client/src/app/grid/actions/clipboard/clipboard.ts
+++ b/quadratic-client/src/app/grid/actions/clipboard/clipboard.ts
@@ -8,9 +8,9 @@ import type { JsClipboard, PasteSpecial } from '@/app/quadratic-core-types';
 import { toUint8Array } from '@/app/shared/utils/Uint8Array';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import type { GlobalSnackbar } from '@/shared/components/GlobalSnackbarProvider';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
 import localforage from 'localforage';
-import mixpanel from 'mixpanel-browser';
 import { isSafari } from 'react-device-detect';
 
 const clipboardLocalStorageKey = 'quadratic-clipboard';
@@ -206,7 +206,7 @@ export const copySelectionToPNG = async (addGlobalSnackbar: GlobalSnackbar['addG
   try {
     if (!fullClipboardSupport()) {
       console.log('copy to PNG is not supported in Firefox (yet)');
-      mixpanel.track('[clipboard].copySelectionToPNG.notSupported');
+      trackEvent('[clipboard].copySelectionToPNG.notSupported');
       return;
     }
 

--- a/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/EmptyGridMessage.tsx
@@ -11,7 +11,7 @@ import { fileHasData } from '@/app/gridGL/helpers/fileHasData';
 import { useConnectionsFetcher } from '@/app/ui/hooks/useConnectionsFetcher';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useCallback, useEffect, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useSetRecoilState } from 'recoil';
@@ -42,12 +42,12 @@ export function EmptyGridMessage() {
   }, [open]);
 
   const handleImportFile = useCallback(() => {
-    mixpanel.track('[EmptyGridMessage].importFile');
+    trackEvent('[EmptyGridMessage].importFile');
     insertActionsSpec[Action.InsertFile].run();
   }, []);
 
   const handleShowConnection = useCallback(() => {
-    mixpanel.track('[EmptyGridMessage].showConnection');
+    trackEvent('[EmptyGridMessage].showConnection');
     const { x, y } = sheets.sheet.cursor.position;
     setCodeEditorCodeCell((prev) => ({
       ...prev,
@@ -58,7 +58,7 @@ export function EmptyGridMessage() {
   }, [setCodeEditorCodeCell, setShowConnectionsMenu]);
 
   const handleUseConnection = useCallback(() => {
-    mixpanel.track('[EmptyGridMessage].useConnection');
+    trackEvent('[EmptyGridMessage].useConnection');
     const { x, y } = sheets.sheet.cursor.position;
     setCodeEditorCodeCell((prev) => ({
       ...prev,

--- a/quadratic-client/src/app/gridGL/HTMLGrid/hoverCell/HoverCell.tsx
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/hoverCell/HoverCell.tsx
@@ -17,7 +17,7 @@ import { useSubmitAIAssistantPrompt } from '@/app/ui/menus/CodeEditor/hooks/useS
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { Rectangle } from 'pixi.js';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -250,7 +250,7 @@ function HoverCellRunError({ codeCell: codeCellCore, onClick }: { codeCell: JsCo
           size="sm"
           variant="destructive"
           onClick={() => {
-            mixpanel.track('[HoverCell].fixWithAI', {
+            trackEvent('[HoverCell].fixWithAI', {
               language: codeCellCore.language,
             });
             submitPrompt({

--- a/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
+++ b/quadratic-client/src/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler.ts
@@ -20,8 +20,8 @@ import { multiplayer } from '@/app/web-workers/multiplayerWebWorker/multiplayer'
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { OPEN_SANS_FIX } from '@/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel';
 import { googleAnalyticsAvailable } from '@/shared/utils/analytics';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import BigNumber from 'bignumber.js';
-import mixpanel from 'mixpanel-browser';
 import { Rectangle } from 'pixi.js';
 
 class InlineEditorHandler {
@@ -519,7 +519,7 @@ class InlineEditorHandler {
           codeString: value.slice(1),
           cursor: sheets.getCursorPosition(),
         });
-        mixpanel.track('[CodeEditor].cellRun', {
+        trackEvent('[CodeEditor].cellRun', {
           type: 'Formula',
           inline: true,
         });

--- a/quadratic-client/src/app/gridGL/cells/CellsArray.ts
+++ b/quadratic-client/src/app/gridGL/cells/CellsArray.ts
@@ -87,7 +87,7 @@
 //           const runError = JSON.parse(codeCell.evaluation_result) as RunError;
 //           // track unimplemented errors
 //           if (typeof runError.msg === 'object' && 'Unimplemented' in runError.msg) {
-//             mixpanel.track('[CellsArray].updateCodeCell', {
+//             trackEvent('[CellsArray].updateCodeCell', {
 //               type: codeCell.language,
 //               error: runError.msg,
 //             });

--- a/quadratic-client/src/app/ui/QuadraticSidebar.tsx
+++ b/quadratic-client/src/app/ui/QuadraticSidebar.tsx
@@ -20,7 +20,7 @@ import { ShowAfter } from '@/shared/components/ShowAfter';
 import { Toggle } from '@/shared/shadcn/ui/toggle';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import React from 'react';
 import { Link } from 'react-router';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
@@ -130,7 +130,7 @@ export const SidebarTooltip = React.forwardRef(
       <TooltipTrigger
         asChild
         onClick={() => {
-          mixpanel.track('[QuadraticSidebar].button', { label });
+          trackEvent('[QuadraticSidebar].button', { label });
         }}
       >
         {children}

--- a/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
+++ b/quadratic-client/src/app/ui/components/AIUsageExceeded.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { memo } from 'react';
 
 type AIUsageExceededProps = {
@@ -21,7 +21,7 @@ export const AIUsageExceeded = memo(({ show }: AIUsageExceededProps) => {
         <Button
           variant="outline"
           onClick={() => {
-            mixpanel.track('[AI].UsageExceeded.clickLearnMore', {
+            trackEvent('[AI].UsageExceeded.clickLearnMore', {
               ab_test: 'variant',
             });
             // go to the team settings page in a new tab
@@ -33,7 +33,7 @@ export const AIUsageExceeded = memo(({ show }: AIUsageExceededProps) => {
         </Button>
         <Button
           onClick={() => {
-            mixpanel.track('[AI].UsageExceeded.clickUpgrade', {
+            trackEvent('[AI].UsageExceeded.clickUpgrade', {
               ab_test: 'variant',
             });
             // navigate to the team settings page

--- a/quadratic-client/src/app/ui/components/FileProvider.tsx
+++ b/quadratic-client/src/app/ui/components/FileProvider.tsx
@@ -2,8 +2,8 @@ import { hasPermissionToEditFile } from '@/app/actions';
 import { editorInteractionStatePermissionsAtom } from '@/app/atoms/editorInteractionStateAtom';
 import { apiClient } from '@/shared/api/apiClient';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { updateRecentFiles } from '@/shared/utils/updateRecentFiles';
-import mixpanel from 'mixpanel-browser';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { useSetRecoilState } from 'recoil';
@@ -41,7 +41,7 @@ export const FileProvider = ({ children }: { children: React.ReactElement }) => 
 
   const renameFile: FileContextType['renameFile'] = useCallback(
     (newName) => {
-      mixpanel.track('[Files].renameCurrentFile', { newFilename: newName });
+      trackEvent('[Files].renameCurrentFile', { newFilename: newName });
       setName(newName);
     },
     [setName]

--- a/quadratic-client/src/app/ui/hooks/useFileImport.tsx
+++ b/quadratic-client/src/app/ui/hooks/useFileImport.tsx
@@ -8,9 +8,9 @@ import { apiClient } from '@/shared/api/apiClient';
 import { ApiError } from '@/shared/api/fetchFromApi';
 import { useGlobalSnackbar } from '@/shared/components/GlobalSnackbarProvider';
 import { ROUTES } from '@/shared/constants/routes';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
 import { Buffer } from 'buffer';
-import mixpanel from 'mixpanel-browser';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useSetRecoilState } from 'recoil';
@@ -56,7 +56,7 @@ export function useFileImport() {
         setFilesImportProgressListState(() => ({ show: true }));
       }
 
-      mixpanel.track('[ImportData].useFileImport', {
+      trackEvent('[ImportData].useFileImport', {
         files: files.map((file) => ({
           type: getFileType(file),
           size: file.size,

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystExamplePrompts.tsx
@@ -1,7 +1,7 @@
 import { sheets } from '@/app/grid/controller/Sheets';
 import { useSubmitAIAnalystPrompt } from '@/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt';
 import { CodeIcon, InsertChartIcon, TableIcon } from '@/shared/components/Icons';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useEffect, useState } from 'react';
 
 const examples = [
@@ -36,7 +36,7 @@ export function AIAnalystExamplePrompts() {
           key={title}
           className="flex items-center gap-3 rounded border border-border px-3 py-2 hover:bg-accent"
           onClick={() => {
-            mixpanel.track('[AIAnalyst].submitExamplePrompt', { title });
+            trackEvent('[AIAnalyst].submitExamplePrompt', { title });
             submitPrompt({
               messageSource: 'ExamplePrompts',
               content: [{ type: 'text', text: prompt }],

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystHeader.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystHeader.tsx
@@ -16,7 +16,7 @@ import { AddIcon, CloseIcon, FastForwardIcon, HistoryIcon } from '@/shared/compo
 import { Button } from '@/shared/shadcn/ui/button';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { aiToolsSpec, type AITool } from 'quadratic-shared/ai/specs/aiToolsSpec';
 import { memo, useMemo } from 'react';
 import { useRecoilCallback, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
@@ -109,7 +109,7 @@ export const AIAnalystHeader = memo(({ textareaRef }: AIAnalystHeaderProps) => {
               className="text-muted-foreground hover:text-foreground"
               disabled={loading || (currentUserMessagesCount === 0 && !showChatHistory)}
               onClick={() => {
-                mixpanel.track('[AIAnalyst].startNewChat', { messageCount: currentUserMessagesCount });
+                trackEvent('[AIAnalyst].startNewChat', { messageCount: currentUserMessagesCount });
                 setCurrentChat({
                   id: '',
                   name: '',

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystMessages.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystMessages.tsx
@@ -27,7 +27,7 @@ import { ThumbDownIcon, ThumbUpIcon } from '@/shared/components/Icons';
 import { Button } from '@/shared/shadcn/ui/button';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import {
   getLastAIPromptMessageIndex,
   getUserPromptMessages,
@@ -328,7 +328,7 @@ const FeedbackButtons = memo(() => {
     ({ snapshot }) =>
       (newLike: boolean | null) => {
         // Log it to mixpanel
-        mixpanel.track('[AIAnalyst].feedback', { like: newLike });
+        trackEvent('[AIAnalyst].feedback', { like: newLike });
 
         // Otherwise, log it to our DB
         const messages = snapshot.getLoadable(aiAnalystCurrentChatMessagesAtom).getValue();

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalystUserMessageForm.tsx
@@ -11,7 +11,7 @@ import type { AIUserMessageFormWrapperProps, SubmitPromptArgs } from '@/app/ui/c
 import { AIUserMessageForm } from '@/app/ui/components/AIUserMessageForm';
 import { defaultAIAnalystContext } from '@/app/ui/menus/AIAnalyst/const/defaultAIAnalystContext';
 import { useSubmitAIAnalystPrompt } from '@/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isSupportedImageMimeType, isSupportedPdfMimeType } from 'quadratic-shared/ai/helpers/files.helper';
 import type { Context } from 'quadratic-shared/typesAndSchemasAI';
 import { forwardRef, memo, useCallback, useState } from 'react';
@@ -31,7 +31,7 @@ export const AIAnalystUserMessageForm = memo(
 
     const handleSubmit = useCallback(
       ({ content }: SubmitPromptArgs) => {
-        mixpanel.track('[AIAnalyst].submitPrompt', { userMessageCountUponSubmit: userMessagesCount });
+        trackEvent('[AIAnalyst].submitPrompt', { userMessageCountUponSubmit: userMessagesCount });
         submitPrompt({
           messageSource: 'User',
           content,

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/hooks/useSubmitAIAnalystPrompt.tsx
@@ -26,7 +26,7 @@ import { sheets } from '@/app/grid/controller/Sheets';
 import { inlineEditorHandler } from '@/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler';
 import { useAnalystPDFImport } from '@/app/ui/menus/AIAnalyst/hooks/useAnalystPDFImport';
 import { useAnalystWebSearch } from '@/app/ui/menus/AIAnalyst/hooks/useAnalystWebSearch';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import {
   getLastAIPromptMessageIndex,
   getMessagesForAI,
@@ -173,7 +173,7 @@ export function useSubmitAIAnalystPrompt() {
 
           set(aiAnalystWaitingOnMessageIndexAtom, messageIndex);
 
-          mixpanel.track('[Billing].ai.exceededBillingLimit', {
+          trackEvent('[Billing].ai.exceededBillingLimit', {
             exceededBillingLimit: exceededBillingLimit,
             location: 'AIAnalyst',
           });

--- a/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/CellTypeMenu/CellTypeMenu.tsx
@@ -20,7 +20,7 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/shared/shadcn/ui/command';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
@@ -66,7 +66,7 @@ export default function CellTypeMenu() {
   const searchLabel = useMemo(() => `Choose a ${includeLanguages ? 'cell type' : 'connection'}…`, [includeLanguages]);
 
   useEffect(() => {
-    mixpanel.track('[CellTypeMenu].opened');
+    trackEvent('[CellTypeMenu].opened');
   }, []);
 
   const close = useCallback(() => {
@@ -75,7 +75,7 @@ export default function CellTypeMenu() {
 
   const openEditor = useCallback(
     (language: CodeCellLanguage) => {
-      mixpanel.track('[CellTypeMenu].selected', { language });
+      trackEvent('[CellTypeMenu].selected', { language });
 
       setShowCellTypeMenu(false);
 

--- a/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm.tsx
@@ -7,7 +7,7 @@ import {
 import type { AIUserMessageFormWrapperProps, SubmitPromptArgs } from '@/app/ui/components/AIUserMessageForm';
 import { AIUserMessageForm } from '@/app/ui/components/AIUserMessageForm';
 import { useSubmitAIAssistantPrompt } from '@/app/ui/menus/CodeEditor/hooks/useSubmitAIAssistantPrompt';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isSupportedImageMimeType } from 'quadratic-shared/ai/helpers/files.helper';
 import { forwardRef, memo, useCallback } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -24,7 +24,7 @@ export const AIAssistantUserMessageForm = memo(
 
     const handleSubmit = useCallback(
       ({ content }: SubmitPromptArgs) => {
-        mixpanel.track('[AIAssistant].submitPrompt');
+        trackEvent('[AIAssistant].submitPrompt');
         submitPrompt({
           messageSource: 'User',
           content,

--- a/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/CodeSnippet.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/CodeSnippet.tsx
@@ -10,9 +10,9 @@ import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { CopyIcon, SaveAndRunIcon } from '@/shared/components/Icons';
 import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import Editor from '@monaco-editor/react';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRecoilCallback, useRecoilValue } from 'recoil';
 
@@ -139,7 +139,7 @@ const CodeSnippetRunButton = memo(
     const handleSaveAndRun = useRecoilCallback(
       ({ snapshot, set }) =>
         async () => {
-          mixpanel.track('[AI].code.run', { language });
+          trackEvent('[AI].code.run', { language });
 
           const editorContent = await snapshot.getPromise(codeEditorEditorContentAtom);
           if (editorContent === text) {
@@ -192,7 +192,7 @@ const CodeSnippetCopyButton = memo(
     const handleCopy = useCallback(
       (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
-        mixpanel.track('[AI].code.copy', { language });
+        trackEvent('[AI].code.copy', { language });
         navigator.clipboard.writeText(text);
         setTooltipMsg('Copied!');
         setTimeout(() => {

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEffects.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEffects.tsx
@@ -18,7 +18,7 @@ import type { JsUpdateCodeCell } from '@/app/quadratic-core-types';
 import { useUpdateCodeEditor } from '@/app/ui/menus/CodeEditor/hooks/useUpdateCodeEditor';
 import { multiplayer } from '@/app/web-workers/multiplayerWebWorker/multiplayer';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { memo, useEffect, useMemo } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -103,7 +103,7 @@ export const CodeEditorEffects = memo(() => {
   }, [setCodeEditorState, setShowCellTypeMenu, setShowSaveChangesAlert, unsavedChanges, waitingForEditorClose]);
 
   useEffect(() => {
-    mixpanel.track('[CodeEditor].opened', { type: language });
+    trackEvent('[CodeEditor].opened', { type: language });
     multiplayer.sendCellEdit({ text: '', cursor: 0, codeEditor: true, inlineCodeEditor: false });
   }, [language]);
 

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEmptyState.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorEmptyState.tsx
@@ -30,7 +30,7 @@ import {
   SnippetsIcon,
 } from '@/shared/components/Icons';
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type * as monaco from 'monaco-editor';
 import { useCallback, useMemo } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
@@ -125,7 +125,7 @@ export function CodeEditorEmptyState({ editorInst }: CodeEditorEmptyStateProps) 
             className="flex h-auto flex-col gap-0.5 bg-background pb-3 pt-3"
             variant="outline"
             onClick={() => {
-              mixpanel.track('[SnippetsEmpty].selected', { label, language: codeCell.id });
+              trackEvent('[SnippetsEmpty].selected', { label, language: codeCell.id });
               onClick();
             }}
           >

--- a/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorPlaceholder.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/CodeEditorPlaceholder.tsx
@@ -2,7 +2,7 @@ import { codeEditorCodeCellAtom, codeEditorEditorContentAtom } from '@/app/atoms
 import { getCodeCell } from '@/app/helpers/codeCellLanguage';
 import { codeEditorBaseStyles, codeEditorCommentStyles } from '@/app/ui/menus/CodeEditor/styles';
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 
@@ -45,7 +45,7 @@ export function CodeEditorPlaceholder() {
         className={`pointer-events-auto italic underline`}
         onClick={() => {
           setShowPlaceholder(false);
-          mixpanel.track('[CodeEditorPlaceholder].dismissed');
+          trackEvent('[CodeEditorPlaceholder].dismissed');
         }}
       >
         don’t show this again

--- a/quadratic-client/src/app/ui/menus/CodeEditor/ReturnTypeInspector.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/ReturnTypeInspector.tsx
@@ -16,8 +16,8 @@ import { codeEditorBaseStyles } from '@/app/ui/menus/CodeEditor/styles';
 import { DOCUMENTATION_JAVASCRIPT_RETURN_DATA, DOCUMENTATION_URL } from '@/shared/constants/urls';
 import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { timeAgoAndNextTimeout } from '@/shared/utils/timeAgo';
-import mixpanel from 'mixpanel-browser';
 import type { JSX, ReactNode } from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
@@ -58,7 +58,7 @@ export const ReturnTypeInspector = memo(() => {
         variant="destructive"
         className="ml-auto"
         onClick={() => {
-          mixpanel.track('[AIAssistant].fixWithAI', {
+          trackEvent('[AIAssistant].fixWithAI', {
             language: codeCellRecoil.language,
           });
           submitPrompt({

--- a/quadratic-client/src/app/ui/menus/CodeEditor/SnippetsPopover.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/SnippetsPopover.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/shared/shadcn/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/shadcn/ui/popover';
 import { TooltipPopover } from '@/shared/shadcn/ui/tooltip';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type * as monaco from 'monaco-editor';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo } from 'react';
@@ -36,7 +36,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
 
   useEffect(() => {
     if (showSnippetsPopover === true) {
-      mixpanel.track('[Snippets].opened');
+      trackEvent('[Snippets].opened');
     }
   }, [showSnippetsPopover]);
 
@@ -92,7 +92,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
                   value={label}
                   keywords={keywords ? [keywords] : []}
                   onSelect={() => {
-                    mixpanel.track('[Snippets].selected', { label });
+                    trackEvent('[Snippets].selected', { label });
 
                     if (editorInst) {
                       const selection = editorInst.getSelection();
@@ -118,7 +118,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
                 <ExternalLink
                   href={WEBSITE_CONNECTIONS}
                   onClick={() => {
-                    mixpanel.track('[Snippets].clickConnections');
+                    trackEvent('[Snippets].clickConnections');
                   }}
                 >
                   Connections
@@ -127,7 +127,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
                 <ExternalLink
                   href={WEBSITE_EXAMPLES}
                   onClick={() => {
-                    mixpanel.track('[Snippets].clickExamples');
+                    trackEvent('[Snippets].clickExamples');
                   }}
                 >
                   Examples
@@ -136,7 +136,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
                 <ExternalLink
                   href={WEBSITE_CHANGELOG}
                   onClick={() => {
-                    mixpanel.track('[Snippets].clickChangelog');
+                    trackEvent('[Snippets].clickChangelog');
                   }}
                 >
                   Changelog
@@ -149,7 +149,7 @@ export function SnippetsPopover({ editorInst }: SnippetsPopoverProps) {
         <ExternalLink
           href={documentationLink}
           onClick={() => {
-            mixpanel.track('[Snippets].clickDocs');
+            trackEvent('[Snippets].clickDocs');
           }}
           className="flex w-full items-center justify-between gap-4 border-t border-border px-3 py-2 text-sm text-muted-foreground hover:underline"
         >

--- a/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useSaveAndRunCell.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useSaveAndRunCell.tsx
@@ -10,7 +10,7 @@ import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import { getLanguage } from '@/app/helpers/codeCellLanguage';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { googleAnalyticsAvailable } from '@/shared/utils/analytics';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useRecoilCallback } from 'recoil';
 
 export const useSaveAndRunCell = () => {
@@ -71,7 +71,7 @@ export const useSaveAndRunCell = () => {
             ]);
           }
         }
-        mixpanel.track('[CodeEditor].cellRun', {
+        trackEvent('[CodeEditor].cellRun', {
           type: getLanguage(codeCell.language),
           language: codeCell.language,
         });

--- a/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useSubmitAIAssistantPrompt.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/hooks/useSubmitAIAssistantPrompt.tsx
@@ -22,7 +22,7 @@ import { sheets } from '@/app/grid/controller/Sheets';
 import { inlineEditorHandler } from '@/app/gridGL/HTMLGrid/inlineEditor/inlineEditorHandler';
 import { getLanguage } from '@/app/helpers/codeCellLanguage';
 import { isSameCodeCell, type CodeCell } from '@/app/shared/types/codeCell';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import {
   getLastAIPromptMessageIndex,
   getMessagesForAI,
@@ -111,7 +111,7 @@ export function useSubmitAIAssistantPrompt() {
 
           set(aiAssistantWaitingOnMessageIndexAtom, messageIndex);
 
-          mixpanel.track('[Billing].ai.exceededBillingLimit', {
+          trackEvent('[Billing].ai.exceededBillingLimit', {
             exceededBillingLimit: exceededBillingLimit,
             location: 'AIAssistant',
           });

--- a/quadratic-client/src/app/ui/menus/CommandPalette/CommandPalette.tsx
+++ b/quadratic-client/src/app/ui/menus/CommandPalette/CommandPalette.tsx
@@ -25,8 +25,8 @@ import viewCommandGroup from '@/app/ui/menus/CommandPalette/commands/View';
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { useFileRouteLoaderData } from '@/shared/hooks/useFileRouteLoaderData';
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandList } from '@/shared/shadcn/ui/command';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import fuzzysort from 'fuzzysort';
-import mixpanel from 'mixpanel-browser';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -52,7 +52,7 @@ export const CommandPalette = () => {
   }, [setAnnotationState]);
 
   useEffect(() => {
-    mixpanel.track('[CommandPalette].open');
+    trackEvent('[CommandPalette].open');
   }, []);
 
   const borderCommandGroup = BordersHook();

--- a/quadratic-client/src/app/ui/menus/CommandPalette/CommandPaletteListItem.tsx
+++ b/quadratic-client/src/app/ui/menus/CommandPalette/CommandPaletteListItem.tsx
@@ -1,7 +1,7 @@
 import type { GenericAction } from '@/app/actions';
 import type { Action } from '@/app/actions/actions';
 import { CommandItem, CommandShortcut } from '@/shared/shadcn/ui/command';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type { JSX } from 'react';
 
 export type CommandGroup = {
@@ -51,7 +51,7 @@ export const CommandPaletteListItem = (props: CommandPaletteListItemProps) => {
     <CommandItem
       value={value}
       onSelect={() => {
-        mixpanel.track('[CommandPalette].run', { label });
+        trackEvent('[CommandPalette].run', { label });
         closeCommandPalette();
         action();
       }}

--- a/quadratic-client/src/app/ui/menus/SheetBar/SheetBar.tsx
+++ b/quadratic-client/src/app/ui/menus/SheetBar/SheetBar.tsx
@@ -9,7 +9,7 @@ import { SheetBarTab } from '@/app/ui/menus/SheetBar/SheetBarTab';
 import { AddIcon, ChevronLeftIcon, ChevronRightIcon } from '@/shared/components/Icons';
 import { SEARCH_PARAMS } from '@/shared/constants/routes';
 import { useUpdateQueryStringValueWithoutNavigation } from '@/shared/hooks/useUpdateQueryStringValueWithoutNavigation';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type { JSX } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
@@ -402,7 +402,7 @@ export const SheetBar = memo((): JSX.Element => {
       {hasPermission && (
         <SheetBarButton
           onClick={() => {
-            mixpanel.track('[Sheets].add');
+            trackEvent('[Sheets].add');
             sheets.userAddSheet();
             focusGrid();
           }}

--- a/quadratic-client/src/app/ui/menus/SheetBar/SheetBarTabDropdownMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/SheetBar/SheetBarTabDropdownMenu.tsx
@@ -15,8 +15,8 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/shared/shadcn/ui/dropdown-menu';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import '@szhsin/react-menu/dist/index.css';
-import mixpanel from 'mixpanel-browser';
 import type { JSX } from 'react';
 import type { ColorResult } from 'react-color';
 
@@ -50,7 +50,7 @@ export const SheetBarTabDropdownMenu = (props: Props): JSX.Element => {
         {numberOfSheets > 1 && (
           <DropdownMenuItem
             onClick={() => {
-              mixpanel.track('[Sheets].delete');
+              trackEvent('[Sheets].delete');
               sheets.userDeleteSheet(sheets.current);
               setTimeout(focusGrid);
             }}
@@ -60,7 +60,7 @@ export const SheetBarTabDropdownMenu = (props: Props): JSX.Element => {
         )}
         <DropdownMenuItem
           onClick={() => {
-            mixpanel.track('[Sheets].duplicate');
+            trackEvent('[Sheets].duplicate');
             sheets.duplicate();
             focusGrid();
           }}

--- a/quadratic-client/src/app/ui/menus/Toolbar/FormattingBar/components.tsx
+++ b/quadratic-client/src/app/ui/menus/Toolbar/FormattingBar/components.tsx
@@ -15,7 +15,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/shadcn/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { memo, type JSX, type ReactNode } from 'react';
 
 export const FormatSeparator = memo(() => {
@@ -143,7 +143,7 @@ export const FormatButtonDropdownActions = memo(
         <DropdownMenuItem
           key={key}
           onClick={() => {
-            mixpanel.track('[FormattingBar].button', { label });
+            trackEvent('[FormattingBar].button', { label });
             actionSpec.run(actionArgs);
           }}
           aria-label={hideLabel ? '' : label}
@@ -186,7 +186,7 @@ export const FormatButton = memo(
               checked ? 'bg-accent' : ''
             )}
             onClick={() => {
-              mixpanel.track('[FormattingBar].button', { label });
+              trackEvent('[FormattingBar].button', { label });
               actionSpec.run(actionArgs);
               focusGrid();
             }}

--- a/quadratic-client/src/app/ui/menus/Toolbar/ZoomMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/Toolbar/ZoomMenu.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/shared/shadcn/ui/dropdown-menu';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useCallback, useEffect, useState } from 'react';
 
 export const ZoomMenu = () => {
@@ -103,7 +103,7 @@ function DropdownMenuItemFromAction<T extends Action>({
   return (
     <DropdownMenuItem
       onClick={() => {
-        mixpanel.track(mixpanelEvent);
+        trackEvent(mixpanelEvent);
         actionSpec.run(actionArgs);
       }}
     >

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/MenubarItemAction.tsx
@@ -4,7 +4,7 @@ import { defaultActionSpec } from '@/app/actions/defaultActionsSpec';
 import { keyboardShortcutEnumToDisplay } from '@/app/helpers/keyboardShortcutsDisplay';
 import { useIsAvailableArgs } from '@/app/ui/hooks/useIsAvailableArgs';
 import { MenubarItem, MenubarShortcut } from '@/shared/shadcn/ui/menubar';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 export const MenubarItemAction = <T extends Action>({
   action,
@@ -32,7 +32,7 @@ export const MenubarItemAction = <T extends Action>({
     <MenubarItem
       disabled={isDisabled ? isDisabled() : false}
       onClick={() => {
-        mixpanel.track('[FileMenu].selected', { label });
+        trackEvent('[FileMenu].selected', { label });
         actionSpec.run(actionArgs);
       }}
     >

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarShareButton.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarShareButton.tsx
@@ -2,7 +2,7 @@ import { editorInteractionStateShowShareFileMenuAtom } from '@/app/atoms/editorI
 import { useRootRouteLoaderData } from '@/routes/_root';
 import { ROUTES } from '@/shared/constants/routes';
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { Link } from 'react-router';
 import { useSetRecoilState } from 'recoil';
 
@@ -18,7 +18,7 @@ export const TopBarShareButton = () => {
           size="sm"
           onClick={() => {
             setShowShareFileMenu((prev) => !prev);
-            mixpanel.track('[FileSharing].menu.open', { context: 'app' });
+            trackEvent('[FileSharing].menu.open', { context: 'app' });
           }}
           className="self-center"
         >

--- a/quadratic-client/src/app/web-workers/javascriptWebWorker/javascriptWebWorker.ts
+++ b/quadratic-client/src/app/web-workers/javascriptWebWorker/javascriptWebWorker.ts
@@ -7,7 +7,7 @@ import type {
 import type { LanguageState } from '@/app/web-workers/languageTypes';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { authClient } from '@/auth/auth';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 class JavascriptWebWorker {
   state: LanguageState = 'loading';
@@ -59,7 +59,7 @@ class JavascriptWebWorker {
   }
 
   cancelExecution = () => {
-    mixpanel.track('[JavascriptWebWorker].restartFromUser');
+    trackEvent('[JavascriptWebWorker].restartFromUser');
     this.initWorker();
     quadraticCore.sendCancelExecution('Javascript');
     events.emit('javascriptState', 'ready');

--- a/quadratic-client/src/app/web-workers/pythonWebWorker/pythonWebWorker.ts
+++ b/quadratic-client/src/app/web-workers/pythonWebWorker/pythonWebWorker.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/app/web-workers/pythonWebWorker/pythonClientMessages';
 import { quadraticCore } from '@/app/web-workers/quadraticCore/quadraticCore';
 import { authClient } from '@/auth/auth';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 class PythonWebWorker {
   state: LanguageState = 'loading';
@@ -59,7 +59,7 @@ class PythonWebWorker {
   }
 
   cancelExecution = () => {
-    mixpanel.track('[PythonWebWorker].restartFromUser');
+    trackEvent('[PythonWebWorker].restartFromUser');
     this.initWorker();
     quadraticCore.sendCancelExecution('Python');
     events.emit('pythonState', 'loading');

--- a/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
+++ b/quadratic-client/src/app/web-workers/quadraticCore/worker/core.ts
@@ -57,9 +57,9 @@ import {
   posToPos,
   toSheetPos,
 } from '@/app/web-workers/quadraticCore/worker/rustConversions';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
 import { Buffer } from 'buffer';
-import mixpanel from 'mixpanel-browser';
 
 class Core {
   gridController?: GridController;
@@ -67,7 +67,7 @@ class Core {
 
   private sendAnalyticsError = (from: string, error: Error | unknown) => {
     console.error(error);
-    mixpanel.track(`[core] ${from} error`, {
+    trackEvent(`[core] ${from} error`, {
       error,
     });
     Sentry.captureException(error);

--- a/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
+++ b/quadratic-client/src/dashboard/components/DashboardSidebar.tsx
@@ -39,9 +39,9 @@ import {
 } from '@/shared/shadcn/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isJsonObject } from '@/shared/utils/isJsonObject';
 import { RocketIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import {
@@ -190,7 +190,7 @@ export function DashboardSidebar({ isLoading }: { isLoading: boolean }) {
               <Link
                 to={ROUTES.TEAM_SETTINGS(activeTeamUuid)}
                 onClick={() => {
-                  mixpanel.track('[DashboardSidebar].upgradeToProClicked', {
+                  trackEvent('[DashboardSidebar].upgradeToProClicked', {
                     team_uuid: activeTeamUuid,
                   });
                 }}

--- a/quadratic-client/src/dashboard/components/FilesListEmptyState.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListEmptyState.tsx
@@ -1,8 +1,8 @@
 import { useDashboardRouteLoaderData } from '@/routes/_dashboard';
 import { EmptyState } from '@/shared/components/EmptyState';
 import { ROUTES } from '@/shared/constants/routes';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { FileIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import { Link } from 'react-router';
 
 export const FilesListEmptyState = ({ isPrivate = false }: { isPrivate?: boolean }) => {
@@ -25,7 +25,7 @@ export const FilesListEmptyState = ({ isPrivate = false }: { isPrivate?: boolean
               reloadDocument
               className="underline hover:text-primary"
               onClick={() => {
-                mixpanel.track('[FilesEmptyState].clickCreateBlankFile');
+                trackEvent('[FilesEmptyState].clickCreateBlankFile');
               }}
             >
               Create a new file

--- a/quadratic-client/src/dashboard/components/FilesListItem.tsx
+++ b/quadratic-client/src/dashboard/components/FilesListItem.tsx
@@ -25,8 +25,8 @@ import {
 } from '@/shared/shadcn/ui/dropdown-menu';
 import { Separator } from '@/shared/shadcn/ui/separator';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { timeAgo } from '@/shared/utils/timeAgo';
-import mixpanel from 'mixpanel-browser';
 import { useEffect, useRef, useState } from 'react';
 import type { SubmitOptions } from 'react-router';
 import { Link, useFetcher, useMatch, useSubmit } from 'react-router';
@@ -138,13 +138,13 @@ export function FilesListItemUserFile({
   };
 
   const handleDownload = () => {
-    mixpanel.track('[Files].downloadFile', { id: uuid });
+    trackEvent('[Files].downloadFile', { id: uuid });
     const data = getActionFileDownload();
     fetcherDownload.submit(data, fetcherSubmitOpts);
   };
 
   const handleDuplicate = () => {
-    mixpanel.track('[Files].duplicateFile', { id: uuid });
+    trackEvent('[Files].duplicateFile', { id: uuid });
     const data = getActionFileDuplicate({
       redirect: false,
       isPrivate: isTeamPrivateFilesRoute ? true : false,
@@ -155,7 +155,7 @@ export function FilesListItemUserFile({
 
   const handleShare = () => {
     setActiveShareMenuFileId(uuid);
-    mixpanel.track('[FileSharing].menu.open', { context: 'dashboard', pathname: window.location.pathname });
+    trackEvent('[FileSharing].menu.open', { context: 'dashboard', pathname: window.location.pathname });
   };
 
   const displayName = fetcherRename.json ? (fetcherRename.json as FileAction['request.rename']).name : name;

--- a/quadratic-client/src/dashboard/components/OnboardingBanner.tsx
+++ b/quadratic-client/src/dashboard/components/OnboardingBanner.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from '@/shared/shadcn/ui/button';
 import { Input } from '@/shared/shadcn/ui/input';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import {
   ArrowDownIcon,
   CheckCircledIcon,
@@ -30,7 +31,6 @@ import {
   RocketIcon,
 } from '@radix-ui/react-icons';
 import * as Tabs from '@radix-ui/react-tabs';
-import mixpanel from 'mixpanel-browser';
 import { UserTeamRoleSchema } from 'quadratic-shared/typesAndSchemas';
 import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -51,7 +51,7 @@ export function OnboardingBanner() {
   } = useDashboardRouteLoaderData();
   const handleFileImport = useFileImport();
   const onClickImport = () => {
-    mixpanel.track('[OnboardingBanner].newFileFromImport');
+    trackEvent('[OnboardingBanner].newFileFromImport');
     handleFileImport({ isPrivate: false, teamUuid });
   };
   const newApiFileToLink = useNewFileFromStatePythonApi({ isPrivate: false, teamUuid });
@@ -66,7 +66,7 @@ export function OnboardingBanner() {
   }, [initialValueOfShowBanner]);
 
   const trackCreateConnection = () => {
-    mixpanel.track('[OnboardingBanner].createConnection');
+    trackEvent('[OnboardingBanner].createConnection');
   };
   const tabContentClassName = 'flex flex-col gap-2';
   const contentBtnClassName = 'min-w-40 flex-shrink-0';
@@ -84,7 +84,7 @@ export function OnboardingBanner() {
                 to={ROUTES.CREATE_FILE(teamUuid)}
                 reloadDocument
                 onClick={() => {
-                  mixpanel.track('[OnboardingBanner].newFileBlank');
+                  trackEvent('[OnboardingBanner].newFileBlank');
                 }}
               >
                 <PlusIcon className="mr-1" /> Create blank file
@@ -95,7 +95,7 @@ export function OnboardingBanner() {
               <Link
                 to={ROUTES.EXAMPLES}
                 onClick={() => {
-                  mixpanel.track('[OnboardingBanner].newFileFromExample');
+                  trackEvent('[OnboardingBanner].newFileFromExample');
                 }}
               >
                 <MixIcon className="mr-1" /> Explore example files
@@ -108,7 +108,7 @@ export function OnboardingBanner() {
               <Link
                 to={newApiFileToLink}
                 onClick={() => {
-                  mixpanel.track('[OnboardingBanner].newFileFromApi');
+                  trackEvent('[OnboardingBanner].newFileFromApi');
                 }}
               >
                 <RocketIcon className="mr-1" /> Fetch data from an API
@@ -312,7 +312,7 @@ export function OnboardingBanner() {
               onClick={() => {
                 setIsOpenConfirmDismiss(false);
                 handleDismiss();
-                mixpanel.track('[OnboardingBanner].dismissOverride');
+                trackEvent('[OnboardingBanner].dismissOverride');
               }}
             >
               Dismiss
@@ -361,7 +361,7 @@ function InviteForm({ teamUuid }: { teamUuid: string }) {
     }, 3000);
 
     // Track it
-    mixpanel.track('[OnboardingBanner].inviteSent');
+    trackEvent('[OnboardingBanner].inviteSent');
 
     // Reset the email input & focus it
     if (inputRef.current) {

--- a/quadratic-client/src/dashboard/hooks/useConnectionSchemaBrowserTableQueryAction.tsx
+++ b/quadratic-client/src/dashboard/hooks/useConnectionSchemaBrowserTableQueryAction.tsx
@@ -2,7 +2,7 @@ import ConditionalWrapper from '@/app/ui/components/ConditionalWrapper';
 import { useSaveAndRunCell } from '@/app/ui/menus/CodeEditor/hooks/useSaveAndRunCell';
 import { newNewFileFromStateConnection } from '@/shared/hooks/useNewFileFromState';
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type * as monaco from 'monaco-editor';
 import type { ConnectionType } from 'quadratic-shared/typesAndSchemasConnections';
 import { Link } from 'react-router';
@@ -33,7 +33,7 @@ export const useConnectionSchemaBrowserTableQueryActionNewFile = ({
               to={to}
               reloadDocument
               onClick={() => {
-                mixpanel.track('[Connections].schemaViewer.newFileFromTable');
+                trackEvent('[Connections].schemaViewer.newFileFromTable');
               }}
             >
               {children}
@@ -64,7 +64,7 @@ export const useConnectionSchemaBrowserTableQueryActionInsertQuery = ({
           size="sm"
           disabled={query.length === 0}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-            mixpanel.track('[Connections].schemaViewer.insertQuery');
+            trackEvent('[Connections].schemaViewer.insertQuery');
 
             if (editorInst) {
               const model = editorInst.getModel();

--- a/quadratic-client/src/routes/_dashboard.tsx
+++ b/quadratic-client/src/routes/_dashboard.tsx
@@ -13,6 +13,7 @@ import { Sheet, SheetContent, SheetTrigger } from '@/shared/shadcn/ui/sheet';
 import { TooltipProvider } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
 import { setActiveTeam } from '@/shared/utils/activeTeam';
+import { registerEventAnalyticsData } from '@/shared/utils/analyticsEvents';
 import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import type { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import { useEffect, useRef, useState } from 'react';
@@ -108,6 +109,10 @@ export const loader = async (loaderArgs: LoaderFunctionArgs): Promise<LoaderData
       if (status >= 400 && status < 500) throw new Response('4xx level error', { status });
       throw error;
     });
+
+  registerEventAnalyticsData({
+    isOnPaidPlan: activeTeam.billing.status === 'ACTIVE',
+  });
 
   return { teams, userMakingRequest, eduStatus, activeTeam };
 };

--- a/quadratic-client/src/routes/file.$uuid.history.tsx
+++ b/quadratic-client/src/routes/file.$uuid.history.tsx
@@ -11,8 +11,8 @@ import { useRemoveInitialLoadingUI } from '@/shared/hooks/useRemoveInitialLoadin
 import { Button } from '@/shared/shadcn/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import type { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import { useCallback, useMemo, useState } from 'react';
 import {
@@ -78,7 +78,7 @@ export const Component = () => {
   const handleDuplicateVersion = useCallback(() => {
     if (!activeCheckpoint || !teamUuid) return;
 
-    mixpanel.track('[FileVersionHistory].duplicateVersion', {
+    trackEvent('[FileVersionHistory].duplicateVersion', {
       uuid,
       checkpointId: activeCheckpoint.id,
     });
@@ -97,7 +97,7 @@ export const Component = () => {
   const handleDownload = useCallback(() => {
     if (!activeCheckpoint) return;
 
-    mixpanel.track('[FileVersionHistory].downloadVersion', {
+    trackEvent('[FileVersionHistory].downloadVersion', {
       uuid,
       checkpointId: activeCheckpoint.id,
     });

--- a/quadratic-client/src/routes/file.$uuid.tsx
+++ b/quadratic-client/src/routes/file.$uuid.tsx
@@ -17,6 +17,7 @@ import { EmptyPage } from '@/shared/components/EmptyPage';
 import { ROUTES, SEARCH_PARAMS } from '@/shared/constants/routes';
 import { CONTACT_URL, SCHEDULE_MEETING } from '@/shared/constants/urls';
 import { Button } from '@/shared/shadcn/ui/button';
+import { registerEventAnalyticsData } from '@/shared/utils/analyticsEvents';
 import { updateRecentFiles } from '@/shared/utils/updateRecentFiles';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import * as Sentry from '@sentry/react';
@@ -138,6 +139,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs): Promise<F
 
   if (debugFlag('debugStartupTime'))
     console.timeEnd('[file.$uuid.tsx] initializing Rust and loading Quadratic file (parallel)');
+
+  registerEventAnalyticsData({
+    isOnPaidPlan: data.team.isOnPaidPlan,
+  });
 
   return data;
 };

--- a/quadratic-client/src/routes/file.tsx
+++ b/quadratic-client/src/routes/file.tsx
@@ -2,11 +2,11 @@ import { EmptyPage } from '@/shared/components/EmptyPage';
 import { CONTACT_URL, DOCUMENTATION_BROWSER_COMPATIBILITY_URL } from '@/shared/constants/urls';
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
 import { Button } from '@/shared/shadcn/ui/button';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isWASMSupported } from '@/shared/utils/isWASMSupported';
 import { isWebGLSupported } from '@pixi/utils';
 import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import * as Sentry from '@sentry/react';
-import mixpanel from 'mixpanel-browser';
 import { useEffect, useState } from 'react';
 import { engineName, isDesktop } from 'react-device-detect';
 import { Outlet } from 'react-router';
@@ -19,7 +19,7 @@ export function Component() {
 
   useEffect(() => {
     if (!isWASMSupported || !isWebGLSupported()) {
-      mixpanel.track('[BrowserCompatibilityLayoutRoute].browserNotSupported', {
+      trackEvent('[BrowserCompatibilityLayoutRoute].browserNotSupported', {
         isWASMSupported,
         isWebGLSupported,
       });
@@ -58,7 +58,7 @@ export function Component() {
             </Button>
             <Button
               onClick={() => {
-                mixpanel.track('[BrowserCompatibilityLayoutRoute].userContinuedAnyway');
+                trackEvent('[BrowserCompatibilityLayoutRoute].userContinuedAnyway');
                 setOverrideNonBlinkMsg(true);
                 setShowNonBlinkMsg(false);
               }}

--- a/quadratic-client/src/routes/login-result.tsx
+++ b/quadratic-client/src/routes/login-result.tsx
@@ -1,5 +1,6 @@
 import { authClient } from '@/auth/auth';
 import { apiClient } from '@/shared/api/apiClient';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isMobile } from 'react-device-detect';
 import { redirect } from 'react-router';
 
@@ -19,6 +20,7 @@ export const loader = async () => {
 
       // Special case for first-time users
       if (userCreated) {
+        trackEvent('[Auth].signup');
         try {
           // Read UTM cookie if it exists
           const utmCookie = document.cookie.split('; ').find((row) => row.startsWith('quadratic_utm='));

--- a/quadratic-client/src/routes/logout.tsx
+++ b/quadratic-client/src/routes/logout.tsx
@@ -1,4 +1,5 @@
 import { authClient } from '@/auth/auth';
+import mixpanel from 'mixpanel-browser';
 import { redirect } from 'react-router';
 
 // If you visit `/logout` directly in your browser, we'll log you out.
@@ -11,5 +12,6 @@ export const action = logout;
 async function logout() {
   localStorage.clear();
   await authClient.logout();
+  mixpanel.reset();
   return redirect('/');
 }

--- a/quadratic-client/src/routes/logout.tsx
+++ b/quadratic-client/src/routes/logout.tsx
@@ -1,5 +1,5 @@
 import { authClient } from '@/auth/auth';
-import mixpanel from 'mixpanel-browser';
+import { resetEventAnalytics } from '@/shared/utils/analyticsEvents';
 import { redirect } from 'react-router';
 
 // If you visit `/logout` directly in your browser, we'll log you out.
@@ -12,6 +12,6 @@ export const action = logout;
 async function logout() {
   localStorage.clear();
   await authClient.logout();
-  mixpanel.reset();
+  resetEventAnalytics();
   return redirect('/');
 }

--- a/quadratic-client/src/routes/onboarding.tsx
+++ b/quadratic-client/src/routes/onboarding.tsx
@@ -3,8 +3,8 @@ import { getPrompt } from '@/dashboard/onboarding/getPrompt';
 import { OnboardingResponseV1Schema, Questions, questionStackIdsByUse } from '@/dashboard/onboarding/Questions';
 import { apiClient } from '@/shared/api/apiClient';
 import { useRemoveInitialLoadingUI } from '@/shared/hooks/useRemoveInitialLoadingUI';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
-import mixpanel from 'mixpanel-browser';
 import { useEffect } from 'react';
 import { redirectDocument, useLoaderData, type ActionFunctionArgs, type LoaderFunctionArgs } from 'react-router';
 import { RecoilRoot } from 'recoil';
@@ -58,7 +58,7 @@ export const Component = () => {
   useRemoveInitialLoadingUI();
 
   useEffect(() => {
-    mixpanel.track('[Onboarding].loaded');
+    trackEvent('[Onboarding].loaded');
   }, []);
 
   return (
@@ -108,7 +108,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     try {
       const uploadToServerPromise = apiClient.user.update({ onboardingResponses: result.data });
       const uploadToMixpanelPromise = new Promise((resolve, reject) => {
-        mixpanel.track('[Onboarding].submit', result.data, () => {
+        trackEvent('[Onboarding].submit', result.data, () => {
           resolve(true);
         });
       });

--- a/quadratic-client/src/routes/teams.$teamUuid.settings.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.settings.tsx
@@ -13,9 +13,9 @@ import { Button } from '@/shared/shadcn/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/shared/shadcn/ui/dialog';
 import { Input } from '@/shared/shadcn/ui/input';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isJsonObject } from '@/shared/utils/isJsonObject';
 import { InfoCircledIcon, PieChartIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import type { TeamSettings } from 'quadratic-shared/typesAndSchemas';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -192,7 +192,7 @@ export const Component = () => {
                       <Button
                         disabled={!canManageBilling}
                         onClick={() => {
-                          mixpanel.track('[TeamSettings].upgradeToProClicked', {
+                          trackEvent('[TeamSettings].upgradeToProClicked', {
                             team_uuid: team.uuid,
                           });
                           apiClient.teams.billing.getCheckoutSessionUrl(team.uuid).then((data) => {
@@ -209,7 +209,7 @@ export const Component = () => {
                         variant="secondary"
                         className="mt-4 w-full"
                         onClick={() => {
-                          mixpanel.track('[TeamSettings].manageBillingClicked', {
+                          trackEvent('[TeamSettings].manageBillingClicked', {
                             team_uuid: team.uuid,
                           });
                           apiClient.teams.billing.getPortalSessionUrl(team.uuid).then((data) => {

--- a/quadratic-client/src/routes/teams.$teamUuid.tsx
+++ b/quadratic-client/src/routes/teams.$teamUuid.tsx
@@ -2,8 +2,8 @@ import { apiClient } from '@/shared/api/apiClient';
 import { EmptyPage } from '@/shared/components/EmptyPage';
 import { Button } from '@/shared/shadcn/ui/button';
 import { setActiveTeam } from '@/shared/utils/activeTeam';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import type { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import type { ActionFunctionArgs } from 'react-router';
 import { Link, Outlet, redirectDocument, useRouteError } from 'react-router';
@@ -59,7 +59,7 @@ export const action = async ({ request, params }: ActionFunctionArgs): Promise<T
   }
 
   if (intent === 'create-team-invite') {
-    mixpanel.track('[Team].[Users].createInvite');
+    trackEvent('[Team].[Users].createInvite');
     try {
       const { email, role } = data;
       await apiClient.teams.invites.create(teamUuid, { email, role });
@@ -70,7 +70,7 @@ export const action = async ({ request, params }: ActionFunctionArgs): Promise<T
   }
 
   if (intent === 'delete-team-invite') {
-    mixpanel.track('[Team].[Users].deleteInvite');
+    trackEvent('[Team].[Users].deleteInvite');
     try {
       const { inviteId } = data;
       await apiClient.teams.invites.delete(teamUuid, inviteId);
@@ -81,7 +81,7 @@ export const action = async ({ request, params }: ActionFunctionArgs): Promise<T
   }
 
   if (intent === 'update-team-user') {
-    mixpanel.track('[Team].[Users].updateRole');
+    trackEvent('[Team].[Users].updateRole');
     try {
       const { userId, role } = data;
       await apiClient.teams.users.update(teamUuid, userId, { role });
@@ -92,7 +92,7 @@ export const action = async ({ request, params }: ActionFunctionArgs): Promise<T
   }
 
   if (intent === 'delete-team-user') {
-    mixpanel.track('[Team].[Users].delete');
+    trackEvent('[Team].[Users].delete');
     try {
       const { userId } = data;
       const res = await apiClient.teams.users.delete(teamUuid, userId);

--- a/quadratic-client/src/shared/api/apiClient.ts
+++ b/quadratic-client/src/shared/api/apiClient.ts
@@ -1,9 +1,9 @@
 import { downloadQuadraticFile } from '@/app/helpers/downloadFileInBrowser';
 import { ApiError, fetchFromApi } from '@/shared/api/fetchFromApi';
 import { xhrFromApi } from '@/shared/api/xhrFromApi';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
 import { Buffer } from 'buffer';
-import mixpanel from 'mixpanel-browser';
 import { ApiSchemas, type ApiTypes } from 'quadratic-shared/typesAndSchemas';
 
 // TODO(ddimaria): make this dynamic
@@ -158,7 +158,7 @@ export const apiClient = {
     },
 
     delete(uuid: string) {
-      mixpanel.track('[Files].deleteFile', { id: uuid });
+      trackEvent('[Files].deleteFile', { id: uuid });
       return fetchFromApi(`/v0/files/${uuid}`, { method: 'DELETE' }, ApiSchemas['/v0/files/:uuid.DELETE.response']);
     },
 
@@ -276,7 +276,7 @@ export const apiClient = {
         );
       },
       update(uuid: string, body: ApiTypes['/v0/files/:uuid/sharing.PATCH.request']) {
-        mixpanel.track('[FileSharing].publicLinkAccess.update', { value: body.publicLinkAccess });
+        trackEvent('[FileSharing].publicLinkAccess.update', { value: body.publicLinkAccess });
         return fetchFromApi(
           `/v0/files/${uuid}/sharing`,
           {
@@ -290,7 +290,7 @@ export const apiClient = {
 
     invites: {
       create(uuid: string, body: ApiTypes['/v0/files/:uuid/invites.POST.request']) {
-        mixpanel.track('[FileSharing].invite.create');
+        trackEvent('[FileSharing].invite.create');
         return fetchFromApi(
           `/v0/files/${uuid}/invites`,
           {
@@ -301,7 +301,7 @@ export const apiClient = {
         );
       },
       delete(uuid: string, inviteId: string) {
-        mixpanel.track('[FileSharing].invite.delete');
+        trackEvent('[FileSharing].invite.delete');
         return fetchFromApi(
           `/v0/files/${uuid}/invites/${inviteId}`,
           {
@@ -314,7 +314,7 @@ export const apiClient = {
 
     users: {
       update(uuid: string, userId: string, body: ApiTypes['/v0/files/:uuid/users/:userId.PATCH.request']) {
-        mixpanel.track('[FileSharing].users.updateRole');
+        trackEvent('[FileSharing].users.updateRole');
         return fetchFromApi(
           `/v0/files/${uuid}/users/${userId}`,
           { method: 'PATCH', body: JSON.stringify(body) },
@@ -322,7 +322,7 @@ export const apiClient = {
         );
       },
       delete(uuid: string, userId: string) {
-        mixpanel.track('[FileSharing].users.remove');
+        trackEvent('[FileSharing].users.remove');
         return fetchFromApi(
           `/v0/files/${uuid}/users/${userId}`,
           { method: 'DELETE' },

--- a/quadratic-client/src/shared/components/EmptyPage.tsx
+++ b/quadratic-client/src/shared/components/EmptyPage.tsx
@@ -4,8 +4,8 @@ import { EmptyState, type EmptyStateProps } from '@/shared/components/EmptyState
 import { ROUTES } from '@/shared/constants/routes';
 import { useRemoveInitialLoadingUI } from '@/shared/hooks/useRemoveInitialLoadingUI';
 import { Button } from '@/shared/shadcn/ui/button';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import * as Sentry from '@sentry/react';
-import mixpanel from 'mixpanel-browser';
 import { useEffect, useState } from 'react';
 import { useSubmit } from 'react-router';
 
@@ -49,7 +49,7 @@ export function EmptyPage(props: EmptyPageProps) {
       );
       // for core errors, we send the source but don't share it with the user
       const sourceTitle = source ? `Core Error in ${source}` : title;
-      mixpanel.track('[Empty].error', {
+      trackEvent('[Empty].error', {
         title: sourceTitle,
         description,
         error: errorString,

--- a/quadratic-client/src/shared/components/ShareDialog.tsx
+++ b/quadratic-client/src/shared/components/ShareDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { Skeleton } from '@/shared/shadcn/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/shadcn/ui/tooltip';
 import { cn } from '@/shared/shadcn/utils';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { isJsonObject } from '@/shared/utils/isJsonObject';
 import {
   Cross2Icon,
@@ -29,7 +30,6 @@ import {
   LockClosedIcon,
   PersonIcon,
 } from '@radix-ui/react-icons';
-import mixpanel from 'mixpanel-browser';
 import type {
   ApiTypes,
   PublicLinkAccess,
@@ -460,7 +460,7 @@ function CopyLinkButton({
         disabled={disabled}
         className="flex-shrink-0"
         onClick={() => {
-          mixpanel.track('[FileSharing].publicLinkAccess.clickCopyLink');
+          trackEvent('[FileSharing].publicLinkAccess.clickCopyLink');
           navigator.clipboard
             .writeText(url + getShareUrlParams())
             .then(() => {
@@ -478,7 +478,7 @@ function CopyLinkButton({
         disabled={disabled}
         className="flex-shrink-0"
         onClick={() => {
-          mixpanel.track('[FileSharing].publicLinkAccess.clickCopyLink');
+          trackEvent('[FileSharing].publicLinkAccess.clickCopyLink');
 
           // Copy the base file URL (which DOES NOT include the current sheet ID)
           // Can't copy the current location because this can be used on the dashboard

--- a/quadratic-client/src/shared/components/ThemeAccentColors.tsx
+++ b/quadratic-client/src/shared/components/ThemeAccentColors.tsx
@@ -2,7 +2,7 @@ import { CheckSmallIcon } from '@/shared/components/Icons';
 import { themeAccentColors, useThemeAccentColor } from '@/shared/hooks/useThemeAccentColor';
 import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 export const ThemeAccentColors = () => {
   const [accentColor, setThemeAccentColor] = useThemeAccentColor();
@@ -14,7 +14,7 @@ export const ThemeAccentColors = () => {
       key={c}
       onClick={() => {
         setThemeAccentColor(c);
-        mixpanel.track('[Theme].changeAccentColor', {
+        trackEvent('[Theme].changeAccentColor', {
           accentColor: c,
         });
       }}

--- a/quadratic-client/src/shared/components/ThemeAppearanceModes.tsx
+++ b/quadratic-client/src/shared/components/ThemeAppearanceModes.tsx
@@ -2,7 +2,7 @@ import { AppearanceDarkModeIcon, AppearanceLightModeIcon, AppearanceSystemModeIc
 import { appearanceModes, useThemeAppearanceMode } from '@/shared/hooks/useThemeAppearanceMode';
 import { Button } from '@/shared/shadcn/ui/button';
 import { cn } from '@/shared/shadcn/utils';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 export function ThemeAppearanceModes() {
   const [appearanceMode, setAppearanceMode] = useThemeAppearanceMode();
@@ -14,7 +14,7 @@ export function ThemeAppearanceModes() {
       className={cn(mode === appearanceMode && 'border-2 border-foreground', 'justify-start gap-1 capitalize')}
       onClick={() => {
         setAppearanceMode(mode);
-        mixpanel.track('[Theme].changeAppearanceMode', {
+        trackEvent('[Theme].changeAppearanceMode', {
           appearanceMode: mode,
         });
       }}

--- a/quadratic-client/src/shared/components/connections/ConnectionForm.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionForm.tsx
@@ -5,7 +5,7 @@ import type { ConnectionFormValues } from '@/shared/components/connections/conne
 import { connectionsByType } from '@/shared/components/connections/connectionsByType';
 import { ROUTES } from '@/shared/constants/routes';
 import { Skeleton } from '@/shared/shadcn/ui/skeleton';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import type { ConnectionType } from 'quadratic-shared/typesAndSchemasConnections';
 import { useEffect } from 'react';
@@ -31,7 +31,7 @@ export function ConnectionFormCreate({
 
   const handleSubmitForm = (formValues: ConnectionFormValues) => {
     const { name, type, ...typeDetails } = formValues;
-    mixpanel.track('[Connections].create', { type });
+    trackEvent('[Connections].create', { type });
     const { json, options } = getCreateConnectionAction({ name, type, typeDetails }, teamUuid);
     submit(json, { ...options, navigate: false });
     handleNavigateToListView();
@@ -68,7 +68,7 @@ export function ConnectionFormEdit({
   const handleSubmitForm = (formValues: ConnectionFormValues) => {
     // Enhancement: if nothing changed, don't submit. Just navigate back
     const { name, type, ...typeDetails } = formValues;
-    mixpanel.track('[Connections].edit', { type });
+    trackEvent('[Connections].edit', { type });
     const { json, options } = getUpdateConnectionAction(connectionUuid, teamUuid, { name, typeDetails });
     submit(json, { ...options, navigate: false });
     handleNavigateToListView();

--- a/quadratic-client/src/shared/components/connections/ConnectionFormActions.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionFormActions.tsx
@@ -5,7 +5,7 @@ import { ErrorIcon, SpinnerIcon } from '@/shared/components/Icons';
 import { CONTACT_URL } from '@/shared/constants/urls';
 import { Alert, AlertDescription, AlertTitle } from '@/shared/shadcn/ui/alert';
 import { Button } from '@/shared/shadcn/ui/button';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type { ConnectionType } from 'quadratic-shared/typesAndSchemasConnections';
 import { useEffect, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
@@ -53,7 +53,7 @@ export function ConnectionFormActions({
                 className="flex-shrink-0"
                 onClick={async () => {
                   if (await confirmFn()) {
-                    mixpanel.track('[Connections].delete', { type: connectionType });
+                    trackEvent('[Connections].delete', { type: connectionType });
                     const { json, options } = getDeleteConnectionAction(connectionUuid, teamUuid);
                     submit(json, {
                       ...options,

--- a/quadratic-client/src/shared/hooks/useConnectionSchemaBrowser.tsx
+++ b/quadratic-client/src/shared/hooks/useConnectionSchemaBrowser.tsx
@@ -1,5 +1,5 @@
 import type { connectionClient } from '@/shared/api/connectionClient';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useFetcher } from 'react-router';
 
@@ -55,7 +55,7 @@ export const useConnectionSchemaBrowser = ({
   const isLoading = useMemo(() => fetcher.state !== 'idle', [fetcher.state]);
 
   const reloadSchema = useCallback(() => {
-    mixpanel.track('[Connections].schemaViewer.refresh');
+    trackEvent('[Connections].schemaViewer.refresh');
     fetcher.load(fetcherUrl);
   }, [fetcher, fetcherUrl]);
 

--- a/quadratic-client/src/shared/hooks/useFeatureFlag.tsx
+++ b/quadratic-client/src/shared/hooks/useFeatureFlag.tsx
@@ -1,5 +1,5 @@
 import useLocalStorage from '@/shared/hooks/useLocalStorage';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 
 const initialState = {};
 export type FeatureFlagKey = keyof typeof initialState;
@@ -10,9 +10,9 @@ export const useFeatureFlag = (key: FeatureFlagKey) => {
   const localState = state[key];
   const setLocalState = (value: boolean) => {
     if (value) {
-      mixpanel.track('[FeatureFlag].on', { key });
+      trackEvent('[FeatureFlag].on', { key });
     } else {
-      mixpanel.track('[FeatureFlag].off', { key });
+      trackEvent('[FeatureFlag].off', { key });
     }
     setState((prevState) => ({ ...prevState, [key]: value }));
   };

--- a/quadratic-client/src/shared/hooks/useRemoveInitialLoadingUI.ts
+++ b/quadratic-client/src/shared/hooks/useRemoveInitialLoadingUI.ts
@@ -1,5 +1,5 @@
 import { useDebugFlags } from '@/app/debugFlags/useDebugFlags';
-import mixpanel from 'mixpanel-browser';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
 import { useLayoutEffect } from 'react';
 
 export function useRemoveInitialLoadingUI() {
@@ -22,7 +22,7 @@ export function useRemoveInitialLoadingUI() {
       console.log(`Loading time: ${loadTimeMs}ms`);
     }
     const route = window.location.pathname + window.location.search;
-    mixpanel.track('[Loading].complete', {
+    trackEvent('[Loading].complete', {
       route,
       loadTimeMs,
     });

--- a/quadratic-client/src/shared/utils/analytics.ts
+++ b/quadratic-client/src/shared/utils/analytics.ts
@@ -1,6 +1,7 @@
 import { debugFlag } from '@/app/debugFlags/debugFlags';
 import type { User as AuthUser } from '@/auth/auth';
 import { identifyEventAnalyticsUser } from '@/shared/utils/analyticsEvents';
+import { getUtmDataFromCookie } from '@/shared/utils/getUtmDataFromCookie';
 import * as amplitude from '@amplitude/analytics-browser';
 import { setUser } from '@sentry/react';
 
@@ -10,30 +11,6 @@ type User = AuthUser | undefined;
 
 export function googleAnalyticsAvailable(): boolean {
   return import.meta.env.VITE_GOOGLE_ANALYTICS_GTAG && import.meta.env.VITE_GOOGLE_ANALYTICS_GTAG !== 'none';
-}
-
-export function getUtmDataFromCookie(): {
-  utm_source: string | undefined;
-  utm_medium: string | undefined;
-  utm_campaign: string | undefined;
-  utm_content: string | undefined;
-  utm_term: string | undefined;
-} {
-  let utmData = {
-    utm_source: undefined,
-    utm_medium: undefined,
-    utm_campaign: undefined,
-    utm_content: undefined,
-    utm_term: undefined,
-  };
-
-  // get utm data from cookie
-  const utmCookie = document.cookie.split('; ').find((row) => row.startsWith('quadratic_utm='));
-  if (utmCookie) {
-    utmData = JSON.parse(decodeURIComponent(utmCookie.split('=')[1]));
-  }
-
-  return utmData;
 }
 
 // This runs in the root loader, so analytics calls can run inside loaders.

--- a/quadratic-client/src/shared/utils/analytics.ts
+++ b/quadratic-client/src/shared/utils/analytics.ts
@@ -119,21 +119,31 @@ export function initMixpanelAnalytics(user: User) {
     cookie_domain: '.quadratichq.com',
   });
 
+  // Only do this stuff it they're logged in
+  // Mixpanel identity management best practices:
+  // https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#best-practices
+  if (!user?.sub) return;
+
+  // Identify the user
+  mixpanel.identify(user.sub);
+
+  // Globally register stuff we want to send with every event
   mixpanel.register({
-    email: user?.email,
-    distinct_id: user?.sub,
+    email: user.email,
     ...utmData,
   });
 
-  mixpanel.identify(user?.sub);
-
+  // Set properties from the auth service to the user's profile in mixpanel
   mixpanel.people.set_once({
-    $distinct_id: user?.sub,
-    $email: user?.email,
-    $name: user?.name,
-    $avatar: user?.picture,
+    $email: user.email,
+    $name: user.name,
+    $avatar: user.picture,
     ...utmData,
   });
+
+  // After calling identify, we're supposed to send an event, so we use just a
+  // dummy event here
+  mixpanel.track('[mixpanel].initialized');
 }
 
 function configureSentry(user: User) {

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -1,0 +1,98 @@
+import type { User } from '@/auth/auth';
+import { getUtmDataFromCookie } from '@/shared/utils/analytics';
+import mixpanel from 'mixpanel-browser';
+// posthog is meant to be an example of how we could use multiple event analytics
+// providers at the same time and have it all centralized here.
+// import posthog from 'posthog-js';
+
+/**
+ *
+ * CONFIGURE PROVIDERS
+ *
+ */
+
+const MIXPANEL_KEY: string =
+  import.meta.env.VITE_MIXPANEL_ANALYTICS_KEY && import.meta.env.VITE_MIXPANEL_ANALYTICS_KEY !== 'none'
+    ? import.meta.env.VITE_MIXPANEL_ANALYTICS_KEY
+    : '';
+const isMixpanelEnabled = Boolean(MIXPANEL_KEY);
+
+// const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_ANALYTICS_KEY && import.meta.env.VITE_POSTHOG_ANALYTICS_KEY !== 'none' ? import.meta.env.VITE_POSTHOG_ANALYTICS_KEY : 'FAKE_KEY';
+// const isPosthogEnabled = Boolean(POSTHOG_KEY);
+
+/**
+ *
+ * INITIALIZE ON IMPORT
+ *
+ */
+
+if (isMixpanelEnabled) {
+  mixpanel.init(MIXPANEL_KEY, {
+    api_host: 'https://mixpanel-proxy.quadratichq.com',
+    cross_subdomain_cookie: true,
+    cookie_domain: '.quadratichq.com',
+  });
+}
+
+// if (isPosthogEnabled) {…}
+
+/**
+ *
+ * PUBLIC API
+ *
+ */
+
+export function trackEvent(event: string, properties?: Record<string, any>, callback?: () => void) {
+  // Only run SDKs that are enabled
+
+  if (isMixpanelEnabled) {
+    mixpanel.track(event, properties, callback);
+  }
+
+  // if (isPosthogEnabled) {…}
+}
+
+export function identifyEventAnalyticsUser(user: User) {
+  if (isMixpanelEnabled) {
+    startMixpanel(user);
+  }
+
+  // if (isPosthogEnabled) {
+  //   startPosthog(user);
+  // }
+}
+
+/**
+ *
+ * SESSION START MANAGEMENT
+ *
+ */
+
+// Mixpanel identity management best practices:
+// https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#best-practices
+function startMixpanel(user: User) {
+  const utmData = getUtmDataFromCookie();
+
+  // Identify the user
+  mixpanel.identify(user.sub);
+
+  // Globally register stuff we want to send with every event
+  mixpanel.register({
+    email: user.email,
+    ...utmData,
+  });
+
+  // Set properties from the auth service to the user's profile in mixpanel
+  mixpanel.people.set_once({
+    $email: user.email,
+    $name: user.name,
+    $avatar: user.picture,
+    ...utmData,
+  });
+
+  // After calling identify, we're supposed to send an event, so we use just a
+  // dummy event here
+  trackEvent('[mixpanel].initialized');
+}
+
+// function startPosthog(user: User) {…}

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -52,6 +52,14 @@ export function trackEvent(event: string, properties?: Record<string, any>, call
   // if (isPosthogEnabled) {…}
 }
 
+export function resetEventAnalytics() {
+  if (isMixpanelEnabled) {
+    mixpanel.reset();
+  }
+
+  // if (isPosthogEnabled) {…}
+}
+
 export function identifyEventAnalyticsUser(user: User) {
   if (isMixpanelEnabled) {
     startMixpanel(user);

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -1,5 +1,5 @@
 import type { User } from '@/auth/auth';
-import { getUtmDataFromCookie } from '@/shared/utils/analytics';
+import { getUtmDataFromCookie } from '@/shared/utils/getUtmDataFromCookie';
 import mixpanel from 'mixpanel-browser';
 // posthog is meant to be an example of how we could use multiple event analytics
 // providers at the same time and have it all centralized here.

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -92,7 +92,7 @@ function startMixpanel(user: User) {
 
   // After calling identify, we're supposed to send an event, so we use just a
   // dummy event here
-  trackEvent('[mixpanel].initialized');
+  trackEvent('[mixpanel].identify');
 }
 
 // function startPosthog(user: User) {…}

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -22,7 +22,7 @@ const isMixpanelEnabled = Boolean(MIXPANEL_KEY);
 
 /**
  *
- * INITIALIZE ON IMPORT
+ * INITIALIZE (ON MODULE IMPORT)
  *
  */
 

--- a/quadratic-client/src/shared/utils/analyticsEvents.ts
+++ b/quadratic-client/src/shared/utils/analyticsEvents.ts
@@ -70,6 +70,16 @@ export function identifyEventAnalyticsUser(user: User) {
   // }
 }
 
+export function registerEventAnalyticsData(data: Record<string, any>) {
+  if (isMixpanelEnabled) {
+    mixpanel.register(data);
+  }
+
+  // if (isPosthogEnabled) {
+  //   ...
+  // }
+}
+
 /**
  *
  * SESSION START MANAGEMENT

--- a/quadratic-client/src/shared/utils/getUtmDataFromCookie.ts
+++ b/quadratic-client/src/shared/utils/getUtmDataFromCookie.ts
@@ -1,0 +1,27 @@
+export function getUtmDataFromCookie(): {
+  utm_source: string | undefined;
+  utm_medium: string | undefined;
+  utm_campaign: string | undefined;
+  utm_content: string | undefined;
+  utm_term: string | undefined;
+} {
+  let utmData = {
+    utm_source: undefined,
+    utm_medium: undefined,
+    utm_campaign: undefined,
+    utm_content: undefined,
+    utm_term: undefined,
+  };
+
+  // get utm data from cookie
+  const utmCookie = document.cookie.split('; ').find((row) => row.startsWith('quadratic_utm='));
+  if (utmCookie) {
+    try {
+      utmData = JSON.parse(decodeURIComponent(utmCookie.split('=')[1]));
+    } catch (error) {
+      console.error('Error parsing UTM data from cookie', error);
+    }
+  }
+
+  return utmData;
+}


### PR DESCRIPTION
## Description
Implement the simplified identity management for mixpanel.

Docs: https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified

### Code changes

- [`analytics.ts`](https://github.com/quadratichq/quadratic/pull/3334/files#diff-ecdf3e02b933e63af3ced1f53e6a517deea21573f2f326ef3d5c309caeb33408) - Moved current analytics event initialization code out of this file to its own file (see `analyticsEvents.ts`)
- [`analyticsEvents.ts`](https://github.com/quadratichq/quadratic/pull/3334/files#diff-7da1aad3d0f1251e7eed2299d1b0860767c9f4793a546bd30445271880cc4288) - This is where all centralized logic for event tracking lives. We centralize all integration with event analytics SDKs here so we can use multiple ones if we want (analytics sdks are initialized when the module is loaded).
- `**/*.ts|tsx` - Change any files with `mixpanel.track()` to use the new `trackEvent()` function

### Mixpanel integration changes

The following changes were made to how we work with the mixpanel SDK based on [their recommendations for simplified ID management](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified)

- [x] "Call `identify(user_id)` when a user signs up or logs in"
  - I think we want to keep the current call to `.identify` where it is, because [their best practices](https://docs.mixpanel.com/docs/tracking-methods/id-management/identifying-users-simplified#best-practices) state (emphasis mine): "Call `.identify` upon a registration/login **or when an app is re-opened in a logged-in state**". 
  - If a user closes a tab to Quadratic, then re-opens a tab and they're logged in (has token in local storage), they won't go through the `login-result` page and therefore mixpanel would never be initialized. `.identify` needs to happen with the initialization of the app.
- [x] "Send at least one event after the `.identify()` call"
  - We're sending `[mixpanel].identify` as just a dummy event
- [x] "Call `.reset()` when a user logs out
  - Happens in [`logout.tsx`](https://github.com/quadratichq/quadratic/pull/3334/files#diff-5002edbc54bd3e41a8c5c5f2d59adca3e3db729a8c5613632ef687c0056a9fb4)
- [x] Send `[Auth].signup` event when a new user is created (from the client)
  - Happens in [`login-result.tsx`](https://github.com/quadratichq/quadratic/pull/3334/files#diff-3e7509f0c12c14e79ef9d0a842c58779162e82ecf89abaf8e8546f89c7490258)

On Deployment
- [ ] Remove the `[Auth0].signUp` event from the auth0 server setup (@davidkircos)
- [ ] Setup new project in mixpanel and change `VITE_MIXPANEL_ANALYTICS_KEY` key (@davidkircos)
- [ ] Check mixpanel on the marketing site. Update project ID on marketing site @davidkircos 