### PR TITLE
add mixpanel tracking for stripe events

### DIFF
--- a/quadratic-api/package.json
+++ b/quadratic-api/package.json
@@ -57,6 +57,7 @@
     "helmet": "^6.0.1",
     "jsonwebtoken": "^9.0.1",
     "jwks-rsa": "^3.0.0",
+    "mixpanel": "^0.18.1",
     "multer": "^2.0.0",
     "multer-s3": "^3.0.1",
     "openai": "5.12.1",

--- a/quadratic-api/src/analytics/index.ts
+++ b/quadratic-api/src/analytics/index.ts
@@ -1,0 +1,12 @@
+import mixpanel from 'mixpanel-browser';
+import { MIXPANEL_TOKEN } from '../env-vars';
+
+if (MIXPANEL_TOKEN) {
+  mixpanel.init(MIXPANEL_TOKEN);
+}
+
+export const trackEvent = (event: string, properties: Record<string, any>) => {
+  if (MIXPANEL_TOKEN) {
+    mixpanel.track(event, properties);
+  }
+};

--- a/quadratic-api/src/env-vars.ts
+++ b/quadratic-api/src/env-vars.ts
@@ -34,6 +34,7 @@ export const GCP_PROJECT_ID = process.env.GCP_PROJECT_ID || 'GCP_PROJECT_ID';
 export const GCP_CLIENT_EMAIL = process.env.GCP_CLIENT_EMAIL || 'GCP_CLIENT_EMAIL';
 export const GCP_PRIVATE_KEY = process.env.GCP_PRIVATE_KEY || 'GCP_PRIVATE_KEY';
 export const GCP_GEMINI_API_KEY = process.env.GCP_GEMINI_API_KEY || 'GCP_GEMINI_API_KEY';
+export const MIXPANEL_TOKEN = process.env.MIXPANEL_TOKEN || undefined;
 
 // Optional Billing
 export const BILLING_AI_USAGE_LIMIT = process.env.BILLING_AI_USAGE_LIMIT

--- a/quadratic-api/src/stripe/stripe.ts
+++ b/quadratic-api/src/stripe/stripe.ts
@@ -1,6 +1,8 @@
 import type { Team } from '@prisma/client';
 import { SubscriptionStatus } from '@prisma/client';
+import { UserTeamRoleSchema } from 'quadratic-shared/typesAndSchemas';
 import Stripe from 'stripe';
+import { trackEvent } from '../analytics';
 import dbClient from '../dbClient';
 import { STRIPE_SECRET_KEY } from '../env-vars';
 import logger from '../utils/logger';
@@ -157,17 +159,73 @@ const updateTeamStatus = async (
       return;
   }
 
-  // Associate the subscription with the team and update the status
-  await dbClient.team.update({
-    where: { stripeCustomerId: customerId },
-    data: {
-      // activated: true, // activate the team
-      stripeSubscriptionId,
-      stripeSubscriptionStatus,
-      stripeCurrentPeriodEnd: endDate,
-      stripeSubscriptionLastUpdated: new Date(),
-    },
+  // Use a transaction to get old data and update atomically
+  const { oldTeam, updatedTeam, teamOwner } = await dbClient.$transaction(async (tx) => {
+    // Get the team before updating
+    const oldTeam = await tx.team.findUnique({
+      where: { stripeCustomerId: customerId },
+      select: {
+        stripeSubscriptionStatus: true,
+        id: true,
+      },
+    });
+
+    if (!oldTeam) {
+      logger.error('Team not found', { customerId });
+      return;
+    }
+
+    // Get the teams first owner
+    // TODO: this is a hack to get the team owner.
+    // Once we store email on the user, we can use that instead because it's also stored in stripe.
+    const userTeamRole = await tx.userTeamRole.findFirst({
+      where: {
+        teamId: oldTeam.id,
+        role: UserTeamRoleSchema.enum.OWNER,
+      },
+      select: {
+        user: {
+          select: {
+            auth0Id: true,
+          },
+        },
+      },
+    });
+    const teamOwner = userTeamRole?.user;
+
+    if (!teamOwner) {
+      logger.error('First owner not found', { teamId: oldTeam.id });
+      return;
+    }
+
+    // Update the team
+    const updatedTeam = await tx.team.update({
+      where: { stripeCustomerId: customerId },
+      data: {
+        // activated: true, // activate the team
+        stripeSubscriptionId,
+        stripeSubscriptionStatus,
+        stripeCurrentPeriodEnd: endDate,
+        stripeSubscriptionLastUpdated: new Date(),
+      },
+    });
+
+    return { oldTeam, updatedTeam, teamOwner };
   });
+
+  // Now you can compare the statuses
+  const statusChanged = oldTeam?.stripeSubscriptionStatus !== updatedTeam.stripeSubscriptionStatus;
+
+  // If the status changed, track the event
+  if (statusChanged && updatedTeam.stripeSubscriptionStatus !== null) {
+    // track the event
+    trackEvent('[Stripe].statusChangedTo.' + updatedTeam.stripeSubscriptionStatus.toLowerCase(), {
+      distinctId: teamOwner.auth0Id,
+      teamId: updatedTeam.id,
+      oldStatus: oldTeam?.stripeSubscriptionStatus?.toLowerCase(),
+      newStatus: updatedTeam.stripeSubscriptionStatus?.toLowerCase(),
+    });
+  }
 };
 
 export const handleSubscriptionWebhookEvent = async (event: Stripe.Subscription) => {


### PR DESCRIPTION
Add Mixpanel tracking on Stripe Webhook events

Limitaions
- The Stripe Team isn't necessarily connected to the right billing user. In the code, I associate the Mixpannel event with the first Team with the Owner, which may not be the owner who set up billing.