### PR TITLE
feat: acknowledge caveat about read-only users

### DIFF
--- a/quadratic-client/src/shared/components/connections/ConnectionForm.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionForm.tsx
@@ -1,6 +1,7 @@
 import { getCreateConnectionAction, getUpdateConnectionAction } from '@/routes/api.connections';
 import { connectionClient } from '@/shared/api/connectionClient';
 import { ConnectionFormActions } from '@/shared/components/connections/ConnectionFormActions';
+import { ConnectionFormAICheckbox } from '@/shared/components/connections/ConnectionFormAICheckbox';
 import type { ConnectionFormValues } from '@/shared/components/connections/connectionsByType';
 import { connectionsByType } from '@/shared/components/connections/connectionsByType';
 import { ROUTES } from '@/shared/constants/routes';
@@ -8,7 +9,7 @@ import { Skeleton } from '@/shared/shadcn/ui/skeleton';
 import { trackEvent } from '@/shared/utils/analyticsEvents';
 import type { ApiTypes } from 'quadratic-shared/typesAndSchemas';
 import type { ConnectionType } from 'quadratic-shared/typesAndSchemasConnections';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
 import { useFetcher, useSubmit } from 'react-router';
 
@@ -107,8 +108,16 @@ function ConnectionFormWrapper({
   const { ConnectionForm } = connectionsByType[type];
   const { form } = connectionsByType[type].useConnectionForm(props.connection);
 
+  // Require the user check the acknowledge box (but this is not tracked in the form state)
+  const [aiCheckboxChecked, setAiCheckboxChecked] = useState(false);
+  const showError = form.formState.isSubmitted && !aiCheckboxChecked;
+
   // This is a middleware that tests the connection before saving
   const handleSubmitMiddleware: SubmitHandler<ConnectionFormValues> = async (formValues, event: any) => {
+    if (!aiCheckboxChecked) {
+      return;
+    }
+
     if (event?.nativeEvent?.submitter?.name === SKIP_TEST_BUTTON_NAME) {
       props.handleSubmitForm(formValues);
       return;
@@ -138,6 +147,8 @@ function ConnectionFormWrapper({
 
   return (
     <ConnectionForm handleSubmitForm={handleSubmitMiddleware} form={form}>
+      <ConnectionFormAICheckbox value={aiCheckboxChecked} setValue={setAiCheckboxChecked} showError={showError} />
+
       <ConnectionFormActions
         form={form}
         handleNavigateToListView={props.handleNavigateToListView}

--- a/quadratic-client/src/shared/components/connections/ConnectionFormAICheckbox.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionFormAICheckbox.tsx
@@ -1,0 +1,26 @@
+import { Checkbox } from '@/shared/shadcn/ui/checkbox';
+import { Label } from '@/shared/shadcn/ui/label';
+import { cn } from '@/shared/shadcn/utils';
+
+export function ConnectionFormAICheckbox({
+  value,
+  setValue,
+  showError,
+}: {
+  value: boolean;
+  setValue: (value: boolean) => void;
+  showError: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-row items-start gap-2 rounded-md border border-border p-3 shadow-sm">
+        <Checkbox id="ai-checkbox" className="mt-0.5" checked={value} onCheckedChange={setValue} />
+        <Label htmlFor="ai-checkbox" className={cn('flex flex-col leading-5', showError && 'text-destructive')}>
+          I acknowledge that I should use a read-only user. Without it, users or the AI agent could execute write
+          queries on my database.
+        </Label>
+      </div>
+      {showError && <p className="text-xs font-medium text-destructive">Required</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Relevant issue(s)
Resoles #3372 

## Description

When users **create or edit** a connection, require that they check the box.

<img width="1270" height="1184" alt="CleanShot 2025-08-21 at 16 11 52@2x" src="https://github.com/user-attachments/assets/97d2fa1c-f78a-4332-87f4-14bdbf9e3a15" />

<img width="1238" height="1168" alt="CleanShot 2025-08-21 at 16 11 37@2x" src="https://github.com/user-attachments/assets/b987596e-6d74-4708-ae36-5db91274d015" />

## To Test

They shouldn't be able to submit the form without checking the box.

<img width="1248" height="1212" alt="CleanShot 2025-08-21 at 16 11 58@2x" src="https://github.com/user-attachments/assets/245af96b-18a7-48a1-92e7-5fe89d00b7d1" />

