### PR TITLE
Improve perf for offsets

### DIFF
--- a/quadratic-client/src/app/gridGL/UI/FakeGraphics.ts
+++ b/quadratic-client/src/app/gridGL/UI/FakeGraphics.ts
@@ -1,0 +1,85 @@
+//! Fake graphics class that uses sprites instead of PIXI.Graphics to draw
+//! simple shapes. This is necessary because PIXI.Graphics does not properly
+//! support very large offsets (> 300m).
+
+import { Container, Sprite, Texture } from 'pixi.js';
+
+interface DrawRectOptions {
+  fill?: number;
+  alpha?: number;
+  strokeWidth?: number;
+  strokeTint?: number;
+  strokeAlpha?: number;
+}
+
+interface DrawLineOptions {
+  tint?: number;
+  alpha?: number;
+  alignment?: number;
+  strokeWidth?: number;
+}
+
+export class FakeGraphics extends Container {
+  private current = 0;
+
+  private getSprite(): Sprite {
+    if (this.current >= this.children.length) {
+      const sprite = this.addChild(new Sprite(Texture.WHITE));
+      return sprite;
+    } else {
+      const sprite = this.children[this.current] as Sprite;
+      sprite.visible = true;
+      this.current++;
+      return sprite;
+    }
+  }
+
+  clear() {
+    this.current = 0;
+  }
+
+  finish() {
+    for (let i = this.current; i < this.children.length; i++) {
+      this.children[i].visible = false;
+    }
+  }
+
+  drawRect(x0: number, y0: number, x1: number, y1: number, options: DrawRectOptions = {}) {
+    const { fill, strokeWidth, alpha, strokeTint, strokeAlpha } = options;
+    const sprite = this.getSprite();
+    this.drawHorizontalLine(x0, x1 - (strokeWidth ?? 1), y0, { tint: strokeTint, alpha: strokeAlpha, strokeWidth });
+    if (strokeWidth !== undefined) {
+      sprite.position.set(x0 + (strokeWidth ?? 1), y0 + (strokeWidth ?? 1));
+      sprite.width = x1 - x0 - (strokeWidth ?? 1) * 2;
+      sprite.height = y1 - y0 - (strokeWidth ?? 1) * 2;
+      sprite.tint = fill ?? 0;
+      sprite.alpha = alpha ?? 1;
+    } else {
+      sprite.position.set(x0, y0);
+      sprite.width = x1 - x0;
+      sprite.height = y1 - y0;
+      sprite.tint = fill ?? 0;
+      sprite.alpha = alpha ?? 1;
+    }
+  }
+
+  drawHorizontalLine(x0: number, x1: number, y: number, options: DrawLineOptions = {}) {
+    const { tint, alpha, alignment, strokeWidth } = options;
+    const sprite = this.getSprite();
+    sprite.position.set(x0, y - (alignment ?? 0.5) * (strokeWidth ?? 1));
+    sprite.width = x1 - x0;
+    sprite.height = strokeWidth ?? 1;
+    sprite.tint = tint ?? 0;
+    sprite.alpha = alpha ?? 1;
+  }
+
+  drawVerticalLine(y0: number, y1: number, x: number, options: DrawLineOptions = {}) {
+    const { tint, alpha, alignment, strokeWidth } = options;
+    const sprite = this.getSprite();
+    sprite.position.set(x, y0 - (alignment ?? 0.5) * (strokeWidth ?? 1));
+    sprite.width = 1;
+    sprite.height = y1 - y0;
+    sprite.tint = tint ?? 0;
+    sprite.alpha = alpha ?? 1;
+  }
+}

--- a/quadratic-client/src/app/gridGL/UI/GridLines.ts
+++ b/quadratic-client/src/app/gridGL/UI/GridLines.ts
@@ -8,7 +8,8 @@ import { sheets } from '@/app/grid/controller/Sheets';
 import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
 import { calculateAlphaForGridLines } from '@/app/gridGL/UI/gridUtils';
-import { Container, Sprite, Texture, type ILineStyleOptions, type Rectangle } from 'pixi.js';
+import { LineGraphics } from '@/app/gridGL/UI/LineGraphics';
+import { type Rectangle } from 'pixi.js';
 
 interface GridLine {
   column?: number;
@@ -21,15 +22,12 @@ interface GridLine {
 
 const GRID_LINE_ALPHA = 0.1;
 
-export class GridLines extends Container {
-  currentLineStyle: ILineStyleOptions = { alpha: 0 };
+export class GridLines extends LineGraphics {
   dirty = true;
 
   // cache of lines used for snapping
   gridLinesX: GridLine[] = [];
   gridLinesY: GridLine[] = [];
-
-  current: number = 0;
 
   // line width that takes scale into account (so it always draws as 1 pixel)
   lineWidth: number = 1;
@@ -68,8 +66,9 @@ export class GridLines extends Container {
       return;
     }
 
-    this.current = 0;
     this.visible = true;
+    this.clear();
+
     this.alpha = gridAlpha * GRID_LINE_ALPHA;
     this.lineWidth = 1 / scale;
 
@@ -87,45 +86,8 @@ export class GridLines extends Container {
     const range = this.drawHorizontalLines(bounds);
     this.drawVerticalLines(bounds, range);
 
-    this.hideRemainingLines();
+    this.finish();
   };
-
-  private getLine(): Sprite {
-    if (this.current >= this.children.length) {
-      const line = this.addChild(new Sprite(Texture.WHITE));
-      line.tint = 0;
-      return line;
-    } else {
-      const line = this.children[this.current] as Sprite;
-      line.visible = true;
-      this.current++;
-      return line;
-    }
-  }
-
-  private drawHorizontalLine(x0: number, x1: number, y: number) {
-    if (y + 1 < sheets.sheet.clamp.top) return;
-    const line = this.getLine();
-    line.position.set(x0, y - this.lineWidth / 2);
-    line.width = x1 - x0;
-    line.height = this.lineWidth;
-    return line;
-  }
-
-  private drawVerticalLine(y0: number, y1: number, x: number) {
-    if (x + 1 < sheets.sheet.clamp.left) return;
-    const line = this.getLine();
-    line.position.set(x - this.lineWidth / 2, y0 - this.lineWidth / 2);
-    line.width = this.lineWidth;
-    line.height = y1 - y0;
-    return line;
-  }
-
-  private hideRemainingLines() {
-    for (let i = this.current; i < this.children.length; i++) {
-      this.children[i].visible = false;
-    }
-  }
 
   private drawVerticalLines(bounds: Rectangle, range: [number, number]) {
     const sheet = sheets.sheet;

--- a/quadratic-client/src/app/gridGL/UI/LineGraphics.ts
+++ b/quadratic-client/src/app/gridGL/UI/LineGraphics.ts
@@ -10,6 +10,9 @@ interface DrawRectOptions {
   strokeWidth?: number;
   strokeTint?: number;
   strokeAlpha?: number;
+
+  // 1 / viewport.scaled
+  scaled?: number;
 }
 
 interface DrawLineOptions {
@@ -17,16 +20,13 @@ interface DrawLineOptions {
   alpha?: number;
   alignment?: number;
   strokeWidth?: number;
+
+  // 1 / viewport.scaled
+  scaled?: number;
 }
 
 export class LineGraphics extends Container {
   private current = 0;
-  private scaled: boolean;
-
-  constructor(scaled: boolean) {
-    super();
-    this.scaled = scaled;
-  }
 
   private getSprite(): Sprite {
     if (this.current >= this.children.length) {
@@ -51,16 +51,14 @@ export class LineGraphics extends Container {
   }
 
   drawRect(x0: number, y0: number, x1: number, y1: number, options: DrawRectOptions = {}) {
-    const { fill, strokeWidth, alpha, strokeTint, strokeAlpha } = options;
+    const { fill, alpha, strokeTint, strokeAlpha, scaled } = options;
+    let strokeWidth = (options.strokeWidth ?? 1) * (scaled ?? 1);
     const sprite = this.getSprite();
-    if (this.scaled) {
-      strokeWidth = (strokeWidth ?? 1) / pixiApp.viewport.scaled;
-    }
-    this.drawHorizontalLine(x0, x1 - (strokeWidth ?? 1), y0, { tint: strokeTint, alpha: strokeAlpha, strokeWidth });
+    this.drawHorizontalLine(x0, x1 - strokeWidth, y0, { tint: strokeTint, alpha: strokeAlpha, strokeWidth });
     if (strokeWidth !== undefined) {
-      sprite.position.set(x0 + (strokeWidth ?? 1), y0 + (strokeWidth ?? 1));
-      sprite.width = x1 - x0 - (strokeWidth ?? 1) * 2;
-      sprite.height = y1 - y0 - (strokeWidth ?? 1) * 2;
+      sprite.position.set(x0 + strokeWidth, y0 + strokeWidth);
+      sprite.width = x1 - x0 - strokeWidth * 2;
+      sprite.height = y1 - y0 - strokeWidth * 2;
       sprite.tint = fill ?? 0;
       sprite.alpha = alpha ?? 1;
     } else {
@@ -73,19 +71,23 @@ export class LineGraphics extends Container {
   }
 
   drawHorizontalLine(x0: number, x1: number, y: number, options: DrawLineOptions = {}) {
-    const { tint, alpha, alignment, strokeWidth } = options;
+    const { tint, alpha, scaled } = options;
+    let alignment = options.alignment ?? 0.5;
+    let strokeWidth = (options.strokeWidth ?? 1) * (scaled ?? 1);
     const sprite = this.getSprite();
-    sprite.position.set(x0, y - (alignment ?? 0.5) * (strokeWidth ?? 1));
+    sprite.position.set(x0, y - alignment * strokeWidth);
     sprite.width = x1 - x0;
-    sprite.height = strokeWidth ?? 1;
+    sprite.height = strokeWidth;
     sprite.tint = tint ?? 0;
     sprite.alpha = alpha ?? 1;
   }
 
   drawVerticalLine(y0: number, y1: number, x: number, options: DrawLineOptions = {}) {
-    const { tint, alpha, alignment, strokeWidth } = options;
+    const { tint, alpha, scaled } = options;
+    let alignment = options.alignment ?? 0.5;
+    let strokeWidth = (options.strokeWidth ?? 1) * (scaled ?? 1);
     const sprite = this.getSprite();
-    sprite.position.set(x, y0 - (alignment ?? 0.5) * (strokeWidth ?? 1));
+    sprite.position.set(x, y0 - alignment * strokeWidth);
     sprite.width = 1;
     sprite.height = y1 - y0;
     sprite.tint = tint ?? 0;

--- a/quadratic-client/src/app/gridGL/UI/LineGraphics.ts
+++ b/quadratic-client/src/app/gridGL/UI/LineGraphics.ts
@@ -1,6 +1,6 @@
-//! Fake graphics class that uses sprites instead of PIXI.Graphics to draw
-//! simple shapes. This is necessary because PIXI.Graphics does not properly
-//! support very large offsets (> 300m).
+//! Line graphics class that uses sprites instead of PIXI.Graphics to draw
+//! simple shapes (axis lines and rects). This is necessary because
+//! PIXI.Graphics does not properly support very large offsets (> 300m).
 
 import { Container, Sprite, Texture } from 'pixi.js';
 
@@ -19,8 +19,14 @@ interface DrawLineOptions {
   strokeWidth?: number;
 }
 
-export class FakeGraphics extends Container {
+export class LineGraphics extends Container {
   private current = 0;
+  private scaled: boolean;
+
+  constructor(scaled: boolean) {
+    super();
+    this.scaled = scaled;
+  }
 
   private getSprite(): Sprite {
     if (this.current >= this.children.length) {
@@ -47,6 +53,9 @@ export class FakeGraphics extends Container {
   drawRect(x0: number, y0: number, x1: number, y1: number, options: DrawRectOptions = {}) {
     const { fill, strokeWidth, alpha, strokeTint, strokeAlpha } = options;
     const sprite = this.getSprite();
+    if (this.scaled) {
+      strokeWidth = (strokeWidth ?? 1) / pixiApp.viewport.scaled;
+    }
     this.drawHorizontalLine(x0, x1 - (strokeWidth ?? 1), y0, { tint: strokeTint, alpha: strokeAlpha, strokeWidth });
     if (strokeWidth !== undefined) {
       sprite.position.set(x0 + (strokeWidth ?? 1), y0 + (strokeWidth ?? 1));

--- a/quadratic-client/src/app/gridGL/cells/tables/TableColumnHeadersGridLines.ts
+++ b/quadratic-client/src/app/gridGL/cells/tables/TableColumnHeadersGridLines.ts
@@ -2,11 +2,11 @@
 
 import type { TableHeader } from '@/app/gridGL/cells/tables/TableHeader';
 import { pixiApp } from '@/app/gridGL/pixiApp/PixiApp';
+import { LineGraphics } from '@/app/gridGL/UI/LineGraphics';
 import { getCSSVariableTint } from '@/app/helpers/convertColor';
 import { sharedEvents } from '@/shared/sharedEvents';
-import { Graphics } from 'pixi.js';
 
-export class TableColumnHeadersGridLines extends Graphics {
+export class TableColumnHeadersGridLines extends LineGraphics {
   private header: TableHeader;
 
   constructor(header: TableHeader) {
@@ -23,29 +23,28 @@ export class TableColumnHeadersGridLines extends Graphics {
 
   update = () => {
     this.clear();
-    if (pixiApp.gridLines?.visible) {
+    if (pixiApp.gridLines.visible) {
       const tableLines = this.header.getColumnHeaderLines();
       if (!tableLines) return;
       const { y0, y1, lines } = tableLines;
-      const currentLineStyle = pixiApp.gridLines.currentLineStyle;
-      if (!currentLineStyle) return;
 
+      let tint = 0;
+      let alignment = 0;
       lines.forEach((line, index) => {
         if (index === 0 || index === lines.length - 1) {
-          this.lineStyle({
-            color: getCSSVariableTint(this.header.table.active ? 'primary' : 'muted-foreground'),
-            width: 1,
-            alignment: index === lines.length - 1 ? 0 : 1,
-          });
+          tint = getCSSVariableTint(this.header.table.active ? 'primary' : 'muted-foreground');
+          alignment = index === lines.length - 1 ? 0 : 1;
         } else {
-          this.lineStyle(currentLineStyle);
+          tint = 0;
+          alignment = 0;
         }
 
-        this.moveTo(line, y0).lineTo(line, y1);
+        this.drawVerticalLine(y0, y1, line, { tint, alignment });
       });
-      this.lineStyle(currentLineStyle);
-      this.moveTo(lines[0], y0).lineTo(lines[lines.length - 1], y0);
-      this.moveTo(lines[0], y1).lineTo(lines[lines.length - 1], y1);
+      this.drawHorizontalLine(lines[0], lines[lines.length - 1], y0);
+      this.drawHorizontalLine(lines[0], lines[lines.length - 1], y1);
     }
+    this.alpha = pixiApp.gridLines.alpha;
+    this.finish();
   };
 }

--- a/quadratic-client/src/app/gridGL/pixiApp/Update.ts
+++ b/quadratic-client/src/app/gridGL/pixiApp/Update.ts
@@ -115,7 +115,7 @@ export class Update {
     }
 
     debugTimeReset();
-    pixiApp.gridLines.update();
+    pixiApp.gridLines.update(undefined, undefined, pixiApp.viewport.dirty);
     debugTimeCheck('[Update] gridLines');
     pixiApp.headings.update(pixiApp.viewport.dirty);
     debugTimeCheck('[Update] headings');

--- a/quadratic-core/src/sheet_offsets/offsets.rs
+++ b/quadratic-core/src/sheet_offsets/offsets.rs
@@ -103,18 +103,52 @@ impl Offsets {
     /// up the search.
     pub fn find_offset(&self, pixel: f64) -> (i64, f64) {
         let mut current_sum = 0.0;
-        let mut current_index = 1;
-        let mut current_size = self.get_size(current_index);
-        while current_sum + current_size <= pixel {
-            current_sum += current_size;
-            current_index += 1;
-            current_size = self.get_size(current_index);
+        let mut current_index = 1i64;
+
+        // If we have no custom sizes then it's all default sizes
+        if self.sizes.is_empty() {
+            let index = (pixel / self.default).floor() as i64 + 1;
+            let position = (index - 1) as f64 * self.default;
+            return (index, position);
         }
 
+        // Iterate through custom sizes only to avoid checking every default value
+        for (&custom_index, &custom_size) in &self.sizes {
+            // Calculate how many default-sized elements are between current_index and custom_index
+            if custom_index > current_index {
+                let default_count = custom_index - current_index;
+                let default_total = default_count as f64 * self.default;
+
+                // Check if pixel falls within the default range
+                if current_sum + default_total > pixel {
+                    // Pixel is in the default range
+                    let remaining = pixel - current_sum;
+                    let offset_in_defaults = (remaining / self.default).floor() as i64;
+                    return (
+                        current_index + offset_in_defaults,
+                        current_sum + offset_in_defaults as f64 * self.default,
+                    );
+                }
+
+                current_sum += default_total;
+                current_index = custom_index;
+            }
+
+            // Check if pixel falls within this custom size
+            if current_sum + custom_size > pixel {
+                return (current_index, current_sum);
+            }
+
+            current_sum += custom_size;
+            current_index += 1;
+        }
+
+        // Pixel is beyond all custom sizes, continue with defaults
+        let remaining = pixel - current_sum;
+        let offset_in_defaults = (remaining / self.default).floor() as i64;
         (
-            // Ensure the current_index is 1-based.
-            current_index,
-            current_sum,
+            current_index + offset_in_defaults,
+            current_sum + offset_in_defaults as f64 * self.default,
         )
     }
 
@@ -153,9 +187,10 @@ impl Offsets {
 
                     // if the key is the index, set the size
                     if *k == index
-                        && let Some(source_width) = source_width {
-                            sizes.insert(*k, source_width);
-                        }
+                        && let Some(source_width) = source_width
+                    {
+                        sizes.insert(*k, source_width);
+                    }
                 } else {
                     sizes.insert(*k, *size);
                 }
@@ -444,5 +479,46 @@ mod tests {
 
         // Verify new entries also use default
         assert_eq!(offsets.get_size(100), 10.0);
+    }
+
+    #[test]
+    fn test_find_offset_large_pixel_ranges() {
+        // Test find_offset with pixel ranges > 300 million
+        let mut offsets = Offsets::new(10.0);
+
+        // Test with default sizes only for large pixel values
+        let pixel_300m = 300_000_000.0;
+        let (index, position) = offsets.find_offset(pixel_300m);
+        let expected_index = (pixel_300m / 10.0).floor() as i64 + 1;
+        let expected_position = (expected_index - 1) as f64 * 10.0;
+        assert_eq!(index, expected_index);
+        assert_eq!(position, expected_position);
+
+        // Test with pixel value > 300m
+        let pixel_500m = 500_000_000.0;
+        let (index, position) = offsets.find_offset(pixel_500m);
+        let expected_index = (pixel_500m / 10.0).floor() as i64 + 1;
+        let expected_position = (expected_index - 1) as f64 * 10.0;
+        assert_eq!(index, expected_index);
+        assert_eq!(position, expected_position);
+
+        // Test with custom sizes and large pixel values
+        offsets.set_size(1, 20.0);
+        offsets.set_size(1000, 50.0);
+
+        // For pixel beyond custom sizes, should continue with defaults
+        let pixel_1b = 1_000_000_000.0;
+        let (index, position) = offsets.find_offset(pixel_1b);
+
+        // Calculate expected values considering custom sizes
+        let custom_contribution = 20.0 - 10.0 + 50.0 - 10.0; // difference from default
+        let remaining_pixels = pixel_1b - custom_contribution - 1000.0 * 10.0; // subtract all pixels up to index 1001
+        let additional_defaults = (remaining_pixels / 10.0).floor() as i64;
+        let expected_index = 1001 + additional_defaults;
+        let expected_position =
+            custom_contribution + 1000.0 * 10.0 + additional_defaults as f64 * 10.0;
+
+        assert_eq!(index, expected_index);
+        assert_eq!(position, expected_position);
     }
 }


### PR DESCRIPTION
- [x] improved perf for pixel-to-offset conversion
- [x] gridLines uses sprites instead of graphics to avoid floating point issues
- [ ] convert selection to use sprites instead of graphics