### PR TITLE
feat: onboarding video

### DIFF
--- a/quadratic-client/src/app/actions/actions.ts
+++ b/quadratic-client/src/app/actions/actions.ts
@@ -32,6 +32,7 @@ export enum Action {
   HelpCommunity = 'help_community',
   HelpChangelog = 'help_changelog',
   HelpFeedback = 'help_feedback',
+  HelpYouTube = 'help_youtube',
   FormatAlignHorizontalCenter = 'format_align_horizontal_center',
   FormatAlignHorizontalLeft = 'format_align_horizontal_left',
   FormatAlignHorizontalRight = 'format_align_horizontal_right',

--- a/quadratic-client/src/app/actions/helpActionsSpec.ts
+++ b/quadratic-client/src/app/actions/helpActionsSpec.ts
@@ -4,7 +4,7 @@ import type { ActionSpecRecord } from '@/app/actions/actionsSpec';
 import { pixiAppSettings } from '@/app/gridGL/pixiApp/PixiAppSettings';
 import { openLink } from '@/app/helpers/links';
 import { ExternalLinkIcon, FeedbackIcon } from '@/shared/components/Icons';
-import { COMMUNITY_FORUMS, CONTACT_URL, DOCUMENTATION_URL } from '@/shared/constants/urls';
+import { COMMUNITY_FORUMS, CONTACT_URL, DOCUMENTATION_URL, YOUTUBE_CHANNEL } from '@/shared/constants/urls';
 
 type HelpActionSpec = Pick<
   ActionSpecRecord,
@@ -14,6 +14,7 @@ type HelpActionSpec = Pick<
   | Action.HelpQuadratic101
   | Action.HelpCommunity
   | Action.HelpChangelog
+  | Action.HelpYouTube
 >;
 
 export const helpActionsSpec: HelpActionSpec = {
@@ -64,6 +65,14 @@ export const helpActionsSpec: HelpActionSpec = {
     run: () => {
       if (!pixiAppSettings.setEditorInteractionState) return;
       pixiAppSettings.setEditorInteractionState((prev) => ({ ...prev, showFeedbackMenu: true }));
+    },
+  },
+  [Action.HelpYouTube]: {
+    label: () => 'YouTube',
+    labelVerbose: 'Visit our YouTube channel',
+    Icon: ExternalLinkIcon,
+    run: () => {
+      openLink(YOUTUBE_CHANNEL);
     },
   },
 };

--- a/quadratic-client/src/app/ui/QuadraticUI.tsx
+++ b/quadratic-client/src/app/ui/QuadraticUI.tsx
@@ -13,6 +13,7 @@ import QuadraticGrid from '@/app/gridGL/QuadraticGrid';
 import { isEmbed } from '@/app/helpers/isEmbed';
 import { FileDragDropWrapper } from '@/app/ui/components/FileDragDropWrapper';
 import { useFileContext } from '@/app/ui/components/FileProvider';
+import { OnboardingVideo } from '@/app/ui/components/OnboardingVideo';
 import { PermissionOverlay } from '@/app/ui/components/PermissionOverlay';
 import PresentationModeHint from '@/app/ui/components/PresentationModeHint';
 import { AIAnalyst } from '@/app/ui/menus/AIAnalyst/AIAnalyst';
@@ -38,12 +39,13 @@ import { useRemoveInitialLoadingUI } from '@/shared/hooks/useRemoveInitialLoadin
 import { Button } from '@/shared/shadcn/ui/button';
 import { CrossCircledIcon } from '@radix-ui/react-icons';
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigation, useParams } from 'react-router';
+import { useNavigation, useParams, useSearchParams } from 'react-router';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 export default function QuadraticUI() {
   const { isAuthenticated } = useRootRouteLoaderData();
   const navigation = useNavigation();
+  const [searchParams] = useSearchParams();
   const { uuid } = useParams() as { uuid: string };
   const { name, renameFile } = useFileContext();
   const [showShareFileMenu, setShowShareFileMenu] = useRecoilState(editorInteractionStateShowShareFileMenuAtom);
@@ -53,6 +55,7 @@ export default function QuadraticUI() {
   const showCommandPalette = useRecoilValue(editorInteractionStateShowCommandPaletteAtom);
   const permissions = useRecoilValue(editorInteractionStatePermissionsAtom);
   const canEditFile = useMemo(() => hasPermissionToEditFile(permissions), [permissions]);
+  const [showOnboardingVideo, setShowOnboardingVideo] = useState(searchParams.get('show-onboarding-video') !== null);
 
   const [error, setError] = useState<{ from: string; error: Error | unknown } | null>(null);
   useEffect(() => {
@@ -82,6 +85,15 @@ export default function QuadraticUI() {
     }
   }, []);
 
+  // Remove the `show-onboarding-video` param from the URL if it's present
+  useEffect(() => {
+    if (showOnboardingVideo === true) {
+      const url = new URLSearchParams(window.location.search);
+      url.delete('show-onboarding-video');
+      window.history.replaceState({}, '', `${window.location.pathname}${url.toString() ? `?${url}` : ''}`);
+    }
+  }, [showOnboardingVideo]);
+
   useRemoveInitialLoadingUI();
 
   if (error) {
@@ -95,6 +107,10 @@ export default function QuadraticUI() {
         source={error.from}
       />
     );
+  }
+
+  if (showOnboardingVideo) {
+    return <OnboardingVideo onClose={() => setShowOnboardingVideo(false)} />;
   }
 
   return (

--- a/quadratic-client/src/app/ui/components/OnboardingVideo.tsx
+++ b/quadratic-client/src/app/ui/components/OnboardingVideo.tsx
@@ -1,0 +1,83 @@
+import { YOUTUBE_CHANNEL } from '@/shared/constants/urls';
+import { Button } from '@/shared/shadcn/ui/button';
+import { trackEvent } from '@/shared/utils/analyticsEvents';
+import { useEffect, useRef, useState } from 'react';
+
+export function OnboardingVideo({ onClose }: { onClose: () => void }) {
+  const [startedPlaying, setStartedPlaying] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Fire event if this component mounts
+  useEffect(() => {
+    trackEvent('[OnboardingVideo].loaded');
+  }, []);
+
+  return (
+    <div className="grid h-full w-full place-items-center overflow-auto px-4 py-8">
+      <div className="flex w-full max-w-7xl flex-col items-center gap-8">
+        <div className="flex flex-col items-center gap-1">
+          <h1 className="text-3xl font-bold">Getting started in 90 seconds</h1>
+          <p className="text-center text-lg text-muted-foreground">
+            You can always find more instructional videos on{' '}
+            <a
+              href={YOUTUBE_CHANNEL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+              onClick={() => trackEvent('[OnboardingVideo].clickedYouTubeChannel')}
+            >
+              our YouTube channel
+            </a>
+          </p>
+        </div>
+        <video
+          ref={videoRef}
+          onEnded={() => {
+            trackEvent('[OnboardingVideo].completedPlaying');
+          }}
+          onPlay={() => {
+            if (!startedPlaying) {
+              setStartedPlaying(true);
+              trackEvent('[OnboardingVideo].startedPlaying');
+              console.log('startedPlaying');
+            }
+          }}
+          controls
+          width="800"
+          height="450"
+          // TODO: do we want the poster from youtube?
+          // and where do we want to host the video?
+          poster="https://img.youtube.com/vi/tyS9H0exaj8/maxresdefault.jpg"
+          className="w-full max-w-5xl rounded-lg border border-border shadow-xl"
+        >
+          <source src="https://cdn.jim-nielsen.com/shared/onboarding-video.mp4" type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+        <div className="flex justify-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              trackEvent('[OnboardingVideo].skipped');
+              onClose();
+            }}
+            className="h-12 w-40 px-8 text-base"
+          >
+            Skip
+          </Button>
+          <Button
+            onClick={() => {
+              if (!startedPlaying) {
+                videoRef.current?.play();
+              } else {
+                onClose();
+              }
+            }}
+            className="h-12 w-40 px-8 text-base"
+          >
+            {startedPlaying ? 'Get started' : 'Play video'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/HelpMenubarMenu.tsx
+++ b/quadratic-client/src/app/ui/menus/TopBar/TopBarMenus/HelpMenubarMenu.tsx
@@ -11,6 +11,7 @@ export const HelpMenubarMenu = () => {
         <MenubarItemAction action={Action.HelpQuadratic101} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpCommunity} actionArgs={undefined} />
         <MenubarItemAction action={Action.HelpChangelog} actionArgs={undefined} />
+        <MenubarItemAction action={Action.HelpYouTube} actionArgs={undefined} />
         <MenubarSeparator />
         <MenubarItemAction action={Action.HelpContactUs} actionArgs={undefined} />
       </MenubarContent>

--- a/quadratic-client/src/shared/constants/urls.ts
+++ b/quadratic-client/src/shared/constants/urls.ts
@@ -24,3 +24,4 @@ export const COMMUNITY_A1_FILE_UPDATE_URL =
   'https://community.quadratichq.com/t/switch-to-a1-notation-from-x-y-coordinates/';
 export const PRICING_URL = 'https://www.quadratichq.com/pricing';
 export const COMMUNITY_FORUMS = 'https://community.quadratichq.com';
+export const YOUTUBE_CHANNEL = 'https://www.youtube.com/@quadraticai';


### PR DESCRIPTION
## Relevant issue(s)

Resolves #3294 

## Description

- Show the onboarding video to a certain number of new users (requires #3394 be merged first)
- Setup events in mixpanel related to this onboarding video
- Put "YouTube" in the help panel so people get more exposure to our videos

<img width="2268" height="1746" alt="CleanShot 2025-09-05 at 19 29 12@2x" src="https://github.com/user-attachments/assets/1f14c32a-4529-4ade-8081-44765874daa0" />

<img width="1400" height="1014" alt="CleanShot 2025-09-05 at 19 29 32@2x" src="https://github.com/user-attachments/assets/f28c2e47-33e4-4cef-a328-aab78ab526f0" />

### To Test

- [ ] "YouTube" link in file menu bar links out to quadratic YouTube 
- [ ] Landing on the app with query param shows onboarding video `?show-onboarding-video`
- [ ] Buttons on page work as expected

### Todos

- [ ] Get video hosted properly
- [ ] Figure out where we pull thumbnails from