### PR TITLE
Remove code cell value from the grid

### DIFF
--- a/quadratic-core/src/controller/execution/control_transaction.rs
+++ b/quadratic-core/src/controller/execution/control_transaction.rs
@@ -10,7 +10,7 @@ use crate::error_core::Result;
 use crate::grid::{CodeCellLanguage, CodeRun, ConnectionKind, DataTable, DataTableKind};
 use crate::parquet::parquet_to_array;
 use crate::renderer_constants::{CELL_SHEET_HEIGHT, CELL_SHEET_WIDTH};
-use crate::{CellValue, Pos, RunError, RunErrorMsg, Value};
+use crate::{Pos, RunError, RunErrorMsg, Value};
 
 impl GridController {
     // loop compute cycle until complete or an async call is made
@@ -183,7 +183,8 @@ impl GridController {
             if let Some(sheet) = self.try_sheet(current_sheet_pos.sheet_id) {
                 // if code cell exists, proceed with processing the connection result
                 // code cell may not exist if deleted by user or multiplayer during the async call
-                if let Some(CellValue::Code(code)) = sheet.cell_value_ref(current_sheet_pos.into())
+                if let Some(data_table) = sheet.data_table_at(&(current_sheet_pos.into()))
+                    && let DataTableKind::CodeRun(code) = &data_table.kind
                 {
                     let name = match code.language {
                         CodeCellLanguage::Connection { kind, .. } => match kind {

--- a/quadratic-core/src/controller/execution/execute_operation/mod.rs
+++ b/quadratic-core/src/controller/execution/execute_operation/mod.rs
@@ -69,7 +69,11 @@ impl GridController {
                 Operation::AddDataTable { .. } => Self::handle_execution_operation_result(
                     self.execute_add_data_table(transaction, op),
                 ),
-
+                Operation::AddDataTableWithoutCellValue { .. } => {
+                    Self::handle_execution_operation_result(
+                        self.execute_add_data_table_without_cell_value(transaction, op),
+                    )
+                }
                 Operation::DeleteDataTable { .. } => Self::handle_execution_operation_result(
                     self.execute_delete_data_table(transaction, op),
                 ),

--- a/quadratic-core/src/controller/operations/operation.rs
+++ b/quadratic-core/src/controller/operations/operation.rs
@@ -45,6 +45,16 @@ pub enum Operation {
         data_table: Option<DataTable>,
         index: usize,
     },
+    AddDataTableWithoutCellValue {
+        sheet_pos: SheetPos,
+        data_table: DataTable,
+
+        // Used to insert a data table at a specific index (usually after an
+        // undo action)
+        #[serde(default)]
+        index: Option<usize>,
+    },
+    /// **Deprecated** (Sept 2025) and replaced with AddDataTableWithoutCellValue
     /// Adds or replaces a data table at a specific SheetPos.
     AddDataTable {
         sheet_pos: SheetPos,

--- a/quadratic-core/src/grid/file/serialize/cell_value.rs
+++ b/quadratic-core/src/grid/file/serialize/cell_value.rs
@@ -37,10 +37,7 @@ pub fn export_cell_value(cell_value: CellValue) -> current::CellValueSchema {
         CellValue::Text(text) => current::CellValueSchema::Text(text),
         CellValue::Number(number) => export_cell_value_number(number),
         CellValue::Html(html) => current::CellValueSchema::Html(html),
-        CellValue::Code(cell_code) => current::CellValueSchema::Code(current::CodeCellSchema {
-            code: cell_code.code,
-            language: export_code_cell_language(cell_code.language),
-        }),
+        CellValue::Code(_) => current::CellValueSchema::Blank,
         CellValue::Logical(logical) => current::CellValueSchema::Logical(logical),
         CellValue::Instant(instant) => current::CellValueSchema::Instant(instant.to_string()),
         CellValue::Duration(duration) => current::CellValueSchema::Duration(duration.to_string()),
@@ -51,9 +48,7 @@ pub fn export_cell_value(cell_value: CellValue) -> current::CellValueSchema {
             current::CellValueSchema::Error(current::RunErrorSchema::from_grid_run_error(*error))
         }
         CellValue::Image(image) => current::CellValueSchema::Image(image),
-        CellValue::Import(import) => current::CellValueSchema::Import(current::ImportSchema {
-            file_name: import.file_name,
-        }),
+        CellValue::Import(_) => current::CellValueSchema::Blank,
     }
 }
 
@@ -98,10 +93,7 @@ pub fn import_cell_value(value: current::CellValueSchema) -> CellValue {
         current::CellValueSchema::Text(text) => CellValue::Text(text),
         current::CellValueSchema::Number(number) => import_cell_value_number(number),
         current::CellValueSchema::Html(html) => CellValue::Html(html),
-        current::CellValueSchema::Code(code_cell) => CellValue::Code(CodeCellValue {
-            code: code_cell.code,
-            language: import_code_cell_language(code_cell.language),
-        }),
+        current::CellValueSchema::Code(_) => CellValue::Blank,
         current::CellValueSchema::Logical(logical) => CellValue::Logical(logical),
         current::CellValueSchema::Instant(instant) => {
             CellValue::Instant(serde_json::from_str(&instant).unwrap_or_default())
@@ -114,9 +106,7 @@ pub fn import_cell_value(value: current::CellValueSchema) -> CellValue {
         current::CellValueSchema::DateTime(dt) => CellValue::DateTime(dt),
         current::CellValueSchema::Error(error) => CellValue::Error(Box::new(error.into())),
         current::CellValueSchema::Image(text) => CellValue::Image(text),
-        current::CellValueSchema::Import(current::ImportSchema { file_name }) => {
-            CellValue::Import(Import::new(file_name))
-        }
+        current::CellValueSchema::Import(_) => CellValue::Blank,
     }
 }
 

--- a/quadratic-core/src/grid/sheet.rs
+++ b/quadratic-core/src/grid/sheet.rs
@@ -206,12 +206,7 @@ impl Sheet {
     /// for it).
     pub fn display_value(&self, pos: Pos) -> Option<CellValue> {
         // if CellValue::Code or CellValue::Import, then we need to get the value from data_tables
-        if let Some(cell_value) = self.cell_value_ref(pos)
-            && !matches!(
-                cell_value,
-                CellValue::Code(_) | CellValue::Import(_) | CellValue::Blank
-            )
-        {
+        if let Some(cell_value) = self.cell_value_ref(pos) {
             return Some(cell_value.clone());
         }
 

--- a/quadratic-core/src/grid/sheet/code.rs
+++ b/quadratic-core/src/grid/sheet/code.rs
@@ -110,7 +110,6 @@ impl Sheet {
     /// Returns the CellValue for a CodeRun (if it exists) at the Pos.
     ///
     /// Note: spill error will return a CellValue::Blank to ensure calculations can continue.
-    /// TODO(ddimaria): move to DataTable code
     pub fn get_code_cell_value(&self, pos: Pos) -> Option<CellValue> {
         let (data_table_pos, data_table) = self.data_table_that_contains(pos)?;
         data_table.cell_value_at(

--- a/quadratic-core/src/grid/sheet/rendering/cells.rs
+++ b/quadratic-core/src/grid/sheet/rendering/cells.rs
@@ -101,7 +101,6 @@ impl Sheet {
     // Converts a CodeValue::Code and CodeRun into a vector of JsRenderCell.
     pub(crate) fn get_render_code_cells(
         &self,
-        code: &CellValue,
         data_table: &DataTable,
         render_rect: &Rect,
         code_rect: &Rect,
@@ -109,90 +108,88 @@ impl Sheet {
     ) -> Vec<JsRenderCell> {
         let mut cells = vec![];
 
-        if let Some(code_cell_value) = code.code_cell_value() {
-            if data_table.has_spill() {
-                cells.push(Self::get_render_cell(
-                    code_rect.min.x,
-                    code_rect.min.y,
-                    &CellValue::Error(Box::new(RunError {
-                        span: None,
-                        msg: RunErrorMsg::Spill,
-                    })),
-                    Format::default(),
-                    Some(code_cell_value.language),
-                    None,
-                ));
-            } else if let Some(error) = data_table.get_error() {
-                cells.push(Self::get_render_cell(
-                    code_rect.min.x,
-                    code_rect.min.y,
-                    &CellValue::Error(Box::new(error)),
-                    Format::default(),
-                    Some(code_cell_value.language),
-                    None,
-                ));
-            } else if let Some(intersection) = code_rect.intersection(render_rect) {
-                let y_adjustment = data_table.y_adjustment(false);
-                for y in intersection.y_range() {
-                    // We now render the header row to ensure clipping works
-                    // properly to the left of the header since we rely on the
-                    // renderer for clipping purposes
-                    let is_header = y < code_rect.min.y + y_adjustment;
-                    let is_table_name = data_table.get_show_name() && y == code_rect.min.y;
-                    let is_column_headers = is_header && !is_table_name;
+        if data_table.has_spill() {
+            cells.push(Self::get_render_cell(
+                code_rect.min.x,
+                code_rect.min.y,
+                &CellValue::Error(Box::new(RunError {
+                    span: None,
+                    msg: RunErrorMsg::Spill,
+                })),
+                Format::default(),
+                Some(data_table.get_language()),
+                None,
+            ));
+        } else if let Some(error) = data_table.get_error() {
+            cells.push(Self::get_render_cell(
+                code_rect.min.x,
+                code_rect.min.y,
+                &CellValue::Error(Box::new(error)),
+                Format::default(),
+                Some(data_table.get_language()),
+                None,
+            ));
+        } else if let Some(intersection) = code_rect.intersection(render_rect) {
+            let y_adjustment = data_table.y_adjustment(false);
+            for y in intersection.y_range() {
+                // We now render the header row to ensure clipping works
+                // properly to the left of the header since we rely on the
+                // renderer for clipping purposes
+                let is_header = y < code_rect.min.y + y_adjustment;
+                let is_table_name = data_table.get_show_name() && y == code_rect.min.y;
+                let is_column_headers = is_header && !is_table_name;
 
-                    for x in intersection.x_range() {
-                        let pos = Pos {
-                            x: x - code_rect.min.x,
-                            y: y - code_rect.min.y,
+                for x in intersection.x_range() {
+                    let pos = Pos {
+                        x: x - code_rect.min.x,
+                        y: y - code_rect.min.y,
+                    };
+
+                    let value = data_table.cell_value_at(pos.x as u32, pos.y as u32);
+
+                    if let Some(value) = value {
+                        let mut format = if is_header {
+                            // column headers are always clipped and bold
+                            Format {
+                                wrap: Some(CellWrap::Clip),
+                                bold: Some(true),
+                                ..Default::default()
+                            }
+                        } else {
+                            let table_format = data_table.get_format(pos);
+                            let sheet_format =
+                                self.formats.try_format(Pos { x, y }).unwrap_or_default();
+                            table_format.combine(&sheet_format)
                         };
 
-                        let value = data_table.cell_value_at(pos.x as u32, pos.y as u32);
+                        let language = if x == code_rect.min.x && y == code_rect.min.y {
+                            Some(data_table.get_language())
+                        } else {
+                            None
+                        };
 
-                        if let Some(value) = value {
-                            let mut format = if is_header {
-                                // column headers are always clipped and bold
-                                Format {
-                                    wrap: Some(CellWrap::Clip),
-                                    bold: Some(true),
-                                    ..Default::default()
-                                }
-                            } else {
-                                let table_format = data_table.get_format(pos);
-                                let sheet_format =
-                                    self.formats.try_format(Pos { x, y }).unwrap_or_default();
-                                table_format.combine(&sheet_format)
-                            };
+                        let special = self
+                            .validations
+                            .render_special_pos(Pos { x, y }, context)
+                            .or(match value {
+                                CellValue::Logical(_) => Some(JsRenderCellSpecial::Logical),
+                                _ => None,
+                            });
 
-                            let language = if x == code_rect.min.x && y == code_rect.min.y {
-                                Some(code_cell_value.language.to_owned())
-                            } else {
-                                None
-                            };
+                        Self::ensure_lists_are_clipped(&mut format, &special);
 
-                            let special = self
-                                .validations
-                                .render_special_pos(Pos { x, y }, context)
-                                .or(match value {
-                                    CellValue::Logical(_) => Some(JsRenderCellSpecial::Logical),
-                                    _ => None,
-                                });
+                        let mut render_cell =
+                            Self::get_render_cell(x, y, &value, format, language, special);
 
-                            Self::ensure_lists_are_clipped(&mut format, &special);
-
-                            let mut render_cell =
-                                Self::get_render_cell(x, y, &value, format, language, special);
-
-                            if is_table_name {
-                                render_cell.table_name = Some(true);
-                            }
-
-                            if is_column_headers {
-                                render_cell.column_header = Some(true);
-                            }
-
-                            cells.push(render_cell);
+                        if is_table_name {
+                            render_cell.table_name = Some(true);
                         }
+
+                        if is_column_headers {
+                            render_cell.column_header = Some(true);
+                        }
+
+                        cells.push(render_cell);
                     }
                 }
             }
@@ -248,19 +245,13 @@ impl Sheet {
         // Fetch values from code cells
         self.iter_data_tables_in_rect(rect)
             .for_each(|(data_table_rect, data_table)| {
-                // sanity check that there is a CellValue::Code for this CodeRun
-                if let Some(cell_value) = self.cell_value_ref(Pos {
-                    x: data_table_rect.min.x,
-                    y: data_table_rect.min.y,
-                }) {
-                    render_cells.extend(self.get_render_code_cells(
-                        cell_value,
-                        data_table,
-                        &rect,
-                        &data_table_rect,
-                        a1_context,
-                    ));
-                }
+                render_cells.extend(self.get_render_code_cells(
+                    data_table,
+                    &rect,
+                    &data_table_rect,
+                    a1_context,
+                ));
+                // }
             });
 
         // Populate validations for cells that are not yet in the render_cells

--- a/quadratic-core/src/grid/sheet/rendering/code.rs
+++ b/quadratic-core/src/grid/sheet/rendering/code.rs
@@ -3,7 +3,7 @@
 use crate::{
     CellValue, Pos, Value,
     grid::{
-        CodeCellLanguage, DataTable, Sheet,
+        CodeCellLanguage, DataTable, DataTableKind, Sheet,
         js_types::{JsHtmlOutput, JsRenderCodeCell, JsRenderCodeCellState},
     },
 };
@@ -58,7 +58,6 @@ impl Sheet {
 
     // Returns data for rendering a code cell.
     fn render_code_cell(&self, pos: Pos, data_table: &DataTable) -> Option<JsRenderCodeCell> {
-        let code = self.cell_value_ref(pos)?;
         let output_size = data_table.output_size();
         let (state, w, h, spill_error) = if data_table.has_spill() {
             let reasons = self.find_spill_error_reasons(&data_table.output_rect(pos, true), pos);
@@ -88,10 +87,9 @@ impl Sheet {
             && !data_table.is_html()
             && data_table.alternating_colors;
 
-        let language = match code {
-            CellValue::Code(code) => code.language.to_owned(),
-            CellValue::Import(_) => CodeCellLanguage::Import,
-            _ => return None,
+        let language = match &data_table.kind {
+            DataTableKind::CodeRun(code) => code.language.to_owned(),
+            DataTableKind::Import(_) => CodeCellLanguage::Import,
         };
         Some(JsRenderCodeCell {
             x: pos.x as i32,
@@ -135,9 +133,10 @@ impl Sheet {
             .collect::<Vec<_>>();
 
         if !code.is_empty()
-            && let Ok(render_code_cells) = serde_json::to_vec(&code) {
-                crate::wasm_bindings::js::jsSheetCodeCells(self.id.to_string(), render_code_cells);
-            }
+            && let Ok(render_code_cells) = serde_json::to_vec(&code)
+        {
+            crate::wasm_bindings::js::jsSheetCodeCells(self.id.to_string(), render_code_cells);
+        }
     }
 
     /// Send images in this sheet to the client. Note: we only have images
@@ -174,18 +173,19 @@ impl Sheet {
 
         let mut sent = false;
         if let Some(table) = self.data_table_at(&pos)
-            && let Some(CellValue::Image(image)) = table.cell_value_at(0, 0) {
-                let output_size = table.chart_output;
-                crate::wasm_bindings::js::jsSendImage(
-                    self.id.to_string(),
-                    pos.x as i32,
-                    pos.y as i32,
-                    output_size.map(|(w, _)| w as i32).unwrap_or(0),
-                    output_size.map(|(_, h)| h as i32 + 1).unwrap_or(0),
-                    Some(image),
-                );
-                sent = true;
-            }
+            && let Some(CellValue::Image(image)) = table.cell_value_at(0, 0)
+        {
+            let output_size = table.chart_output;
+            crate::wasm_bindings::js::jsSendImage(
+                self.id.to_string(),
+                pos.x as i32,
+                pos.y as i32,
+                output_size.map(|(w, _)| w as i32).unwrap_or(0),
+                output_size.map(|(_, h)| h as i32 + 1).unwrap_or(0),
+                Some(image),
+            );
+            sent = true;
+        }
         if !sent {
             crate::wasm_bindings::js::jsSendImage(
                 self.id.to_string(),

--- a/quadratic-core/src/wasm_bindings/controller/code.rs
+++ b/quadratic-core/src/wasm_bindings/controller/code.rs
@@ -39,8 +39,7 @@ impl GridController {
         }
     }
 
-    /// Returns the code cell (which is a combination of CellValue::Code and CodeRun).
-    /// If the cell is part of a code run, it returns the code run that caused the output.
+    /// Returns the code cell if the pos is part of a code run.
     ///
     /// * CodeCell.evaluation_result is a stringified version of the output (used for AI models)
     #[wasm_bindgen(js_name = "getCodeCell")]


### PR DESCRIPTION
Technical update to remove the CellValue::Code from the grid. It now lives only as part of the Sheet's data structure.

- [x] remove CellValue::Code on import/export
- [x] rendering without CellValue::Code
- [ ] remove all references to CellValue::Code 

# Testing Notes

This should work exactly the same as prod