### PR TITLE
fix: semantic description & snowflake connection

### DIFF
--- a/quadratic-api/src/routes/v0/teams.$uuid.connections.$connectionUuid.PUT.test.ts
+++ b/quadratic-api/src/routes/v0/teams.$uuid.connections.$connectionUuid.PUT.test.ts
@@ -55,6 +55,17 @@ describe('PUT /v0/teams/:uuid/connections/:connectionUuid', () => {
         });
     });
 
+    it('responds with a 200 and removes the semantic description when it is not included in the update', async () => {
+      await request(app)
+        .put('/v0/teams/00000000-0000-0000-0000-000000000000/connections/10000000-0000-0000-0000-000000000000')
+        .send({ ...validPayload, semanticDescription: undefined })
+        .set('Authorization', `Bearer ValidToken teamUserOwner`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.semanticDescription).toBeUndefined();
+        });
+    });
+
     it('responds with a 403 for users who cannot edit a connection', async () => {
       await request(app)
         .put('/v0/teams/00000000-0000-0000-0000-000000000000/connections/10000000-0000-0000-0000-000000000000')

--- a/quadratic-api/src/routes/v0/teams.$uuid.connections.$connectionUuid.PUT.ts
+++ b/quadratic-api/src/routes/v0/teams.$uuid.connections.$connectionUuid.PUT.ts
@@ -49,7 +49,7 @@ async function handler(
     data: {
       name,
       updatedDate: new Date(),
-      semanticDescription,
+      semanticDescription: semanticDescription ? semanticDescription : null,
       typeDetails: Buffer.from(encryptFromEnv(JSON.stringify(typeDetails))),
     },
   });

--- a/quadratic-client/src/shared/components/connections/ConnectionFormSemantic.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionFormSemantic.tsx
@@ -1,41 +1,70 @@
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/shared/shadcn/ui/form';
+import { FormControl, FormField, FormItem, FormMessage } from '@/shared/shadcn/ui/form';
+import { Label } from '@/shared/shadcn/ui/label';
+import { Switch } from '@/shared/shadcn/ui/switch';
 import { Textarea } from '@/shared/shadcn/ui/textarea';
+import { useEffect, useRef, useState } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 interface ConnectionFormSemanticProps {
   form: UseFormReturn<any>;
-  semanticDescription?: string;
 }
 
-// Change the component signature to use the new props type
-export const ConnectionFormSemantic = ({ form, semanticDescription }: ConnectionFormSemanticProps) => {
-  return (
-    <FormField
-      control={form.control}
-      name="semanticDescription"
-      defaultValue={semanticDescription}
-      render={({ field }) => (
-        <FormItem>
-          <FormLabel>Semantic description (optional)</FormLabel>
-          <FormControl>
-            <Textarea
-              autoComplete="off"
-              className="h-48"
-              placeholder="Information put here will be used by AI to better understand your database. Example: 
+const NAME = 'semanticDescription';
 
-table: widget-sales
+// Change the component signature to use the new props type
+export const ConnectionFormSemantic = ({ form }: ConnectionFormSemanticProps) => {
+  // Only show the semantic description if the user has checked the checkbox
+  const value = form.getValues(NAME);
+  const [checked, setChecked] = useState(Boolean(value));
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    // When the box is checked, focus the textarea and reset the value
+    // to whatever the current value is (from the DB)
+    if (checked) {
+      ref.current?.focus();
+      form.resetField(NAME);
+      // Otherwise, set the value to empty (equivalent to removing the value)
+    } else {
+      form.setValue(NAME, '');
+    }
+  }, [checked, form]);
+
+  return (
+    <>
+      <div className="flex items-center gap-2 py-1">
+        <Switch
+          id="semantic-description-checkbox"
+          checked={checked}
+          onCheckedChange={(checked) => setChecked(!!checked)}
+          className=""
+        />
+        <Label htmlFor="semantic-description-checkbox">Include a semantic description</Label>
+      </div>
+      {checked && (
+        <FormField
+          control={form.control}
+          name={NAME}
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Textarea autoComplete="off" className="h-48" placeholder="" {...field} ref={ref} />
+              </FormControl>
+              <FormMessage />
+              <p className="mb-0 text-sm text-muted-foreground">
+                Information put here will be used by AI to better understand your database. Example:
+              </p>
+              <pre className="overflow-x-auto rounded font-sans text-sm text-muted-foreground">{`table: widget-sales
 purpose: all the historical sales for all widgets sold in North America.
 columns:
   - column_name: 158394
     description: this column contains the regions in which sales can occur 
   - column_name: sales_accounting
-    description: number of total sales in corresponding region"
-              {...field}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
+    description: number of total sales in corresponding region`}</pre>
+            </FormItem>
+          )}
+        />
       )}
-    />
+    </>
   );
 };

--- a/quadratic-client/src/shared/components/connections/ConnectionFormSnowflake.tsx
+++ b/quadratic-client/src/shared/components/connections/ConnectionFormSnowflake.tsx
@@ -29,6 +29,8 @@ export const useConnectionForm: UseConnectionForm<FormValues> = (connection) => 
     database: String(connection?.typeDetails?.database || ''),
     username: String(connection?.typeDetails?.username || ''),
     password: String(connection?.typeDetails?.password || ''),
+    warehouse: String(connection?.typeDetails?.warehouse || ''),
+    role: String(connection?.typeDetails?.role || ''),
     semanticDescription: String(connection?.semanticDescription || ''),
   };
 


### PR DESCRIPTION
## Description

- [bug] Fix where "Warehouse" and "Role" values were not showing up when saved
- [bug] Fix where "Semantic description" could not be removed once added
- [feature] Hides (large) UI around adding a semantic description behind a on/off toggle

<img width="1272" height="1272" alt="CleanShot 2025-09-19 at 14 38 19@2x" src="https://github.com/user-attachments/assets/ca334a5c-2bb8-4a02-aca3-7217017ceffb" />

<img width="1276" height="2018" alt="CleanShot 2025-09-19 at 14 38 34@2x" src="https://github.com/user-attachments/assets/bff01a0a-1f0e-438f-941c-51e5f4fd6b78" />


## To Test

### Snowflake connections

- Create a snowflake connection with "Warehouse" and "Role" values
- Go back to editing the connection and ensure that the values for those fields are what you saved
- Remove the "Warehouse" and "Role" values you added
- Go back to editing the connection and ensure the those two fields are empty now

<img width="1280" height="1242" alt="CleanShot 2025-09-19 at 14 41 03@2x" src="https://github.com/user-attachments/assets/aa04b96e-79ce-4eaa-b01c-fd56ce8f0a1f" />

### Semantic description

- Toggle ON semantic description, enter one, and save it. Go back to editing the connection and ensure you can see the value you added.
- Toggle OFF the semantic description, save it. Go back to editing the connection and ensure the toggle is OFF and if you turn it on the value is empty.
