### PR TITLE
Fix heading auto resize

### DIFF
--- a/quadratic-client/src/app/gridGL/interaction/pointer/PointerHeading.ts
+++ b/quadratic-client/src/app/gridGL/interaction/pointer/PointerHeading.ts
@@ -38,6 +38,9 @@ export interface ResizeHeadingColumnEvent extends CustomEvent {
 export class PointerHeading {
   private downTimeout: number | undefined;
   cursor?: string;
+
+  // counts whether this was already clicked (used for double click to
+  // auto-resize)
   private clicked = false;
   private fitToColumnTimeout?: number;
 
@@ -131,6 +134,8 @@ export class PointerHeading {
         height: headingResize.height,
       };
       this.active = true;
+      if (headingResize.column !== null && cursor.isEntireColumnSelected(headingResize.column)) return true;
+      if (headingResize.row !== null && cursor.isEntireRowSelected(headingResize.row)) return true;
     } else if (
       !intersects.corner &&
       !isRightClick &&

--- a/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
+++ b/quadratic-client/src/app/web-workers/renderWebWorker/worker/cellsLabel/CellLabel.ts
@@ -530,6 +530,7 @@ export class CellLabel {
   };
 
   private getUnwrappedTextWidth = (text: string): number => {
+    if (!text) return 0;
     const data = this.cellsLabels.bitmapFonts[this.fontName];
     if (!data) throw new Error(`Expected BitmapFont ${this.fontName} to be defined in CellLabel.getUnwrappedTextWidth`);
 


### PR DESCRIPTION
- [x] clicking on resize heading no longer selects a single column
- [x] fix bug with auto resize when there is a chart in the column or row