### PR TITLE
feat: turn on sentry replay

### DIFF
--- a/quadratic-client/src/shared/utils/sentry.ts
+++ b/quadratic-client/src/shared/utils/sentry.ts
@@ -6,6 +6,7 @@ import {
   extraErrorDataIntegration,
   httpClientIntegration,
   init,
+  replayIntegration,
   zodErrorsIntegration,
 } from '@sentry/react';
 
@@ -20,6 +21,8 @@ export const initSentry = () => {
         dsn,
         environment,
         release: `quadratic@${version}`,
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 1.0,
         integrations: [
           browserProfilingIntegration(),
           browserSessionIntegration(),
@@ -28,6 +31,10 @@ export const initSentry = () => {
           extraErrorDataIntegration(),
           httpClientIntegration(),
           zodErrorsIntegration(),
+          replayIntegration({ maskAllText: false, blockAllMedia: false }),
+          // Canvas is not supported by default, but if we ever need to turn it
+          // on, we explored that once here:
+          // https://github.com/quadratichq/quadratic/pull/3422/commits/c2f6d31a9bbf9035dfa1f3dd2f0840ca138adf3b
         ],
         profilesSampleRate: 1.0,
         tracesSampleRate: 1.0,


### PR DESCRIPTION
## Description

Turn on replays in Sentry.

Tested this locally by adding the `VITE_SENTRY_DSN` value and [my recording ended up in Sentry](https://sentry.quadratichq.com/organizations/quadratic/replays/46e3ce1202674f6fa27ebc5dd67f7aa2/?project=1&query=&referrer=%2Freplays%2F&statsPeriod=14d&yAxis=count%28%29)

Can test in the preview branch by changing the same env var, or just ship to prod and see it turn on.