### PR TITLE
fix: update sentry replays to exclude iframe

### DIFF
--- a/quadratic-client/src/shared/utils/sentry.ts
+++ b/quadratic-client/src/shared/utils/sentry.ts
@@ -31,7 +31,11 @@ export const initSentry = () => {
           extraErrorDataIntegration(),
           httpClientIntegration(),
           zodErrorsIntegration(),
-          replayIntegration({ maskAllText: false, blockAllMedia: false }),
+          replayIntegration({
+            maskAllText: false,
+            blockAllMedia: false,
+            networkDetailDenyUrls: ['/iframe-indexeddb'],
+          }),
           // Canvas is not supported by default, but if we ever need to turn it
           // on, we explored that once here:
           // https://github.com/quadratichq/quadratic/pull/3422/commits/c2f6d31a9bbf9035dfa1f3dd2f0840ca138adf3b


### PR DESCRIPTION
## Description

We're getting tons of "Anonymous" user replays in Sentry because it's capturing people uploading files from the marketing site

<img width="1604" height="2298" alt="CleanShot 2025-10-02 at 15 51 27@2x" src="https://github.com/user-attachments/assets/5065945c-a444-4bf1-aaa3-dd0072f3e6d3" />

We don't want to log any of these sessions, so we exclude any paths that match that string [based on Sentry's config](https://docs.sentry.io/platforms/javascript/session-replay/configuration/)