### PR TITLE
Show remaining message count to free users 

### DIFF
--- a/quadratic-client/src/app/ui/components/AIMessageCounterBar.tsx
+++ b/quadratic-client/src/app/ui/components/AIMessageCounterBar.tsx
@@ -1,0 +1,35 @@
+import { useAIUsage } from '@/app/ui/hooks/useAIUsage';
+import { useIsOnPaidPlan } from '@/app/ui/hooks/useIsOnPaidPlan';
+import { memo } from 'react';
+
+interface AIMessageCounterBarProps {
+  messageIndex?: number;
+  showEmptyChatPromptSuggestions?: boolean;
+}
+
+export const AIMessageCounterBar = memo(
+  ({ messageIndex = 0, showEmptyChatPromptSuggestions = false }: AIMessageCounterBarProps) => {
+    const { isOnPaidPlan } = useIsOnPaidPlan();
+    const { data, messagesRemaining } = useAIUsage();
+
+    // Only show for free plans, when we have usage data, and NOT in initial/empty chat state
+    if (isOnPaidPlan || !data || messagesRemaining === null || (showEmptyChatPromptSuggestions && messageIndex === 0)) {
+      return null;
+    }
+
+    const handleUpgradeClick = () => {
+      window.open('/team/settings', '_blank');
+    };
+
+    return (
+      <div className="flex items-center justify-between px-2 py-1 text-xs text-muted-foreground">
+        <span>
+          {messagesRemaining} message{messagesRemaining !== 1 ? 's' : ''} left on your Free plan.
+        </span>
+        <button onClick={handleUpgradeClick} className="text-blue-600 hover:text-blue-800 hover:underline">
+          Upgrade now
+        </button>
+      </div>
+    );
+  }
+);

--- a/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
+++ b/quadratic-client/src/app/ui/components/AIUserMessageForm.tsx
@@ -374,6 +374,8 @@ export const AIUserMessageForm = memo(
             setContext={setContext}
             filesSupportedText={filesSupportedText}
             uiContext={uiContext}
+            messageIndex={messageIndex}
+            showEmptyChatPromptSuggestions={showEmptyChatPromptSuggestions}
           />
         </form>
       </div>
@@ -415,27 +417,36 @@ interface CancelButtonProps {
   show: boolean;
   disabled: boolean;
   abortPrompt: () => void;
+  messageIndex: number;
+  showEmptyChatPromptSuggestions?: boolean;
 }
-const CancelButton = memo(({ show, disabled, abortPrompt }: CancelButtonProps) => {
-  if (!show) {
-    return null;
-  }
+const CancelButton = memo(
+  ({ show, disabled, abortPrompt, messageIndex, showEmptyChatPromptSuggestions = false }: CancelButtonProps) => {
+    if (!show) {
+      return null;
+    }
 
-  return (
-    <Button
-      size="sm"
-      variant="outline"
-      className="absolute -top-10 right-1/2 z-10 translate-x-1/2 bg-background"
-      onClick={(e) => {
-        e.stopPropagation();
-        abortPrompt();
-      }}
-      disabled={disabled}
-    >
-      <BackspaceIcon className="mr-1" /> Cancel generating
-    </Button>
-  );
-});
+    // Check if message counter is showing (same logic as AIMessageCounterBar)
+    const isMessageCounterShowing = !(showEmptyChatPromptSuggestions && messageIndex === 0);
+
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        className={`absolute right-1/2 z-10 translate-x-1/2 bg-background ${
+          isMessageCounterShowing ? '-top-16' : '-top-10'
+        }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          abortPrompt();
+        }}
+        disabled={disabled}
+      >
+        <BackspaceIcon className="mr-1" /> Cancel generating
+      </Button>
+    );
+  }
+);
 
 interface AIUserMessageFormFooterProps {
   disabled: boolean;
@@ -453,6 +464,8 @@ interface AIUserMessageFormFooterProps {
   setContext?: React.Dispatch<React.SetStateAction<Context>>;
   filesSupportedText: string;
   uiContext: AIUserMessageFormProps['uiContext'];
+  messageIndex: number;
+  showEmptyChatPromptSuggestions?: boolean;
 }
 const AIUserMessageFormFooter = memo(
   ({
@@ -471,6 +484,8 @@ const AIUserMessageFormFooter = memo(
     setContext,
     filesSupportedText,
     uiContext,
+    messageIndex,
+    showEmptyChatPromptSuggestions,
   }: AIUserMessageFormFooterProps) => {
     const handleClickSubmit = useCallback(
       (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -534,7 +549,13 @@ const AIUserMessageFormFooter = memo(
           </div>
         </div>
 
-        <CancelButton show={loading} disabled={cancelDisabled} abortPrompt={abortPrompt} />
+        <CancelButton
+          show={loading}
+          disabled={cancelDisabled}
+          abortPrompt={abortPrompt}
+          messageIndex={messageIndex}
+          showEmptyChatPromptSuggestions={showEmptyChatPromptSuggestions}
+        />
       </>
     );
   }

--- a/quadratic-client/src/app/ui/hooks/useAIUsage.tsx
+++ b/quadratic-client/src/app/ui/hooks/useAIUsage.tsx
@@ -1,0 +1,60 @@
+import { aiAnalystCurrentChatMessagesCountAtom } from '@/app/atoms/aiAnalystAtom';
+import { aiAssistantCurrentChatMessagesCountAtom } from '@/app/atoms/codeEditorAtom';
+import { editorInteractionStateTeamUuidAtom } from '@/app/atoms/editorInteractionStateAtom';
+import { apiClient } from '@/shared/api/apiClient';
+import { useCallback, useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+
+export interface AIUsageData {
+  exceededBillingLimit: boolean;
+  billingLimit?: number;
+  currentPeriodUsage?: number;
+}
+
+export const useAIUsage = () => {
+  const teamUuid = useRecoilValue(editorInteractionStateTeamUuidAtom);
+  const aiAnalystMessageCount = useRecoilValue(aiAnalystCurrentChatMessagesCountAtom);
+  const aiAssistantMessageCount = useRecoilValue(aiAssistantCurrentChatMessagesCountAtom);
+  const [data, setData] = useState<AIUsageData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAIUsage = useCallback(async () => {
+    if (!teamUuid) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await apiClient.teams.billing.aiUsage(teamUuid);
+      setData(result);
+    } catch (err) {
+      console.error('Failed to fetch AI usage:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch AI usage');
+    } finally {
+      setLoading(false);
+    }
+  }, [teamUuid]);
+
+  useEffect(() => {
+    fetchAIUsage();
+  }, [fetchAIUsage]);
+
+  // Refetch usage when message counts change (new messages sent)
+  useEffect(() => {
+    fetchAIUsage();
+  }, [aiAnalystMessageCount, aiAssistantMessageCount, fetchAIUsage]);
+
+  const messagesRemaining =
+    data?.billingLimit && data?.currentPeriodUsage !== undefined
+      ? Math.max(0, data.billingLimit - data.currentPeriodUsage)
+      : null;
+
+  return {
+    data,
+    loading,
+    error,
+    refetch: fetchAIUsage,
+    messagesRemaining,
+  };
+};

--- a/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
+++ b/quadratic-client/src/app/ui/menus/AIAnalyst/AIAnalyst.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/app/atoms/aiAnalystAtom';
 import { presentationModeAtom } from '@/app/atoms/gridSettingsAtom';
 import { events } from '@/app/events/events';
+import { AIMessageCounterBar } from '@/app/ui/components/AIMessageCounterBar';
 import { AIUserMessageFormDisclaimer } from '@/app/ui/components/AIUserMessageFormDisclaimer';
 import { ResizeControl } from '@/app/ui/components/ResizeControl';
 import { AIAnalystChatHistory } from '@/app/ui/menus/AIAnalyst/AIAnalystChatHistory';
@@ -93,17 +94,33 @@ export const AIAnalyst = memo(() => {
             <>
               <AIAnalystMessages textareaRef={textareaRef} />
 
-              <div className={'grid grid-rows-[1fr_auto] px-2 py-0.5'}>
-                <AIAnalystUserMessageForm
-                  ref={textareaRef}
-                  autoFocusRef={autoFocusRef}
-                  textareaRef={textareaRef}
-                  messageIndex={messagesCount}
-                  showEmptyChatPromptSuggestions={true}
-                />
-
-                <AIUserMessageFormDisclaimer />
-              </div>
+              {messagesCount === 0 ? (
+                // Original layout for empty state - completely unaltered
+                <div className={'grid grid-rows-[1fr_auto] px-2 py-0.5'}>
+                  <AIAnalystUserMessageForm
+                    ref={textareaRef}
+                    autoFocusRef={autoFocusRef}
+                    textareaRef={textareaRef}
+                    messageIndex={messagesCount}
+                    showEmptyChatPromptSuggestions={true}
+                  />
+                  <AIUserMessageFormDisclaimer />
+                </div>
+              ) : (
+                // Layout with message counter above chat box for non-empty state
+                <div className={'grid grid-rows-[1fr_auto_auto_auto] px-2 py-0.5'}>
+                  <div></div>
+                  <AIMessageCounterBar messageIndex={messagesCount} showEmptyChatPromptSuggestions={true} />
+                  <AIAnalystUserMessageForm
+                    ref={textareaRef}
+                    autoFocusRef={autoFocusRef}
+                    textareaRef={textareaRef}
+                    messageIndex={messagesCount}
+                    showEmptyChatPromptSuggestions={true}
+                  />
+                  <AIUserMessageFormDisclaimer />
+                </div>
+              )}
             </>
           )}
         </div>

--- a/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistant.tsx
+++ b/quadratic-client/src/app/ui/menus/CodeEditor/AIAssistant/AIAssistant.tsx
@@ -1,4 +1,5 @@
 import { aiAssistantMessagesCountAtom } from '@/app/atoms/codeEditorAtom';
+import { AIMessageCounterBar } from '@/app/ui/components/AIMessageCounterBar';
 import { AIUserMessageFormDisclaimer } from '@/app/ui/components/AIUserMessageFormDisclaimer';
 import { AIAssistantMessages } from '@/app/ui/menus/CodeEditor/AIAssistant/AIAssistantMessages';
 import { AIAssistantUserMessageForm } from '@/app/ui/menus/CodeEditor/AIAssistant/AIAssistantUserMessageForm';
@@ -15,6 +16,7 @@ export const AIAssistant = memo(() => {
       <AIAssistantMessages textareaRef={textareaRef} />
 
       <div className="flex h-full flex-col justify-end px-2 py-0.5">
+        <AIMessageCounterBar messageIndex={messagesCount} showEmptyChatPromptSuggestions={false} />
         <AIAssistantUserMessageForm
           ref={textareaRef}
           autoFocusRef={autoFocusRef}


### PR DESCRIPTION
## Description 

Shows a count of messages to Free users. 

## Test plan 

- [ ] Count should properly decrement and show correct count 
- [ ] Count should only show to Free users (start with free and ensure it shows, then upgrade and ensure it's no longer showing) 
- [ ] Cancel generating button should not overlap count; when on Pro cancel generating should be in its prior position 
- [ ] "Upgrade now" should work same as "Upgrade to Pro" button from when user gets blocked (open in new tab to team/settings) 